### PR TITLE
fix(i18n): make ten Class-B translations normalizer-reachable again (#483)

### DIFF
--- a/i18n/de/skills/annotate-source-files/SKILL.md
+++ b/i18n/de/skills/annotate-source-files/SKILL.md
@@ -139,6 +139,38 @@ Beispiel mit `node_type`:
 #   output:'result.parquet'
 ```
 
+**Block comment syntax** (for `//`-prefix languages only: JS, TS, Go, Rust, C, C++, Java, etc.):
+
+Languages that use `//` for line comments also support PUT annotations inside `/* */` and `/** */` block comments. Use `* put` as the line prefix inside the block body:
+
+```javascript
+/* put id:'init', label:'Initialize Config', output:'config.internal' */
+
+/**
+ * put id:'process', \
+ *   label:'Process Records', \
+ *   input:'config.internal, records.json', \
+ *   output:'results.json'
+ */
+function processRecords(config, records) {
+  // ...
+}
+```
+
+JSDoc-style annotations are particularly useful when documenting workflow steps alongside API documentation:
+
+```typescript
+/**
+ * Transform raw sensor data into normalized readings.
+ * put id:'normalize', label:'Normalize Sensor Data', input:'raw_readings.json', output:'normalized.parquet'
+ */
+export function normalizeSensorData(readings: SensorReading[]): NormalizedData {
+  // ...
+}
+```
+
+> **Note:** Block comment annotations are **not** supported for `#`-prefix languages (R, Python, Shell) or `--`-prefix languages (SQL, Lua). Use only line comments for those languages. Block-originated annotations do not support backslash continuation across lines.
+
 **Dateiübergreifender Datenfluss** (Skripte über dateibasiertes I/O verbinden):
 ```r
 # Skript 1: extract.R
@@ -219,38 +251,6 @@ cat(put_diagram(merged, theme = "github"))
 - Doppelte Anführungszeichen innerhalb: `id:"name"` → `id:'name'`
 - Doppelte IDs über Dateien hinweg: jede `id` muss innerhalb des gesamten gescannten Verzeichnisses eindeutig sein
 - Backslash-Fortsetzung auf der falschen Zeile: `\` muss das letzte Zeichen vor dem Zeilenumbruch sein
-
-**Block comment syntax** (for `//`-prefix languages only: JS, TS, Go, Rust, C, C++, Java, etc.):
-
-Languages that use `//` for line comments also support PUT annotations inside `/* */` and `/** */` block comments. Use `* put` as the line prefix inside the block body:
-
-```javascript
-/* put id:'init', label:'Initialize Config', output:'config.internal' */
-
-/**
- * put id:'process', \
- *   label:'Process Records', \
- *   input:'config.internal, records.json', \
- *   output:'results.json'
- */
-function processRecords(config, records) {
-  // ...
-}
-```
-
-JSDoc-style annotations are particularly useful when documenting workflow steps alongside API documentation:
-
-```typescript
-/**
- * Transform raw sensor data into normalized readings.
- * put id:'normalize', label:'Normalize Sensor Data', input:'raw_readings.json', output:'normalized.parquet'
- */
-export function normalizeSensorData(readings: SensorReading[]): NormalizedData {
-  // ...
-}
-```
-
-> **Note:** Block comment annotations are **not** supported for `#`-prefix languages (R, Python, Shell) or `--`-prefix languages (SQL, Lua). Use only line comments for those languages.
 
 ## Validierung
 

--- a/i18n/de/skills/create-skill/SKILL.md
+++ b/i18n/de/skills/create-skill/SKILL.md
@@ -279,6 +279,15 @@ Zwei Dateien erstellen:
 }
 ```
 
+```markdown
+<!-- references/CITATIONS.md -->
+# Citations
+
+References underpinning the **skill-name** skill.
+
+1. Author, F., & Other, S. (2024). *Paper Title*. Journal Name. https://doi.org/10.xxxx/xxxxx
+```
+
 Zitate sind optional — hinzufuegen wenn die Herkunftsverfolgung wichtig ist (akademische Methoden, veroffentlichte Standards, Regulierungsrahmen).
 
 **Erwartet:** Beide Dateien existieren und `.bib` wird als gueltiges BibTeX geparst.

--- a/i18n/de/skills/design-serialization-schema/SKILL.md
+++ b/i18n/de/skills/design-serialization-schema/SKILL.md
@@ -124,6 +124,24 @@ enum Unit {
 }
 ```
 
+#### Apache-Avro-Beispiel:
+
+```json
+{
+  "type": "record",
+  "name": "Measurement",
+  "namespace": "com.example.sensors",
+  "doc": "A sensor measurement reading",
+  "fields": [
+    {"name": "sensor_id", "type": "string", "doc": "Unique sensor identifier"},
+    {"name": "value", "type": "double", "doc": "Measured value"},
+    {"name": "unit", "type": {"type": "enum", "name": "Unit", "symbols": ["CELSIUS", "FAHRENHEIT", "KELVIN", "PERCENT", "PPM"]}},
+    {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "metadata", "type": ["null", {"type": "map", "values": "string"}], "default": null}
+  ]
+}
+```
+
 **Erwartet:** Schema ist selbstdokumentierend mit Beschreibungen, Beschraenkungen und klaren Typdefinitionen.
 **Bei Fehler:** Falls das Datenmodell noch nicht stabil ist, das Schema als `draft` markieren und die Veroeffentlichung in einer Registry vermeiden.
 
@@ -147,6 +165,48 @@ Sichere Evolutionsstrategie:
 2. **Niemals entfernen oder umbenennen** -- stattdessen deprecaten
 3. **Schema versionieren** im Bezeichner (`v1`, `v2`)
 4. **Schema-Registry verwenden** fuer Binaerformate (Confluent Schema Registry fuer Avro/Protobuf)
+#### Protobuf-Evolutionsregeln:
+
+```protobuf
+// v1 — original
+message Measurement {
+  string sensor_id = 1;
+  double value = 2;
+  Unit unit = 3;
+}
+
+// v2 — safe evolution
+message Measurement {
+  string sensor_id = 1;
+  double value = 2;
+  Unit unit = 3;
+  // NEW: added in v2 — old clients ignore this field
+  google.protobuf.Timestamp timestamp = 4;
+  // DEPRECATED: use sensor_id instead
+  reserved 6;
+  reserved "old_sensor_name";
+}
+```
+
+
+#### JSON-Schema-Versionierung:
+
+```json
+{
+  "$id": "https://example.com/schemas/measurement/v2",
+  "allOf": [
+    {"$ref": "https://example.com/schemas/measurement/v1"},
+    {
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Added in v2: GPS coordinates"
+        }
+      }
+    }
+  ]
+}
+```
 
 **Erwartet:** Evolutionsplan dokumentiert: welche Aenderungen sicher sind, welche neue Versionen erfordern.
 **Bei Fehler:** Falls eine brechende Aenderung unvermeidlich ist, das Schema versionieren (v1 -> v2) und parallele Unterstuetzung waehrend der Migration aufrechterhalten.
@@ -201,6 +261,31 @@ if (!result.success) {
 ### Schritt 5: Schema dokumentieren
 
 Eine Schema-Dokumentationsseite erstellen mit Uebersicht, Feldbeschreibungen, Aenderungsprotokoll und Kompatibilitaetsrichtlinie.
+
+```markdown
+# Measurement Schema (v1)
+
+## Overview
+Represents a single sensor reading with metadata.
+
+## Fields
+| Field | Type | Required | Description | Constraints |
+|-------|------|----------|-------------|-------------|
+| sensor_id | string | Yes | Unique sensor ID | Pattern: `^[a-z]+-[0-9]+$` |
+| value | number | Yes | Measured value | Any valid IEEE 754 double |
+| unit | enum | Yes | Unit of measurement | One of: celsius, fahrenheit, kelvin, percent, ppm |
+| timestamp | string | Yes | Reading time | ISO 8601 with timezone |
+| metadata | object | No | Key-value pairs | String keys and values |
+
+## Changelog
+| Version | Date | Changes |
+|---------|------|---------|
+| v1 | 2025-03-01 | Initial schema |
+
+## Compatibility
+- **Backwards**: Consumers of v1 will continue to work with future versions
+- **Policy**: Only additive, optional field changes between minor versions
+```
 
 **Erwartet:** Dokumentation ist automatisch generiert oder bleibt mit der Schema-Definition synchron.
 **Bei Fehler:** Falls Dokumentation vom Schema abweicht, einen CI-Check hinzufuegen, der die Dokumentation gegen die Schema-Quelle validiert.

--- a/i18n/de/skills/design-serialization-schema/SKILL.md
+++ b/i18n/de/skills/design-serialization-schema/SKILL.md
@@ -165,6 +165,7 @@ Sichere Evolutionsstrategie:
 2. **Niemals entfernen oder umbenennen** -- stattdessen deprecaten
 3. **Schema versionieren** im Bezeichner (`v1`, `v2`)
 4. **Schema-Registry verwenden** fuer Binaerformate (Confluent Schema Registry fuer Avro/Protobuf)
+
 #### Protobuf-Evolutionsregeln:
 
 ```protobuf
@@ -187,7 +188,6 @@ message Measurement {
   reserved "old_sensor_name";
 }
 ```
-
 
 #### JSON-Schema-Versionierung:
 

--- a/i18n/de/skills/optimize-cloud-costs/SKILL.md
+++ b/i18n/de/skills/optimize-cloud-costs/SKILL.md
@@ -217,6 +217,18 @@ jq '.data[] | select(.totalRecommendedSavings > 10) | {
 # ... (see EXAMPLES.md for complete configuration)
 ```
 
+**Auslastungs-Dashboard erstellen:**
+
+```yaml
+# grafana-utilization-dashboard.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: utilization-dashboard
+  namespace: monitoring
+# ... (see EXAMPLES.md for complete configuration)
+```
+
 **Erwartet:** Klare Uebersicht ueber aktuelle Ressourcenanforderungen vs tatsaechliche Nutzung. Identifikation von Pods mit <30% Auslastung (ueberbereitgestellt). Liste von Optimierungsmoeglichkeiten mit geschaetzten Einsparungen.
 
 **Bei Fehler:**

--- a/i18n/de/skills/optimize-cloud-costs/SKILL.md
+++ b/i18n/de/skills/optimize-cloud-costs/SKILL.md
@@ -218,7 +218,6 @@ jq '.data[] | select(.totalRecommendedSavings > 10) | {
 ```
 
 **Auslastungs-Dashboard erstellen:**
-
 ```yaml
 # grafana-utilization-dashboard.yaml
 apiVersion: v1

--- a/i18n/de/skills/review-skill-format/SKILL.md
+++ b/i18n/de/skills/review-skill-format/SKILL.md
@@ -106,6 +106,14 @@ If the frontmatter contains a `locale` field, the file is a translated SKILL.md.
 
 3. **Code block identity check** — Compare code blocks in the translated file against the English source. Code blocks must be identical (code is never translated).
 
+```bash
+# Check translation frontmatter fields
+for field in "locale:" "source_locale:" "source_commit:" "translator:" "translation_date:"; do
+  grep -q "^${field}\|^  ${field}" i18n/<locale>/skills/<skill-name>/SKILL.md \
+    && echo "$field OK" || echo "$field MISSING"
+done
+```
+
 **Expected:** All five translation fields present. Body paragraphs are in the target locale. Code blocks match the English source exactly.
 
 **On failure:** Report missing translation fields as BLOCKING. If body paragraphs are in English despite a non-English `locale`, report as BLOCKING.

--- a/i18n/es/skills/design-serialization-schema/SKILL.md
+++ b/i18n/es/skills/design-serialization-schema/SKILL.md
@@ -169,6 +169,7 @@ Estrategia de evolucion segura:
 2. **Nunca eliminar ni renombrar** -- deprecar en su lugar
 3. **Versionar el esquema** en el identificador (`v1`, `v2`)
 4. **Usar un registro de esquemas** para formatos binarios (Confluent Schema Registry para Avro/Protobuf)
+
 #### Reglas de evolucion de Protobuf:
 
 ```protobuf
@@ -191,7 +192,6 @@ message Measurement {
   reserved "old_sensor_name";
 }
 ```
-
 
 #### Versionado de JSON Schema:
 

--- a/i18n/es/skills/design-serialization-schema/SKILL.md
+++ b/i18n/es/skills/design-serialization-schema/SKILL.md
@@ -128,6 +128,24 @@ enum Unit {
 }
 ```
 
+#### Ejemplo de Apache Avro:
+
+```json
+{
+  "type": "record",
+  "name": "Measurement",
+  "namespace": "com.example.sensors",
+  "doc": "A sensor measurement reading",
+  "fields": [
+    {"name": "sensor_id", "type": "string", "doc": "Unique sensor identifier"},
+    {"name": "value", "type": "double", "doc": "Measured value"},
+    {"name": "unit", "type": {"type": "enum", "name": "Unit", "symbols": ["CELSIUS", "FAHRENHEIT", "KELVIN", "PERCENT", "PPM"]}},
+    {"name": "timestamp", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+    {"name": "metadata", "type": ["null", {"type": "map", "values": "string"}], "default": null}
+  ]
+}
+```
+
 **Esperado:** Esquema auto-documentado con descripciones, restricciones y definiciones claras de tipos.
 **En caso de fallo:** Si el modelo de datos aun no es estable, marcar el esquema como `draft` y evitar publicarlo en un registro.
 
@@ -151,6 +169,48 @@ Estrategia de evolucion segura:
 2. **Nunca eliminar ni renombrar** -- deprecar en su lugar
 3. **Versionar el esquema** en el identificador (`v1`, `v2`)
 4. **Usar un registro de esquemas** para formatos binarios (Confluent Schema Registry para Avro/Protobuf)
+#### Reglas de evolucion de Protobuf:
+
+```protobuf
+// v1 — original
+message Measurement {
+  string sensor_id = 1;
+  double value = 2;
+  Unit unit = 3;
+}
+
+// v2 — safe evolution
+message Measurement {
+  string sensor_id = 1;
+  double value = 2;
+  Unit unit = 3;
+  // NEW: added in v2 — old clients ignore this field
+  google.protobuf.Timestamp timestamp = 4;
+  // DEPRECATED: use sensor_id instead
+  reserved 6;
+  reserved "old_sensor_name";
+}
+```
+
+
+#### Versionado de JSON Schema:
+
+```json
+{
+  "$id": "https://example.com/schemas/measurement/v2",
+  "allOf": [
+    {"$ref": "https://example.com/schemas/measurement/v1"},
+    {
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Added in v2: GPS coordinates"
+        }
+      }
+    }
+  ]
+}
+```
 
 **Esperado:** Plan de evolucion documentado: que cambios son seguros, cuales requieren nuevas versiones.
 **En caso de fallo:** Si un cambio incompatible es inevitable, versionar el esquema (v1 -> v2) y mantener soporte paralelo durante la migracion.
@@ -178,12 +238,58 @@ errors = validate_measurement({"sensor_id": "s-01", "value": "not_a_number"})
 # -> ["$.value: 'not_a_number' is not of type 'number'"]
 ```
 
+```typescript
+// TypeScript with Zod (runtime + compile-time)
+import { z } from 'zod';
+
+const MeasurementSchema = z.object({
+  sensor_id: z.string().regex(/^[a-z]+-[0-9]+$/),
+  value: z.number(),
+  unit: z.enum(['celsius', 'fahrenheit', 'kelvin', 'percent', 'ppm']),
+  timestamp: z.string().datetime(),
+  metadata: z.record(z.string()).optional(),
+});
+
+type Measurement = z.infer<typeof MeasurementSchema>;
+
+// Validation
+const result = MeasurementSchema.safeParse(inputData);
+if (!result.success) {
+  console.error(result.error.issues);
+}
+```
+
 **Esperado:** La validacion se ejecuta en todos los datos entrantes en los limites del sistema (endpoints API, ingestion de archivos).
 **En caso de fallo:** Registrar errores de validacion con la carga completa (redactando campos sensibles) para depuracion.
 
 ### Paso 5: Documentar el Esquema
 
 Crear una pagina de documentacion del esquema con: resumen, tabla de campos (campo, tipo, requerido, descripcion, restricciones), registro de cambios (version, fecha, cambios) y politica de compatibilidad.
+
+```markdown
+# Measurement Schema (v1)
+
+## Overview
+Represents a single sensor reading with metadata.
+
+## Fields
+| Field | Type | Required | Description | Constraints |
+|-------|------|----------|-------------|-------------|
+| sensor_id | string | Yes | Unique sensor ID | Pattern: `^[a-z]+-[0-9]+$` |
+| value | number | Yes | Measured value | Any valid IEEE 754 double |
+| unit | enum | Yes | Unit of measurement | One of: celsius, fahrenheit, kelvin, percent, ppm |
+| timestamp | string | Yes | Reading time | ISO 8601 with timezone |
+| metadata | object | No | Key-value pairs | String keys and values |
+
+## Changelog
+| Version | Date | Changes |
+|---------|------|---------|
+| v1 | 2025-03-01 | Initial schema |
+
+## Compatibility
+- **Backwards**: Consumers of v1 will continue to work with future versions
+- **Policy**: Only additive, optional field changes between minor versions
+```
 
 **Esperado:** La documentacion se genera automaticamente o se mantiene sincronizada con la definicion del esquema.
 **En caso de fallo:** Si la documentacion se desvia del esquema, agregar una verificacion CI que valide la documentacion contra la fuente del esquema.

--- a/i18n/es/skills/review-skill-format/SKILL.md
+++ b/i18n/es/skills/review-skill-format/SKILL.md
@@ -106,6 +106,14 @@ If the frontmatter contains a `locale` field, the file is a translated SKILL.md.
 
 3. **Code block identity check** — Compare code blocks in the translated file against the English source. Code blocks must be identical (code is never translated).
 
+```bash
+# Check translation frontmatter fields
+for field in "locale:" "source_locale:" "source_commit:" "translator:" "translation_date:"; do
+  grep -q "^${field}\|^  ${field}" i18n/<locale>/skills/<skill-name>/SKILL.md \
+    && echo "$field OK" || echo "$field MISSING"
+done
+```
+
 **Expected:** All five translation fields present. Body paragraphs are in the target locale. Code blocks match the English source exactly.
 
 **On failure:** Report missing translation fields as BLOCKING. If body paragraphs are in English despite a non-English `locale`, report as BLOCKING.

--- a/i18n/ja/skills/design-serialization-schema/SKILL.md
+++ b/i18n/ja/skills/design-serialization-schema/SKILL.md
@@ -168,6 +168,7 @@ enum Unit {
 2. **削除や名前変更は行わない** — 代わりに非推奨にする
 3. **識別子でスキーマをバージョニング**する（`v1`、`v2`）
 4. バイナリフォーマットには**スキーマレジストリを使用**する（Avro/ProtobufのConfluent Schema Registry）
+
 #### Protobufの進化ルール:
 
 ```protobuf
@@ -190,7 +191,6 @@ message Measurement {
   reserved "old_sensor_name";
 }
 ```
-
 
 #### JSON Schemaのバージョニング:
 

--- a/i18n/ja/skills/design-serialization-schema/SKILL.md
+++ b/i18n/ja/skills/design-serialization-schema/SKILL.md
@@ -168,6 +168,48 @@ enum Unit {
 2. **削除や名前変更は行わない** — 代わりに非推奨にする
 3. **識別子でスキーマをバージョニング**する（`v1`、`v2`）
 4. バイナリフォーマットには**スキーマレジストリを使用**する（Avro/ProtobufのConfluent Schema Registry）
+#### Protobufの進化ルール:
+
+```protobuf
+// v1 — original
+message Measurement {
+  string sensor_id = 1;
+  double value = 2;
+  Unit unit = 3;
+}
+
+// v2 — safe evolution
+message Measurement {
+  string sensor_id = 1;
+  double value = 2;
+  Unit unit = 3;
+  // NEW: added in v2 — old clients ignore this field
+  google.protobuf.Timestamp timestamp = 4;
+  // DEPRECATED: use sensor_id instead
+  reserved 6;
+  reserved "old_sensor_name";
+}
+```
+
+
+#### JSON Schemaのバージョニング:
+
+```json
+{
+  "$id": "https://example.com/schemas/measurement/v2",
+  "allOf": [
+    {"$ref": "https://example.com/schemas/measurement/v1"},
+    {
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Added in v2: GPS coordinates"
+        }
+      }
+    }
+  ]
+}
+```
 
 **期待結果:** 進化計画が文書化: どの変更が安全か、どれが新バージョンを必要とするか。
 **失敗時:** 破壊的変更が不可避な場合、スキーマをバージョニングし（v1 -> v2）、移行中は並行サポートを維持する。

--- a/i18n/zh-CN/skills/design-serialization-schema/SKILL.md
+++ b/i18n/zh-CN/skills/design-serialization-schema/SKILL.md
@@ -255,6 +255,31 @@ if (!result.success) {
 
 创建模式文档页面，包含概述、字段表、变更日志和兼容性策略。
 
+```markdown
+# Measurement Schema (v1)
+
+## Overview
+Represents a single sensor reading with metadata.
+
+## Fields
+| Field | Type | Required | Description | Constraints |
+|-------|------|----------|-------------|-------------|
+| sensor_id | string | Yes | Unique sensor ID | Pattern: `^[a-z]+-[0-9]+$` |
+| value | number | Yes | Measured value | Any valid IEEE 754 double |
+| unit | enum | Yes | Unit of measurement | One of: celsius, fahrenheit, kelvin, percent, ppm |
+| timestamp | string | Yes | Reading time | ISO 8601 with timezone |
+| metadata | object | No | Key-value pairs | String keys and values |
+
+## Changelog
+| Version | Date | Changes |
+|---------|------|---------|
+| v1 | 2025-03-01 | Initial schema |
+
+## Compatibility
+- **Backwards**: Consumers of v1 will continue to work with future versions
+- **Policy**: Only additive, optional field changes between minor versions
+```
+
 **预期结果：** 文档自动生成或与模式定义保持同步。
 **失败处理：** 如果文档与模式不同步，添加 CI 检查来验证文档与模式源的一致性。
 

--- a/i18n/zh-CN/skills/review-skill-format/SKILL.md
+++ b/i18n/zh-CN/skills/review-skill-format/SKILL.md
@@ -102,6 +102,14 @@ If the frontmatter contains a `locale` field, the file is a translated SKILL.md.
 
 3. **Code block identity check** — Compare code blocks in the translated file against the English source. Code blocks must be identical (code is never translated).
 
+```bash
+# Check translation frontmatter fields
+for field in "locale:" "source_locale:" "source_commit:" "translator:" "translation_date:"; do
+  grep -q "^${field}\|^  ${field}" i18n/<locale>/skills/<skill-name>/SKILL.md \
+    && echo "$field OK" || echo "$field MISSING"
+done
+```
+
 **Expected:** All five translation fields present. Body paragraphs are in the target locale. Code blocks match the English source exactly.
 
 **On failure:** Report missing translation fields as BLOCKING. If body paragraphs are in English despite a non-English `locale`, report as BLOCKING.


### PR DESCRIPTION
Addresses #483 — ten of the twelve. The other two came back **misclassified**; see below.

These are faithful translations that `normalize-i18n-fences.js` refuses because their fence count or tag sequence diverges from English. That is the ordinal-mapping guard, not a content defect, and they are explicitly **not** #478's re-authored forks.

## What was done

Each missing block is re-inserted **by anchor** — a line verified to occur exactly once in the translated file — never by ordinal, since ordinal insertion is the unsoundness that made the normalizer skip these. Every fence body is copied verbatim from that translation's own `source_commit` basis. No fence content is authored.

The applier refuses rather than guesses: an anchor matching zero or more than one line is rejected, and so is any edit whose result does not leave the file's tag sequence **byte-equal to the basis**. All ten passed.

| file | fences |
|---|---|
| `de/review-skill-format`, `es/…`, `zh-CN/…` | 6 → 7 each |
| `de/create-skill` | 17 → 18 |
| `de/optimize-cloud-costs` | 16 → 17 |
| `de/design-serialization-schema` | 4 → 8 |
| `es/design-serialization-schema` | 3 → 8 |
| `ja/design-serialization-schema` | 6 → 8 |
| `zh-CN/design-serialization-schema` | 7 → 8 |
| `de/annotate-source-files` | 12 → 12 (a **move**) |

`annotate-source-files` was the only one whose count already matched. Its "Block comment syntax" subsection sits at the file tail instead of inside Schritt 3 — traced to `faa4938f7`, whose own commit message names it: *"ecb11b8b (annotate-source-files): Block comment syntax section added"*. That automated refresh appended the section at the end instead of inserting it at its anchor.

## This is the structural half only

It makes the files normalizer-reachable. The in-fence comment translations they also carry are the mechanical half, and **that run is blocked twice over — deliberately not attempted here:**

1. An unscoped normalizer run on this branch also plans **`de/design-shiny-ui`**, the known #498 content fork. The step-correspondence guard that refuses it lives on #512, which is unmerged, so a `--write` here would corrupt the exact file that PR exists to protect. Caught by reading the plan before running it.
2. The plan also includes the six **regulated** files of #501 §1, which are [USER]-blocked pending a named reviewer.

Neither is scopeable with today's flags: `--locale es` and `--locale ja` are clean, but `--locale de` pulls in the fork and `--locale zh-CN` pulls in the regulated set. Completing the mechanical half wants #512 merged plus either an `--id` scope or the compliance carve-out applied.

## Two files are misclassified — #483's population needs a correction

**`es/configure-mcp-server` fails #483's own admission test.** That issue admits Class B on "`metadata.tags` byte-identical to English". Here they are not: `r-mcptools` substituted for `mcptools` and reordered; `complexity` is `basic` where English is `intermediate`; the procedure has 4 steps against English's 6, with a Paso 1 that has no English counterpart and two whole English steps absent; two Related Skills appear in no English revision; and two fences are invented outright. Control: the de, ja and zh-CN translations of this same skill are all 100% faithful with byte-identical tags. This looks like a **#478-class re-authored fork**, and its disposition is a decision, not a repair.

**`es/create-glyph` is stale, not short.** It is in perfect ordinal parity with English at `acc252e6d^` — before English collapsed three per-entity `Rscript build-*-icons.R` fences into one `bash viz/build.sh`. The tempting fix (de-translate four comment lines) would turn the gate green **by re-publishing bare `Rscript` invocations that repo policy forbids** (CLAUDE.md Viz Deploy Model; `feedback_build_sh`). Its `source_commit` also *postdates* the restructure it has not absorbed, so `validate:translations` reads it as fresh — a #405-shaped staleness confound.

Both filed separately rather than forced into this PR.