### PR TITLE
fix(i18n): lift the pre-flight legality checklist into prose, recovering four translations (#502)

### DIFF
--- a/i18n/caveman-lite/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/caveman-lite/skills/audit-dependency-versions/SKILL.md
@@ -199,11 +199,9 @@ Color coding:
 Run ecosystem-specific security audit tools:
 
 **R:**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js:**
 ```bash

--- a/i18n/caveman-lite/skills/evolve-skill/SKILL.md
+++ b/i18n/caveman-lite/skills/evolve-skill/SKILL.md
@@ -121,14 +121,12 @@ Use this decision matrix to determine whether to refine in-place or create a var
 
 Edit the existing SKILL.md directly:
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- Open for editing
+- Add/revise procedure steps
+- Strengthen Expected/On failure pairs
+- Add tables or examples
+- Update When to Use triggers
+- Revise Inputs if scope changed
 
 Follow these editing rules:
 - Preserve all existing sections — add content, don't remove sections

--- a/i18n/caveman-lite/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/caveman-lite/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,13 +291,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. Interpret BIC differences using standard guidelines:
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/caveman-lite/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/caveman-lite/skills/fit-drift-diffusion-model/SKILL.md
@@ -296,7 +296,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/caveman-lite/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/caveman-lite/skills/generate-workflow-diagram/SKILL.md
@@ -84,23 +84,24 @@ Each `node_type` also receives a corresponding CSS class (e.g., `class nodeId in
 
 Choose a theme appropriate for the target audience.
 
+List all available themes:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standard themes
+- "light"   — Default, bright colors
+- "dark"    — For dark mode environments
+- "auto"    — GitHub-adaptive with solid colors
+- "minimal" — Grayscale, print-friendly
+- "github"  — Optimized for GitHub README files
+
+Colorblind-safe themes (viridis family)
+- "viridis" — Purple→Blue→Green→Yellow, general accessibility
+- "magma"   — Purple→Red→Yellow, high contrast for print
+- "plasma"  — Purple→Pink→Orange→Yellow, presentations
+- "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 
 Additional parameters:
 - `direction`: Diagram flow direction — `"TD"` (top-down, default), `"LR"` (left-right), `"RL"`, `"BT"`

--- a/i18n/caveman-lite/skills/prepare-print-model/SKILL.md
+++ b/i18n/caveman-lite/skills/prepare-print-model/SKILL.md
@@ -53,16 +53,14 @@ Export and optimize 3D models for additive manufacturing. This skill covers the 
 Export the 3D model in a suitable format for printing:
 
 **For FDM/SLA**:
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 **Got:** Model file exported with appropriate resolution (0.1mm chord tolerance for mechanical parts, 0.05mm for organic shapes).
 
@@ -129,16 +127,14 @@ Verify minimum wall thickness for chosen process:
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 **Got:** All walls meet minimum thickness for chosen process. Thin walls flagged for review.
 
@@ -210,15 +206,13 @@ Configure automatic or manual supports for overhangs:
 - Reduces surface marks
 - Slightly easier removal
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 **Got:** Supports generated for all overhangs exceeding threshold angle, preview shows no floating geometry.
 
@@ -274,17 +268,15 @@ retract_speed: 150-180mm/min
 
 Inspect sliced G-code for issues:
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **Red flags in preview**:
 - **White gaps in solid regions**: Walls too thin for current line width

--- a/i18n/caveman-lite/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/caveman-lite/skills/rotate-scraping-proxies/SKILL.md
@@ -60,16 +60,15 @@ credential stuffing / sneaker bots / content piracy.
 Gate the workflow on a documented legal and ethical review. Skipping this is
 the single biggest source of harm.
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Inputs to confirm before writing any code:
+
+1. Is the data public (no login required)?
+2. Does robots.txt permit the path?
+3. Does the site's ToS prohibit automated access? (read it)
+4. Would the scraping process personal data? If yes, what is the legal basis?
+5. Could this access circumvent geo-licensing, paywalls, or auth?
+6. Is there a public API or data dump that would make scraping unnecessary?
+7. Have you contacted the site owner if scope is large?
 
 **Got:** Every question has a defensible written answer. The first "no" or
 "unknown" stops the procedure until resolved.

--- a/i18n/caveman-lite/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/caveman-lite/skills/troubleshoot-print-issues/SKILL.md
@@ -292,7 +292,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 **Got:** Consistent extrusion with no gaps in perimeters or infill.
 

--- a/i18n/caveman-lite/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/caveman-lite/skills/troubleshoot-print-issues/SKILL.md
@@ -156,25 +156,23 @@ Implement immediate solutions for common issues:
 ### Poor Bed Adhesion
 
 **Immediate fixes**:
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **Slicer settings**:
 - First layer height: 0.2-0.3mm (thicker = better squish)
@@ -218,20 +216,18 @@ retraction_speed: 40-60mm/s
 ### Layer Shifts
 
 **Mechanical checks**:
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **Speed reduction**:
 ```yaml
@@ -277,30 +273,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Under-Extrusion
 
 **Quick fixes**:
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **E-steps calibration**:
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 **Got:** Consistent extrusion with no gaps in perimeters or infill.
 
@@ -320,13 +312,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **Dimensional accuracy test**:
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 **Got:** Accurate dimensions, smooth surfaces, no bulging.
 

--- a/i18n/caveman-ultra/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/caveman-ultra/skills/audit-dependency-versions/SKILL.md
@@ -199,11 +199,9 @@ Color coding:
 Run ecosystem-specific audit tools:
 
 **R:**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js:**
 ```bash

--- a/i18n/caveman-ultra/skills/evolve-skill/SKILL.md
+++ b/i18n/caveman-ultra/skills/evolve-skill/SKILL.md
@@ -121,14 +121,12 @@ If err: unsure → default refinement. Extract variant later easier than merge b
 
 Edit existing SKILL.md directly:
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- Open for editing
+- Add/revise procedure steps
+- Strengthen Expected/On failure pairs
+- Add tables or examples
+- Update When to Use triggers
+- Revise Inputs if scope changed
 
 Editing rules:
 - Preserve all sections — add not remove

--- a/i18n/caveman-ultra/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/caveman-ultra/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,13 +291,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. Interpret BIC (Kass & Raftery, 1995):
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. Bayesian → DIC or WAIC:
 

--- a/i18n/caveman-ultra/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/caveman-ultra/skills/fit-drift-diffusion-model/SKILL.md
@@ -296,7 +296,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. Bayesian → DIC or WAIC:
 

--- a/i18n/caveman-ultra/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/caveman-ultra/skills/generate-workflow-diagram/SKILL.md
@@ -80,23 +80,24 @@ Each → CSS class (`class nodeId input;`) for theme styling.
 
 ### Step 2: Select theme + options
 
+List all available themes:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standard themes
+- "light"   — Default, bright colors
+- "dark"    — For dark mode environments
+- "auto"    — GitHub-adaptive with solid colors
+- "minimal" — Grayscale, print-friendly
+- "github"  — Optimized for GitHub README files
+
+Colorblind-safe themes (viridis family)
+- "viridis" — Purple→Blue→Green→Yellow, general accessibility
+- "magma"   — Purple→Red→Yellow, high contrast for print
+- "plasma"  — Purple→Pink→Orange→Yellow, presentations
+- "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 
 Extra params:
 - `direction`: `"TD"` (top-down, default), `"LR"`, `"RL"`, `"BT"`

--- a/i18n/caveman-ultra/skills/prepare-print-model/SKILL.md
+++ b/i18n/caveman-ultra/skills/prepare-print-model/SKILL.md
@@ -51,16 +51,14 @@ Export + optimize 3D models for additive manufacturing. CAD/modeling export → 
 Export 3D model in suitable format:
 
 **FDM/SLA**:
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 → Model exported w/ appropriate resolution (0.1mm chord tolerance for mech parts, 0.05mm for organic).
 
@@ -127,16 +125,14 @@ Verify min wall thickness for process:
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 → All walls meet min thickness for process. Thin walls flagged.
 
@@ -208,15 +204,13 @@ Auto or manual supports for overhangs:
 - Reduces surface marks
 - Easier removal
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 → Supports gen'd for all overhangs > threshold, preview shows no floating geometry.
 
@@ -272,17 +266,15 @@ If err: unsure → start w/ slicer's default "Standard Quality" profile for mate
 
 Inspect sliced G-code:
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **Red flags**:
 - **White gaps in solid regions**: Walls too thin for line width

--- a/i18n/caveman-ultra/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/caveman-ultra/skills/rotate-scraping-proxies/SKILL.md
@@ -48,16 +48,15 @@ Network-layer escalation when client stealth exhausted. Last resort, not default
 
 Gate workflow on documented review. Skip = biggest harm source.
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Inputs to confirm before writing any code:
+
+1. Is the data public (no login required)?
+2. Does robots.txt permit the path?
+3. Does the site's ToS prohibit automated access? (read it)
+4. Would the scraping process personal data? If yes, what is the legal basis?
+5. Could this access circumvent geo-licensing, paywalls, or auth?
+6. Is there a public API or data dump that would make scraping unnecessary?
+7. Have you contacted the site owner if scope is large?
 
 → Every Q has defensible written ans. First "no"|"unknown" stops proc.
 

--- a/i18n/caveman-ultra/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/caveman-ultra/skills/troubleshoot-print-issues/SKILL.md
@@ -290,7 +290,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 **Got:** Consistent extrusion, no gaps in perimeters|infill.
 

--- a/i18n/caveman-ultra/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/caveman-ultra/skills/troubleshoot-print-issues/SKILL.md
@@ -154,25 +154,23 @@ Root cause: Material choice (ABS) incompatible with open printer in drafty room
 ### Poor Bed Adhesion
 
 **Immediate**:
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **Slicer**:
 - First layer height: 0.2-0.3mm (thicker = better squish)
@@ -216,20 +214,18 @@ retraction_speed: 40-60mm/s
 ### Layer Shifts
 
 **Mech checks**:
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **Speed reduction**:
 ```yaml
@@ -275,30 +271,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Under-Extrusion
 
 **Quick**:
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **E-steps cal**:
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 **Got:** Consistent extrusion, no gaps in perimeters|infill.
 
@@ -318,13 +310,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **Dim accuracy test**:
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 **Got:** Accurate dims, smooth surfaces, no bulging.
 

--- a/i18n/caveman/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/caveman/skills/audit-dependency-versions/SKILL.md
@@ -199,11 +199,9 @@ Color coding:
 Run ecosystem-specific audit tools:
 
 **R:**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js:**
 ```bash

--- a/i18n/caveman/skills/evolve-skill/SKILL.md
+++ b/i18n/caveman/skills/evolve-skill/SKILL.md
@@ -121,14 +121,12 @@ Use this pick matrix to decide refine in-place or make variant:
 
 Edit existing SKILL.md direct:
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- Open for editing
+- Add/revise procedure steps
+- Strengthen Expected/On failure pairs
+- Add tables or examples
+- Update When to Use triggers
+- Revise Inputs if scope changed
 
 Follow these edit rules:
 - Keep all existing sections — add content, do not remove sections

--- a/i18n/caveman/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/caveman/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,13 +291,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. Read BIC differences with standard guides:
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/caveman/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/caveman/skills/fit-drift-diffusion-model/SKILL.md
@@ -296,7 +296,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/caveman/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/caveman/skills/generate-workflow-diagram/SKILL.md
@@ -84,23 +84,24 @@ Each `node_type` also gets CSS class (`class nodeId input;`) for theme-based sty
 
 Pick theme for target audience.
 
+List all available themes:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standard themes
+- "light"   — Default, bright colors
+- "dark"    — For dark mode environments
+- "auto"    — GitHub-adaptive with solid colors
+- "minimal" — Grayscale, print-friendly
+- "github"  — Optimized for GitHub README files
+
+Colorblind-safe themes (viridis family)
+- "viridis" — Purple→Blue→Green→Yellow, general accessibility
+- "magma"   — Purple→Red→Yellow, high contrast for print
+- "plasma"  — Purple→Pink→Orange→Yellow, presentations
+- "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 
 Additional parameters:
 - `direction`: Diagram flow direction — `"TD"` (top-down, default), `"LR"` (left-right), `"RL"`, `"BT"`

--- a/i18n/caveman/skills/prepare-print-model/SKILL.md
+++ b/i18n/caveman/skills/prepare-print-model/SKILL.md
@@ -53,16 +53,14 @@ Export and optimize 3D models for additive manufacturing. Cover full workflow fr
 Export 3D model in suitable format for printing:
 
 **For FDM/SLA**:
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 **Got:** Model file exported with appropriate resolution (0.1mm chord tolerance for mechanical parts, 0.05mm for organic shapes).
 
@@ -129,16 +127,14 @@ Verify minimum wall thickness for chosen process:
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 **Got:** All walls meet minimum thickness for chosen process. Thin walls flagged for review.
 
@@ -210,15 +206,13 @@ Configure automatic or manual supports for overhangs:
 - Reduces surface marks
 - Slightly easier removal
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 **Got:** Supports generated for all overhangs exceeding threshold angle. Preview shows no floating geometry.
 
@@ -274,17 +268,15 @@ retract_speed: 150-180mm/min
 
 Inspect sliced G-code for issues:
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **Red flags in preview**:
 - **White gaps in solid regions**: Walls too thin for current line width

--- a/i18n/caveman/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/caveman/skills/rotate-scraping-proxies/SKILL.md
@@ -53,16 +53,15 @@ Network-layer escalation for scraping when client-side stealth exhausted. Proxy 
 
 Gate workflow on documented legal+ethical review. Skip = biggest source of harm.
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Inputs to confirm before writing any code:
+
+1. Is the data public (no login required)?
+2. Does robots.txt permit the path?
+3. Does the site's ToS prohibit automated access? (read it)
+4. Would the scraping process personal data? If yes, what is the legal basis?
+5. Could this access circumvent geo-licensing, paywalls, or auth?
+6. Is there a public API or data dump that would make scraping unnecessary?
+7. Have you contacted the site owner if scope is large?
 
 **Got:** Every question has defensible written answer. First "no" or "unknown" stops procedure.
 

--- a/i18n/caveman/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/caveman/skills/troubleshoot-print-issues/SKILL.md
@@ -154,25 +154,23 @@ Implement immediate solutions for common issues:
 ### Poor Bed Adhesion
 
 **Immediate fixes**:
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **Slicer settings**:
 - First layer height: 0.2-0.3mm (thicker = better squish)
@@ -216,20 +214,18 @@ retraction_speed: 40-60mm/s
 ### Layer Shifts
 
 **Mechanical checks**:
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **Speed reduction**:
 ```yaml
@@ -275,30 +271,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Under-Extrusion
 
 **Quick fixes**:
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **E-steps calibration**:
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 **Got:** Consistent extrusion. No gaps in perimeters or infill.
 
@@ -318,13 +310,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **Dimensional accuracy test**:
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 **Got:** Accurate dimensions, smooth surfaces, no bulging.
 

--- a/i18n/caveman/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/caveman/skills/troubleshoot-print-issues/SKILL.md
@@ -290,7 +290,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 **Got:** Consistent extrusion. No gaps in perimeters or infill.
 

--- a/i18n/de/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/de/skills/audit-dependency-versions/SKILL.md
@@ -199,11 +199,9 @@ Color coding:
 Ausfuehren ecosystem-specific security audit tools:
 
 **R:**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js:**
 ```bash

--- a/i18n/de/skills/evolve-skill/SKILL.md
+++ b/i18n/de/skills/evolve-skill/SKILL.md
@@ -123,14 +123,12 @@ Diese Entscheidungsmatrix verwenden, um zu bestimmen, ob direkt verfeinert oder 
 
 Die bestehende SKILL.md direkt bearbeiten:
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- Zur Bearbeitung oeffnen
+- Verfahrensschritte hinzufuegen/ueberarbeiten
+- Expected/On-failure-Paare staerken
+- Tabellen oder Beispiele hinzufuegen
+- Ausloser fuer "When to Use" aktualisieren
+- Inputs ueberarbeiten, falls sich Umfang geaendert hat
 
 Diese Bearbeitungsregeln befolgen:
 - Alle bestehenden Abschnitte erhalten — Inhalte hinzufuegen, keine Abschnitte entfernen

--- a/i18n/de/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/de/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,13 +291,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. Interpret BIC differences using standard guidelines:
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/de/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/de/skills/fit-drift-diffusion-model/SKILL.md
@@ -296,7 +296,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/de/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/de/skills/generate-workflow-diagram/SKILL.md
@@ -85,23 +85,24 @@ Jeder `node_type` erhaelt auch eine entsprechende CSS-Klasse (z.B. `class nodeId
 
 Ein fuer die Zielgruppe geeignetes Thema auswaehlen.
 
+Alle verfuegbaren Themen auflisten:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standardthemen
+- "light"   — Standard, helle Farben
+- "dark"    — Fuer Dunkelmodusumgebungen
+- "auto"    — GitHub-adaptiv mit Volltonfarben
+- "minimal" — Graustufen, druckfreundlich
+- "github"  — Optimiert fuer GitHub-README-Dateien
+
+Farbenblindensichere Themen (Viridis-Familie)
+- "viridis" — Lila→Blau→Gruen→Gelb, allgemeine Barrierefreiheit
+- "magma"   — Lila→Rot→Gelb, hoher Kontrast fuer Druck
+- "plasma"  — Lila→Pink→Orange→Gelb, Praesentationen
+- "cividis" — Blau→Grau→Gelb, maximale Barrierefreiheit (kein Rot-Gruen)
 
 Zusaetzliche Parameter:
 - `direction`: Diagrammflussrichtung — `"TD"` (von oben nach unten, Standard), `"LR"` (von links nach rechts), `"RL"`, `"BT"`

--- a/i18n/de/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/de/skills/harden-github-repo-security/SKILL.md
@@ -181,24 +181,22 @@ Recommended: a GitHub App installation token. (Deploy key is a narrower
 single-repo alternative: add an SSH deploy key with write access and use
 `actor_type: DeployKey` in 3b.)
 
-```bash
-# Create a GitHub App (personal account, Settings > Developer settings >
-# GitHub Apps), permission Repository > Contents: Read and write; install it
-# on THIS repo. Store the App id as a repo variable and the private key as an
-# Actions secret. In the workflow, mint a token and pass it to checkout + the
-# commit action:
-#   - uses: actions/create-github-app-token@<sha>   # v2
-#     id: app-token
-#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
-#   - uses: actions/checkout@<sha>
-#     with: { token: ${{ steps.app-token.outputs.token }} }
-#   - uses: stefanzweifel/git-auto-commit-action@<sha>
-#     with: { ... }   # inherits the app token via the checkout credentials
-#
-# The numeric App id used in Step 3b is shown on the App's own page:
-# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
-# It is unrelated to the repository id and cannot be derived from /repos/$R.
-```
+Create a GitHub App (personal account, Settings > Developer settings >
+GitHub Apps), permission Repository > Contents: Read and write; install it
+on THIS repo. Store the App id as a repo variable and the private key as an
+Actions secret. In the workflow, mint a token and pass it to checkout + the
+commit action:
+  - uses: actions/create-github-app-token@<sha>   # v2
+    id: app-token
+    with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+  - uses: actions/checkout@<sha>
+    with: { token: ${{ steps.app-token.outputs.token }} }
+  - uses: stefanzweifel/git-auto-commit-action@<sha>
+    with: { ... }   # inherits the app token via the checkout credentials
+
+The numeric App id used in Step 3b is shown on the App's own page:
+Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Higher-assurance alternative (no standing bypass actor).** If a manual merge
 click is acceptable, convert the job to open a PR with the App token (e.g.

--- a/i18n/de/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/de/skills/harden-github-repo-security/SKILL.md
@@ -186,6 +186,8 @@ GitHub Apps), permission Repository > Contents: Read and write; install it
 on THIS repo. Store the App id as a repo variable and the private key as an
 Actions secret. In the workflow, mint a token and pass it to checkout + the
 commit action:
+
+```yaml
   - uses: actions/create-github-app-token@<sha>   # v2
     id: app-token
     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
@@ -193,9 +195,10 @@ commit action:
     with: { token: ${{ steps.app-token.outputs.token }} }
   - uses: stefanzweifel/git-auto-commit-action@<sha>
     with: { ... }   # inherits the app token via the checkout credentials
+```
 
 The numeric App id used in Step 3b is shown on the App's own page:
-Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+Settings > Developer settings > GitHub Apps > `<your app>` > About ("App ID").
 It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Higher-assurance alternative (no standing bypass actor).** If a manual merge

--- a/i18n/de/skills/prepare-print-model/SKILL.md
+++ b/i18n/de/skills/prepare-print-model/SKILL.md
@@ -54,16 +54,14 @@ metadata:
 Das 3D-Modell in einem geeigneten Format fuer den Druck exportieren:
 
 **Fuer FDM/SLA**:
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+Bei Start aus CAD (Fusion 360, SolidWorks)
+Exportieren als: STL (binaer) oder 3MF
+Aufloesung: Hoch (Dreiecksanzahl ausreichend fuer Details)
+Einheiten: mm (Massstab ueberpruefen)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Beispiel-Exporteinstellungen:
+STL: Binaerformat, Verfeinerung 0.1mm
+3MF: Farb-/Materialdaten einschliessen bei Multimaterial-Drucker
 
 **Erwartet:** Modelldatei mit geeigneter Aufloesung exportiert (0.1mm Sehnentoleranz fuer mechanische Teile, 0.05mm fuer organische Formen).
 
@@ -130,16 +128,14 @@ Mindestwandstaerke fuer gewaehltes Verfahren verifizieren:
 | SLA (Engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (Nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Wandstaerke visuell im Slicer pruefen:
+- Modell importieren
+- "Duennwaende"-Erkennung aktivieren
+- Mit 0 Fuellung slicen um Wandstruktur zu sehen
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+Fuer praezise Messung CAD-Software verwenden:
+- Abstand zwischen parallelen Flaechen messen
+- In kritischen lasttragenden Bereichen pruefen
 
 **Erwartet:** Alle Waende erfuellen Mindeststärke fuer gewaehltes Verfahren. Duenne Waende zur Pruefung markiert.
 
@@ -211,15 +207,13 @@ Automatische oder manuelle Stuetzstrukturen fuer Ueberhaenge konfigurieren:
 - Reduziert Oberflaechenmarkierungen
 - Etwas einfachere Entfernung
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+Im Slicer (PrusaSlicer Beispiel):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 **Erwartet:** Stuetzstrukturen fuer alle Ueberhaenge ueber Schwellenwertwinkel generiert, Vorschau zeigt keine schwebende Geometrie.
 
@@ -275,17 +269,15 @@ retract_speed: 150-180mm/min
 
 Gesliceten G-Code auf Probleme untersuchen:
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+Im Slicer:
+- Modell slicen
+- Schichtvorschau-Schieberegler zur Inspektion jeder Schicht verwenden
+- Pruefen auf:
+  * Luecken in Perimetern (zeigt duenne Waende an)
+  * Schwebende Bereiche (fehlende Stuetzstrukturen)
+  * Uebermassige Fadenzieh-Pfade (Fahrwege reduzieren)
+  * Erste Schicht: korrekte Anpressung und Haftung
+  * Obere Schichten: ausreichende Vollmaterial-Fuellung
 
 **Warnsignale in der Vorschau**:
 - **Weisse Luecken in Vollbereichen**: Waende zu duenn fuer aktuelle Linienbreite

--- a/i18n/de/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/de/skills/rotate-scraping-proxies/SKILL.md
@@ -74,16 +74,15 @@ Machen Sie den gesamten Arbeitsablauf von einer dokumentierten rechtlichen
 und ethischen Prüfung abhängig. Das Überspringen dieses Schritts ist die mit
 Abstand größte Schadensquelle.
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Vor dem Schreiben jeglichen Codes zu bestätigende Eingaben:
+
+1. Sind die Daten öffentlich (kein Login erforderlich)?
+2. Erlaubt robots.txt den Pfad?
+3. Verbieten die AGB der Website automatisierten Zugriff? (lesen!)
+4. Würden beim Scraping personenbezogene Daten verarbeitet? Wenn ja, welche rechtliche Grundlage?
+5. Könnte dieser Zugriff Geo-Lizenzierung, Paywalls oder Authentifizierung umgehen?
+6. Gibt es eine öffentliche API oder einen Daten-Dump, der Scraping überflüssig macht?
+7. Haben Sie den Website-Betreiber kontaktiert, falls der Umfang groß ist?
 
 **Expected:** Jede Frage hat eine verteidigungsfähige schriftliche Antwort.
 Das erste „Nein" oder „Unbekannt" stoppt das Vorgehen, bis es geklärt ist.

--- a/i18n/de/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/de/skills/troubleshoot-print-issues/SKILL.md
@@ -292,7 +292,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. 100mm extrudieren: G1 E100 F100
 3. Verbleibende Distanz zur Markierung messen
 4. Berechnen: neue_steps = aktuelle_steps × (100 / tatsaechlich_extrudiert)
-5. Setzen: M92 E<neue_steps>; M500 (im EEPROM speichern)
+5. Setzen: `M92 E<neue_steps>`; M500 (im EEPROM speichern)
 
 **Erwartet:** Konsistente Extrusion ohne Luecken in Perimetern oder Fuellung.
 

--- a/i18n/de/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/de/skills/troubleshoot-print-issues/SKILL.md
@@ -156,25 +156,23 @@ Sofortloesungen fuer gaengige Probleme umsetzen:
 ### Schlechte Betthaftung
 
 **Sofortkorrekturen**:
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Bett gruendlich reinigen
+   Glas/PEI: Isopropylalkohol 90%+
+   BuildTak: Warmes Wasser und Spuelmittel
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Bett nivellieren (Papiertest an 4 Ecken + Mitte)
+   Papier sollte leicht schleifen
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Z-Offset nach unten anpassen (erste Schicht staerker anpressen)
+   Start: -0.05mm Schritte bis Linien verschmelzen
 
-# 4. Increase bed temperature +5°C
+4. Betttemperatur +5 Grad C erhoehen
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Haftmittel hinzufuegen:
+   - Klebestift (PLA/PETG)
+   - Haarspray (ABS)
+   - ABS-Saft (ABS) - ABS in Aceton aufgeloest
+   - Magigoo/3D-Druck-Haftmittel
 
 **Slicer-Einstellungen**:
 - Erstschichthoehe: 0.2-0.3mm (dicker = bessere Anpressung)
@@ -218,20 +216,18 @@ retraction_speed: 40-60mm/s
 ### Schichtversatz
 
 **Mechanische Pruefungen**:
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Riemenspannung pruefen (sollte wie Gitarrensaite schwingen)
+   Nachspannen wenn locker
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Riemenscheiben-Madenschrauben pruefen (Motorwellen)
+   Muessen auf der Abflachung der Motorwelle sitzen
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Auf mechanischen Widerstand pruefen
+   X/Y-Achsen manuell bewegen - sollten leichtgaengig gleiten
+   Klemmen deutet auf verschmutzte Stangen, abgenutzte Lager oder Fehlausrichtung hin
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Schrittmotorstrom pruefen (fortgeschritten)
+   Zu niedrig → Schritte ueberspringen; zu hoch → Ueberhitzung
 
 **Geschwindigkeitsreduzierung**:
 ```yaml
@@ -277,30 +273,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Unterextrusion
 
 **Schnellkorrekturen**:
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Auf Duesenverstopfung pruefen
+   Auf Drucktemperatur aufheizen, Filament manuell durchschieben
+   Sollte gleichmaessig extrudieren
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold-Pull-Reinigung (bei teilweiser Verstopfung)
+   Auf 220 Grad C aufheizen, Reinigungsfilament durchschieben
+   Auf 90 Grad C abkuehlen, ruckartig ziehen - sollte Ablagerungen entfernen
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Temperatur +5-10 Grad C erhoehen
+   Hoehere Temperatur = besserer Durchfluss
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Durchflussrate 2-5% erhoehen
+   Slicer: Filament-Einstellungen → Durchfluss → 102-105%
 
 **E-Steps-Kalibrierung**:
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Filament 120mm ueber Extruder markieren
+2. 100mm extrudieren: G1 E100 F100
+3. Verbleibende Distanz zur Markierung messen
+4. Berechnen: neue_steps = aktuelle_steps × (100 / tatsaechlich_extrudiert)
+5. Setzen: M92 E<neue_steps>; M500 (im EEPROM speichern)
 
 **Erwartet:** Konsistente Extrusion ohne Luecken in Perimetern oder Fuellung.
 
@@ -320,13 +312,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **Massgenauigkeitstest**:
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+20mm Kalibrierwuerfel drucken
+Mit Messschieber messen:
+X/Y-Masse sollten 20.0mm ± 0.1mm sein
+Wenn konsistent uebergross → Durchfluss reduzieren
+Wenn untergross → Durchfluss erhoehen
 
 **Erwartet:** Genaue Masse, glatte Oberflaechen, keine Woelbungen.
 

--- a/i18n/es/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/es/skills/audit-dependency-versions/SKILL.md
@@ -199,11 +199,9 @@ Color coding:
 Run ecosystem-specific security audit tools:
 
 **R:**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js:**
 ```bash

--- a/i18n/es/skills/evolve-skill/SKILL.md
+++ b/i18n/es/skills/evolve-skill/SKILL.md
@@ -124,14 +124,12 @@ Usar esta matriz de decisión para determinar si refinar en el lugar o crear una
 
 Editar el SKILL.md existente directamente:
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- Abrir para edición
+- Añadir/revisar pasos del procedimiento
+- Fortalecer pares Expected/On failure
+- Añadir tablas o ejemplos
+- Actualizar los disparadores de When to Use
+- Revisar Inputs si el alcance cambió
 
 Seguir estas reglas de edición:
 - Preservar todas las secciones existentes — añadir contenido, no eliminar secciones

--- a/i18n/es/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/es/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,13 +291,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. Interpret BIC differences using standard guidelines:
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/es/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/es/skills/fit-drift-diffusion-model/SKILL.md
@@ -296,7 +296,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/es/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/es/skills/generate-workflow-diagram/SKILL.md
@@ -84,23 +84,24 @@ Each `node_type` also receives a corresponding CSS class (e.g., `class nodeId in
 
 Choose a theme appropriate for the target audience.
 
+List all available themes:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standard themes
+- "light"   — Default, bright colors
+- "dark"    — For dark mode environments
+- "auto"    — GitHub-adaptive with solid colors
+- "minimal" — Grayscale, print-friendly
+- "github"  — Optimized for GitHub README files
+
+Colorblind-safe themes (viridis family)
+- "viridis" — Purple→Blue→Green→Yellow, general accessibility
+- "magma"   — Purple→Red→Yellow, high contrast for print
+- "plasma"  — Purple→Pink→Orange→Yellow, presentations
+- "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 
 Additional parameters:
 - `direction`: Diagram flow direction — `"TD"` (top-down, default), `"LR"` (left-right), `"RL"`, `"BT"`

--- a/i18n/es/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/es/skills/harden-github-repo-security/SKILL.md
@@ -181,24 +181,22 @@ Recommended: a GitHub App installation token. (Deploy key is a narrower
 single-repo alternative: add an SSH deploy key with write access and use
 `actor_type: DeployKey` in 3b.)
 
-```bash
-# Create a GitHub App (personal account, Settings > Developer settings >
-# GitHub Apps), permission Repository > Contents: Read and write; install it
-# on THIS repo. Store the App id as a repo variable and the private key as an
-# Actions secret. In the workflow, mint a token and pass it to checkout + the
-# commit action:
-#   - uses: actions/create-github-app-token@<sha>   # v2
-#     id: app-token
-#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
-#   - uses: actions/checkout@<sha>
-#     with: { token: ${{ steps.app-token.outputs.token }} }
-#   - uses: stefanzweifel/git-auto-commit-action@<sha>
-#     with: { ... }   # inherits the app token via the checkout credentials
-#
-# The numeric App id used in Step 3b is shown on the App's own page:
-# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
-# It is unrelated to the repository id and cannot be derived from /repos/$R.
-```
+Create a GitHub App (personal account, Settings > Developer settings >
+GitHub Apps), permission Repository > Contents: Read and write; install it
+on THIS repo. Store the App id as a repo variable and the private key as an
+Actions secret. In the workflow, mint a token and pass it to checkout + the
+commit action:
+  - uses: actions/create-github-app-token@<sha>   # v2
+    id: app-token
+    with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+  - uses: actions/checkout@<sha>
+    with: { token: ${{ steps.app-token.outputs.token }} }
+  - uses: stefanzweifel/git-auto-commit-action@<sha>
+    with: { ... }   # inherits the app token via the checkout credentials
+
+The numeric App id used in Step 3b is shown on the App's own page:
+Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Higher-assurance alternative (no standing bypass actor).** If a manual merge
 click is acceptable, convert the job to open a PR with the App token (e.g.

--- a/i18n/es/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/es/skills/harden-github-repo-security/SKILL.md
@@ -186,6 +186,8 @@ GitHub Apps), permission Repository > Contents: Read and write; install it
 on THIS repo. Store the App id as a repo variable and the private key as an
 Actions secret. In the workflow, mint a token and pass it to checkout + the
 commit action:
+
+```yaml
   - uses: actions/create-github-app-token@<sha>   # v2
     id: app-token
     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
@@ -193,9 +195,10 @@ commit action:
     with: { token: ${{ steps.app-token.outputs.token }} }
   - uses: stefanzweifel/git-auto-commit-action@<sha>
     with: { ... }   # inherits the app token via the checkout credentials
+```
 
 The numeric App id used in Step 3b is shown on the App's own page:
-Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+Settings > Developer settings > GitHub Apps > `<your app>` > About ("App ID").
 It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Higher-assurance alternative (no standing bypass actor).** If a manual merge

--- a/i18n/es/skills/prepare-print-model/SKILL.md
+++ b/i18n/es/skills/prepare-print-model/SKILL.md
@@ -53,16 +53,14 @@ Exportar y optimizar modelos 3D para manufactura aditiva. Esta habilidad cubre e
 Exportar el modelo 3D en un formato adecuado para impresión:
 
 **For FDM/SLA**:
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 **Esperado:** Archivo de modelo exportado con resolución apropiada (tolerancia de cuerda de 0.1mm para piezas mecánicas, 0.05mm para formas orgánicas).
 
@@ -129,16 +127,14 @@ Verificar el grosor mínimo de pared para el proceso elegido:
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 **Esperado:** Todas las paredes cumplen el grosor mínimo para el proceso elegido. Paredes delgadas marcadas para revisión.
 
@@ -210,15 +206,13 @@ Configurar soportes automáticos o manuales para voladizos:
 - Reduces surface marks
 - Slightly easier removal
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 **Esperado:** Soportes generados para todos los voladizos que excedan el ángulo umbral, la vista previa no muestra geometría flotante.
 
@@ -274,17 +268,15 @@ retract_speed: 150-180mm/min
 
 Inspeccionar el G-code laminado en busca de problemas:
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **Señales de alerta en la vista previa**:
 - **Huecos blancos en regiones sólidas**: Paredes demasiado delgadas para el ancho de línea actual

--- a/i18n/es/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/es/skills/rotate-scraping-proxies/SKILL.md
@@ -71,16 +71,15 @@ zapatillas / piratería de contenidos.
 Condicione todo el flujo de trabajo a una revisión legal y ética documentada.
 Saltarse este paso es, con diferencia, la mayor fuente de daños.
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Datos a confirmar antes de escribir una sola linea de codigo:
+
+1. ¿Son publicos los datos (sin requerir login)?
+2. ¿Permite robots.txt la ruta?
+3. ¿Prohiben los terminos del servicio el acceso automatizado? (leelos)
+4. ¿Procesaria el scraping datos personales? Si es asi, ¿cual es la base legal?
+5. ¿Podria este acceso eludir licencias geograficas, muros de pago o autenticacion?
+6. ¿Existe una API publica o volcado de datos que haga innecesario el scraping?
+7. ¿Has contactado con el propietario del sitio si el alcance es grande?
 
 **Expected:** Cada pregunta tiene una respuesta escrita defendible. El primer
 "no" o "desconocido" detiene el procedimiento hasta que se resuelva.

--- a/i18n/es/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/es/skills/troubleshoot-print-issues/SKILL.md
@@ -156,25 +156,23 @@ Implementar soluciones inmediatas para problemas comunes:
 ### Mala Adhesión a la Cama
 
 **Correcciones inmediatas**:
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **Configuraciones del slicer**:
 - Altura de primera capa: 0.2-0.3mm (más gruesa = mejor aplastamiento)
@@ -218,20 +216,18 @@ retraction_speed: 40-60mm/s
 ### Desplazamientos de Capa
 
 **Verificaciones mecánicas**:
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **Reducción de velocidad**:
 ```yaml
@@ -277,30 +273,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Sub-Extrusión
 
 **Correcciones rápidas**:
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **Calibración de e-steps**:
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 **Esperado:** Extrusión consistente sin huecos en perímetros o relleno.
 
@@ -320,13 +312,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **Prueba de precisión dimensional**:
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 **Esperado:** Dimensiones precisas, superficies lisas, sin abultamiento.
 

--- a/i18n/es/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/es/skills/troubleshoot-print-issues/SKILL.md
@@ -292,7 +292,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 **Esperado:** Extrusión consistente sin huecos en perímetros o relleno.
 

--- a/i18n/ja/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/ja/skills/audit-dependency-versions/SKILL.md
@@ -198,11 +198,9 @@ cargo search serde --limit 1
 エコシステム固有のセキュリティ監査ツールを実行する:
 
 **R:**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js:**
 ```bash

--- a/i18n/ja/skills/evolve-skill/SKILL.md
+++ b/i18n/ja/skills/evolve-skill/SKILL.md
@@ -122,14 +122,12 @@ grep -oP '`[\w-]+`' skills/<skill-name>/SKILL.md | sort -u
 
 既存のSKILL.mdを直接編集する:
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- 編集のために開く
+- 手順ステップを追加/改訂する
+- Expected/On failureペアを強化する
+- テーブルや例を追加する
+- 使用タイミングのトリガーを更新する
+- スコープが変わった場合、入力を改訂する
 
 これらの編集ルールに従う:
 - 既存のすべてのセクションを保持する — コンテンツを追加し、セクションを削除しない

--- a/i18n/ja/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/ja/skills/fit-drift-diffusion-model/SKILL.md
@@ -294,7 +294,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. ベイズモデルではDICまたはWAICを使用する：
 

--- a/i18n/ja/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/ja/skills/fit-drift-diffusion-model/SKILL.md
@@ -289,13 +289,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. 標準的なガイドラインを使用してBIC差を解釈する：
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. ベイズモデルではDICまたはWAICを使用する：
 

--- a/i18n/ja/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/ja/skills/generate-workflow-diagram/SKILL.md
@@ -84,23 +84,24 @@ workflow <- put_merge("./src/", merge_strategy = "supplement")
 
 ターゲットオーディエンスに適したテーマを選択する。
 
+List all available themes:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standard themes
+- "light"   — Default, bright colors
+- "dark"    — For dark mode environments
+- "auto"    — GitHub-adaptive with solid colors
+- "minimal" — Grayscale, print-friendly
+- "github"  — Optimized for GitHub README files
+
+Colorblind-safe themes (viridis family)
+- "viridis" — Purple→Blue→Green→Yellow, general accessibility
+- "magma"   — Purple→Red→Yellow, high contrast for print
+- "plasma"  — Purple→Pink→Orange→Yellow, presentations
+- "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 
 追加パラメータ:
 - `direction`: 図のフロー方向 — `"TD"`（上から下、デフォルト）、`"LR"`（左から右）、`"RL"`、`"BT"`

--- a/i18n/ja/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/ja/skills/harden-github-repo-security/SKILL.md
@@ -181,24 +181,22 @@ Recommended: a GitHub App installation token. (Deploy key is a narrower
 single-repo alternative: add an SSH deploy key with write access and use
 `actor_type: DeployKey` in 3b.)
 
-```bash
-# Create a GitHub App (personal account, Settings > Developer settings >
-# GitHub Apps), permission Repository > Contents: Read and write; install it
-# on THIS repo. Store the App id as a repo variable and the private key as an
-# Actions secret. In the workflow, mint a token and pass it to checkout + the
-# commit action:
-#   - uses: actions/create-github-app-token@<sha>   # v2
-#     id: app-token
-#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
-#   - uses: actions/checkout@<sha>
-#     with: { token: ${{ steps.app-token.outputs.token }} }
-#   - uses: stefanzweifel/git-auto-commit-action@<sha>
-#     with: { ... }   # inherits the app token via the checkout credentials
-#
-# The numeric App id used in Step 3b is shown on the App's own page:
-# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
-# It is unrelated to the repository id and cannot be derived from /repos/$R.
-```
+Create a GitHub App (personal account, Settings > Developer settings >
+GitHub Apps), permission Repository > Contents: Read and write; install it
+on THIS repo. Store the App id as a repo variable and the private key as an
+Actions secret. In the workflow, mint a token and pass it to checkout + the
+commit action:
+  - uses: actions/create-github-app-token@<sha>   # v2
+    id: app-token
+    with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+  - uses: actions/checkout@<sha>
+    with: { token: ${{ steps.app-token.outputs.token }} }
+  - uses: stefanzweifel/git-auto-commit-action@<sha>
+    with: { ... }   # inherits the app token via the checkout credentials
+
+The numeric App id used in Step 3b is shown on the App's own page:
+Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Higher-assurance alternative (no standing bypass actor).** If a manual merge
 click is acceptable, convert the job to open a PR with the App token (e.g.

--- a/i18n/ja/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/ja/skills/harden-github-repo-security/SKILL.md
@@ -186,6 +186,8 @@ GitHub Apps), permission Repository > Contents: Read and write; install it
 on THIS repo. Store the App id as a repo variable and the private key as an
 Actions secret. In the workflow, mint a token and pass it to checkout + the
 commit action:
+
+```yaml
   - uses: actions/create-github-app-token@<sha>   # v2
     id: app-token
     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
@@ -193,9 +195,10 @@ commit action:
     with: { token: ${{ steps.app-token.outputs.token }} }
   - uses: stefanzweifel/git-auto-commit-action@<sha>
     with: { ... }   # inherits the app token via the checkout credentials
+```
 
 The numeric App id used in Step 3b is shown on the App's own page:
-Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+Settings > Developer settings > GitHub Apps > `<your app>` > About ("App ID").
 It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Higher-assurance alternative (no standing bypass actor).** If a manual merge

--- a/i18n/ja/skills/prepare-print-model/SKILL.md
+++ b/i18n/ja/skills/prepare-print-model/SKILL.md
@@ -53,16 +53,14 @@ Export and optimize 3D models for additive manufacturing. This skill covers the 
 Export the 3D model in a suitable format for printing:
 
 **For FDM/SLA**:
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 **期待結果:** Model file exported with appropriate resolution (0.1mm chord tolerance for mechanical parts, 0.05mm for organic shapes).
 
@@ -129,16 +127,14 @@ Verify minimum wall thickness for chosen process:
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 **期待結果:** All walls meet minimum thickness for chosen process. Thin walls flagged for review.
 
@@ -210,15 +206,13 @@ Configure automatic or manual supports for overhangs:
 - Reduces surface marks
 - Slightly easier removal
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 **期待結果:** Supports generated for all overhangs exceeding threshold angle, preview shows no floating geometry.
 
@@ -274,17 +268,15 @@ retract_speed: 150-180mm/min
 
 Inspect sliced G-code for issues:
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **Red flags in preview**:
 - **White gaps in solid regions**: Walls too thin for current line width

--- a/i18n/ja/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/ja/skills/rotate-scraping-proxies/SKILL.md
@@ -71,16 +71,15 @@ metadata:
 ワークフロー全体を、文書化された法的・倫理的レビューの通過を条件として
 ゲートします。この手順を飛ばすことが、害の最大の発生源です。
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+コードを書き始める前に確認すべき入力:
+
+1. データは公開されているか（ログイン不要か）？
+2. robots.txt は該当パスを許可しているか？
+3. サイトの ToS は自動アクセスを禁止していないか？（実際に読む）
+4. 処理対象に個人データは含まれるか？ 含まれる場合、法的根拠は何か？
+5. このアクセスは地理ライセンス、有料コンテンツ、認証の回避になり得るか？
+6. スクレイピング不要にできる公開 API やデータダンプは存在しないか？
+7. 範囲が大きい場合、サイト運営者に連絡したか？
 
 **Expected:** すべての質問に、説明可能な書面での回答が揃っている。最初に
 「いいえ」または「不明」が出た時点で、解決するまで手順を停止する。

--- a/i18n/ja/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/ja/skills/troubleshoot-print-issues/SKILL.md
@@ -292,7 +292,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 **期待結果:** Consistent extrusion with no gaps in perimeters or infill.
 

--- a/i18n/ja/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/ja/skills/troubleshoot-print-issues/SKILL.md
@@ -156,25 +156,23 @@ Implement immediate solutions for common issues:
 ### Poor Bed Adhesion
 
 **Immediate fixes**:
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **Slicer settings**:
 - First layer height: 0.2-0.3mm (thicker = better squish)
@@ -218,20 +216,18 @@ retraction_speed: 40-60mm/s
 ### Layer Shifts
 
 **Mechanical checks**:
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **Speed reduction**:
 ```yaml
@@ -277,30 +273,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Under-Extrusion
 
 **Quick fixes**:
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **E-steps calibration**:
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 **期待結果:** Consistent extrusion with no gaps in perimeters or infill.
 
@@ -320,13 +312,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **Dimensional accuracy test**:
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 **期待結果:** Accurate dimensions, smooth surfaces, no bulging.
 

--- a/i18n/wenyan-lite/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/wenyan-lite/skills/audit-dependency-versions/SKILL.md
@@ -199,11 +199,9 @@ cargo search serde --limit 1
 執行生態對應之安全審計工具：
 
 **R：**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js：**
 ```bash

--- a/i18n/wenyan-lite/skills/evolve-skill/SKILL.md
+++ b/i18n/wenyan-lite/skills/evolve-skill/SKILL.md
@@ -121,14 +121,12 @@ grep -oP '`[\w-]+`' skills/<skill-name>/SKILL.md | sort -u
 
 直接編既有 SKILL.md：
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- Open for editing
+- Add/revise procedure steps
+- Strengthen Expected/On failure pairs
+- Add tables or examples
+- Update When to Use triggers
+- Revise Inputs if scope changed
 
 遵此編輯規：
 - 保所有既有節——加內容，勿移節

--- a/i18n/wenyan-lite/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/wenyan-lite/skills/fit-drift-diffusion-model/SKILL.md
@@ -296,7 +296,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. 於 Bayesian 模型，用 DIC 或 WAIC：
 

--- a/i18n/wenyan-lite/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/wenyan-lite/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,13 +291,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. 以標準指南釋 BIC 差：
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. 於 Bayesian 模型，用 DIC 或 WAIC：
 

--- a/i18n/wenyan-lite/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/wenyan-lite/skills/generate-workflow-diagram/SKILL.md
@@ -84,23 +84,24 @@ workflow <- put_merge("./src/", merge_strategy = "supplement")
 
 擇合目標讀者之主題。
 
+列所有可用主題:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+標準主題
+- "light"   — 預設，明色
+- "dark"    — 暗模式環境
+- "auto"    — GitHub 自適應實色
+- "minimal" — 灰階，宜列印
+- "github"  — 為 GitHub README 優化
+
+色盲安全主題（viridis 家族）
+- "viridis" — 紫→藍→綠→黃，通用可及性
+- "magma"   — 紫→紅→黃，列印高對比
+- "plasma"  — 紫→粉→橙→黃，簡報
+- "cividis" — 藍→灰→黃，最大可及性（無紅綠）
 
 附加參數：
 - `direction`：圖流向——`"TD"`（上下，預設）、`"LR"`（左右）、`"RL"`、`"BT"`

--- a/i18n/wenyan-lite/skills/prepare-print-model/SKILL.md
+++ b/i18n/wenyan-lite/skills/prepare-print-model/SKILL.md
@@ -53,16 +53,14 @@ metadata:
 以適合列印之格式匯出 3D 模型：
 
 **FDM/SLA 用**：
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 **預期：** 以適切解析度匯出之模型檔（機械件用 0.1mm 弦容差，有機形用 0.05mm）。
 
@@ -129,16 +127,14 @@ meshlab model.stl
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 **預期：** 各壁皆達所擇製程之最小厚。薄壁標記以便檢視。
 
@@ -210,15 +206,13 @@ If part experiences:
 - 減少表面痕
 - 略易拆
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 **預期：** 已為超出門檻之懸垂生成支撐，預覽顯示無浮空幾何。
 
@@ -274,17 +268,15 @@ retract_speed: 150-180mm/min
 
 檢視切片之 G-code：
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **預覽中之警訊**：
 - **實體區出現白色縫隙**：壁過薄不及當前線寬

--- a/i18n/wenyan-lite/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/wenyan-lite/skills/rotate-scraping-proxies/SKILL.md
@@ -53,16 +53,15 @@ metadata:
 
 整個流程以書面合法與倫理審查為閘。跳此步乃單一最大傷害源。
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Inputs to confirm before writing any code:
+
+1. Is the data public (no login required)?
+2. Does robots.txt permit the path?
+3. Does the site's ToS prohibit automated access? (read it)
+4. Would the scraping process personal data? If yes, what is the legal basis?
+5. Could this access circumvent geo-licensing, paywalls, or auth?
+6. Is there a public API or data dump that would make scraping unnecessary?
+7. Have you contacted the site owner if scope is large?
 
 **預期：** 每問皆有可辯護之書面答覆。首見「否」或「不知」即停止流程，待解決後再續。
 

--- a/i18n/wenyan-lite/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/wenyan-lite/skills/troubleshoot-print-issues/SKILL.md
@@ -292,7 +292,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 **預期：** 一致擠出,牆面或填充無縫隙。
 

--- a/i18n/wenyan-lite/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/wenyan-lite/skills/troubleshoot-print-issues/SKILL.md
@@ -156,25 +156,23 @@ Root cause: Material choice (ABS) incompatible with open printer in drafty room
 ### 底床附著不良
 
 **立即修復**：
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **切片器設定**：
 - 首層高度：0.2-0.3mm（較厚 = 較佳擠壓）
@@ -218,20 +216,18 @@ retraction_speed: 40-60mm/s
 ### 層位偏移
 
 **機械檢查**：
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **降速**：
 ```yaml
@@ -277,30 +273,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### 欠擠出
 
 **快速修復**：
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **E-steps 校準**：
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 **預期：** 一致擠出,牆面或填充無縫隙。
 
@@ -320,13 +312,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **尺寸精度測試**：
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 **預期：** 尺寸精準、表面光滑、無凸出。
 

--- a/i18n/wenyan-ultra/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/wenyan-ultra/skills/audit-dependency-versions/SKILL.md
@@ -199,11 +199,9 @@ cargo search serde --limit 1
 依生態行險審工具：
 
 **R：**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js：**
 ```bash

--- a/i18n/wenyan-ultra/skills/evolve-skill/SKILL.md
+++ b/i18n/wenyan-ultra/skills/evolve-skill/SKILL.md
@@ -121,14 +121,12 @@ grep -oP '`[\w-]+`' skills/<skill-name>/SKILL.md | sort -u
 
 直編舊 SKILL.md：
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- Open for editing
+- Add/revise procedure steps
+- Strengthen Expected/On failure pairs
+- Add tables or examples
+- Update When to Use triggers
+- Revise Inputs if scope changed
 
 循此編則：
 - 保諸節——加容，勿去節

--- a/i18n/wenyan-ultra/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/wenyan-ultra/skills/fit-drift-diffusion-model/SKILL.md
@@ -296,7 +296,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. 貝葉模用 DIC 或 WAIC：
 

--- a/i18n/wenyan-ultra/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/wenyan-ultra/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,13 +291,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. 以標引釋 BIC 差：
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. 貝葉模用 DIC 或 WAIC：
 

--- a/i18n/wenyan-ultra/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/wenyan-ultra/skills/generate-workflow-diagram/SKILL.md
@@ -84,23 +84,24 @@ workflow <- put_merge("./src/", merge_strategy = "supplement")
 
 依目標受眾擇題。
 
+List all available themes:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standard themes
+- "light"   — Default, bright colors
+- "dark"    — For dark mode environments
+- "auto"    — GitHub-adaptive with solid colors
+- "minimal" — Grayscale, print-friendly
+- "github"  — Optimized for GitHub README files
+
+Colorblind-safe themes (viridis family)
+- "viridis" — Purple→Blue→Green→Yellow, general accessibility
+- "magma"   — Purple→Red→Yellow, high contrast for print
+- "plasma"  — Purple→Pink→Orange→Yellow, presentations
+- "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 
 他參：
 - `direction`：圖向——`"TD"`（上下，默）、`"LR"`（左右）、`"RL"`、`"BT"`

--- a/i18n/wenyan-ultra/skills/prepare-print-model/SKILL.md
+++ b/i18n/wenyan-ultra/skills/prepare-print-model/SKILL.md
@@ -53,16 +53,14 @@ metadata:
 出 3D 模於合印之式：
 
 **FDM/SLA**：
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 得：模出含合解（機件 0.1mm 弦差、有機 0.05mm）。
 
@@ -129,16 +127,14 @@ meshlab model.stl
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 得：諸壁達擇程之最小。薄壁標察。
 
@@ -210,15 +206,13 @@ If part experiences:
 - 減面痕
 - 略易除
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 得：支生於諸過限懸、覽無浮幾何。
 
@@ -274,17 +268,15 @@ retract_speed: 150-180mm/min
 
 察切 G-code 為事：
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **覽紅旗**：
 - **實區白缺**：壁過薄於今線寬

--- a/i18n/wenyan-ultra/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/wenyan-ultra/skills/rotate-scraping-proxies/SKILL.md
@@ -53,16 +53,15 @@ metadata:
 
 文錄之法倫察為閘。略此為害源。
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Inputs to confirm before writing any code:
+
+1. Is the data public (no login required)?
+2. Does robots.txt permit the path?
+3. Does the site's ToS prohibit automated access? (read it)
+4. Would the scraping process personal data? If yes, what is the legal basis?
+5. Could this access circumvent geo-licensing, paywalls, or auth?
+6. Is there a public API or data dump that would make scraping unnecessary?
+7. Have you contacted the site owner if scope is large?
 
 得：諸問皆有可辯之答。首「否」/「未知」即停。
 

--- a/i18n/wenyan-ultra/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/wenyan-ultra/skills/troubleshoot-print-issues/SKILL.md
@@ -290,7 +290,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 得：擠均、壁與填無隙。
 

--- a/i18n/wenyan-ultra/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/wenyan-ultra/skills/troubleshoot-print-issues/SKILL.md
@@ -154,25 +154,23 @@ Root cause: Material choice (ABS) incompatible with open printer in drafty room
 #### 黏床差
 
 **速修**：
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **切片設**：
 - 首層高：0.2-0.3mm（厚→壓佳）
@@ -216,20 +214,18 @@ retraction_speed: 40-60mm/s
 #### 層移
 
 **機察**：
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **降速**：
 ```yaml
@@ -275,30 +271,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 #### 欠擠
 
 **速修**：
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **E-steps 校**：
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 得：擠均、壁與填無隙。
 
@@ -318,13 +310,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **尺驗**：
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 得：尺準、表平、無凸。
 

--- a/i18n/wenyan/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/wenyan/skills/audit-dependency-versions/SKILL.md
@@ -199,11 +199,9 @@ cargo search serde --limit 1
 行生態專用之安審之器：
 
 **R:**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js:**
 ```bash

--- a/i18n/wenyan/skills/evolve-skill/SKILL.md
+++ b/i18n/wenyan/skills/evolve-skill/SKILL.md
@@ -121,14 +121,12 @@ grep -oP '`[\w-]+`' skills/<skill-name>/SKILL.md | sort -u
 
 直編 SKILL.md：
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- Open for editing
+- Add/revise procedure steps
+- Strengthen Expected/On failure pairs
+- Add tables or examples
+- Update When to Use triggers
+- Revise Inputs if scope changed
 
 循此編則：
 - 保諸有節——加容，勿去節

--- a/i18n/wenyan/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/wenyan/skills/fit-drift-diffusion-model/SKILL.md
@@ -296,7 +296,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. 貝葉斯模用 DIC 或 WAIC：
 

--- a/i18n/wenyan/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/wenyan/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,13 +291,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. 以標則釋 BIC 差：
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. 貝葉斯模用 DIC 或 WAIC：
 

--- a/i18n/wenyan/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/wenyan/skills/generate-workflow-diagram/SKILL.md
@@ -84,23 +84,24 @@ workflow <- put_merge("./src/", merge_strategy = "supplement")
 
 擇合目標眾之主題。
 
+List all available themes:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standard themes
+- "light"   — Default, bright colors
+- "dark"    — For dark mode environments
+- "auto"    — GitHub-adaptive with solid colors
+- "minimal" — Grayscale, print-friendly
+- "github"  — Optimized for GitHub README files
+
+Colorblind-safe themes (viridis family)
+- "viridis" — Purple→Blue→Green→Yellow, general accessibility
+- "magma"   — Purple→Red→Yellow, high contrast for print
+- "plasma"  — Purple→Pink→Orange→Yellow, presentations
+- "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 
 附加參數：
 - `direction`：圖流向——`"TD"`（上下，默）、`"LR"`（左右）、`"RL"`、`"BT"`

--- a/i18n/wenyan/skills/prepare-print-model/SKILL.md
+++ b/i18n/wenyan/skills/prepare-print-model/SKILL.md
@@ -49,16 +49,14 @@ metadata:
 匯出 3D 模型以宜印之格：
 
 **為 FDM/SLA**：
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 得：模型文件以宜解析匯（機械部 0.1mm 弦容差，有機形 0.05mm）。
 
@@ -125,16 +123,14 @@ meshlab model.stl
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 得：諸壁達所擇程之最小厚。薄壁標待察。
 
@@ -206,15 +202,13 @@ If part experiences:
 - 減表面痕
 - 略易除
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 得：支生於諸逾閾角之懸，預覽示無浮幾何。
 
@@ -270,17 +264,15 @@ retract_speed: 150-180mm/min
 
 察切之 G-code 問題：
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **預覽之紅旗**：
 - **實區之白缺**：壁過薄於當前線寬

--- a/i18n/wenyan/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/wenyan/skills/rotate-scraping-proxies/SKILL.md
@@ -53,16 +53,15 @@ metadata:
 
 全程繫於書面之法德審。略此者，害之最大源也。
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Inputs to confirm before writing any code:
+
+1. Is the data public (no login required)?
+2. Does robots.txt permit the path?
+3. Does the site's ToS prohibit automated access? (read it)
+4. Would the scraping process personal data? If yes, what is the legal basis?
+5. Could this access circumvent geo-licensing, paywalls, or auth?
+6. Is there a public API or data dump that would make scraping unnecessary?
+7. Have you contacted the site owner if scope is large?
 
 得：每問皆有可辯之書答。一遇「否」或「未知」則止，俟其解。
 

--- a/i18n/wenyan/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/wenyan/skills/troubleshoot-print-issues/SKILL.md
@@ -292,7 +292,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 得：出料一致，周或填無隙。
 

--- a/i18n/wenyan/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/wenyan/skills/troubleshoot-print-issues/SKILL.md
@@ -156,25 +156,23 @@ Root cause: Material choice (ABS) incompatible with open printer in drafty room
 ### 床附不良
 
 **即修**：
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **切片設**：
 - 首層高：0.2-0.3mm（厚則擠佳）
@@ -218,20 +216,18 @@ retraction_speed: 40-60mm/s
 ### 層偏
 
 **機械之察**：
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **減速**：
 ```yaml
@@ -277,30 +273,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### 出料不足
 
 **速修**：
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **E-steps 校**：
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 得：出料一致，周或填無隙。
 
@@ -320,13 +312,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **度量校**：
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 得：度量正、面滑、無凸。
 

--- a/i18n/zh-CN/skills/audit-dependency-versions/SKILL.md
+++ b/i18n/zh-CN/skills/audit-dependency-versions/SKILL.md
@@ -196,11 +196,9 @@ cargo search serde --limit 1
 运行生态系统特定的安全审计工具：
 
 **R：**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js：**
 ```bash

--- a/i18n/zh-CN/skills/evolve-skill/SKILL.md
+++ b/i18n/zh-CN/skills/evolve-skill/SKILL.md
@@ -118,14 +118,12 @@ grep -oP '`[\w-]+`' skills/<skill-name>/SKILL.md | sort -u
 
 直接编辑现有 SKILL.md：
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- 打开编辑
+- 添加/修改步骤
+- 强化 Expected/On failure 对
+- 添加表格或示例
+- 更新 When to Use 触发条件
+- 若范围改变则修改 Inputs
 
 遵循以下编辑规则：
 - 保留所有现有章节——添加内容，不删除章节

--- a/i18n/zh-CN/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/zh-CN/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,13 +291,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. Interpret BIC differences using standard guidelines:
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/zh-CN/skills/fit-drift-diffusion-model/SKILL.md
+++ b/i18n/zh-CN/skills/fit-drift-diffusion-model/SKILL.md
@@ -296,7 +296,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/i18n/zh-CN/skills/generate-workflow-diagram/SKILL.md
+++ b/i18n/zh-CN/skills/generate-workflow-diagram/SKILL.md
@@ -82,23 +82,24 @@ workflow <- put_merge("./src/", merge_strategy = "supplement")
 
 选择适合目标受众的主题。
 
+List all available themes:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standard themes
+- "light"   — Default, bright colors
+- "dark"    — For dark mode environments
+- "auto"    — GitHub-adaptive with solid colors
+- "minimal" — Grayscale, print-friendly
+- "github"  — Optimized for GitHub README files
+
+Colorblind-safe themes (viridis family)
+- "viridis" — Purple→Blue→Green→Yellow, general accessibility
+- "magma"   — Purple→Red→Yellow, high contrast for print
+- "plasma"  — Purple→Pink→Orange→Yellow, presentations
+- "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 
 其他参数：
 - `direction`：图表流向——`"TD"`（自上而下，默认）、`"LR"`（从左到右）、`"RL"`、`"BT"`

--- a/i18n/zh-CN/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/zh-CN/skills/harden-github-repo-security/SKILL.md
@@ -181,24 +181,22 @@ Recommended: a GitHub App installation token. (Deploy key is a narrower
 single-repo alternative: add an SSH deploy key with write access and use
 `actor_type: DeployKey` in 3b.)
 
-```bash
-# Create a GitHub App (personal account, Settings > Developer settings >
-# GitHub Apps), permission Repository > Contents: Read and write; install it
-# on THIS repo. Store the App id as a repo variable and the private key as an
-# Actions secret. In the workflow, mint a token and pass it to checkout + the
-# commit action:
-#   - uses: actions/create-github-app-token@<sha>   # v2
-#     id: app-token
-#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
-#   - uses: actions/checkout@<sha>
-#     with: { token: ${{ steps.app-token.outputs.token }} }
-#   - uses: stefanzweifel/git-auto-commit-action@<sha>
-#     with: { ... }   # inherits the app token via the checkout credentials
-#
-# The numeric App id used in Step 3b is shown on the App's own page:
-# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
-# It is unrelated to the repository id and cannot be derived from /repos/$R.
-```
+Create a GitHub App (personal account, Settings > Developer settings >
+GitHub Apps), permission Repository > Contents: Read and write; install it
+on THIS repo. Store the App id as a repo variable and the private key as an
+Actions secret. In the workflow, mint a token and pass it to checkout + the
+commit action:
+  - uses: actions/create-github-app-token@<sha>   # v2
+    id: app-token
+    with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+  - uses: actions/checkout@<sha>
+    with: { token: ${{ steps.app-token.outputs.token }} }
+  - uses: stefanzweifel/git-auto-commit-action@<sha>
+    with: { ... }   # inherits the app token via the checkout credentials
+
+The numeric App id used in Step 3b is shown on the App's own page:
+Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Higher-assurance alternative (no standing bypass actor).** If a manual merge
 click is acceptable, convert the job to open a PR with the App token (e.g.

--- a/i18n/zh-CN/skills/harden-github-repo-security/SKILL.md
+++ b/i18n/zh-CN/skills/harden-github-repo-security/SKILL.md
@@ -186,6 +186,8 @@ GitHub Apps), permission Repository > Contents: Read and write; install it
 on THIS repo. Store the App id as a repo variable and the private key as an
 Actions secret. In the workflow, mint a token and pass it to checkout + the
 commit action:
+
+```yaml
   - uses: actions/create-github-app-token@<sha>   # v2
     id: app-token
     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
@@ -193,9 +195,10 @@ commit action:
     with: { token: ${{ steps.app-token.outputs.token }} }
   - uses: stefanzweifel/git-auto-commit-action@<sha>
     with: { ... }   # inherits the app token via the checkout credentials
+```
 
 The numeric App id used in Step 3b is shown on the App's own page:
-Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+Settings > Developer settings > GitHub Apps > `<your app>` > About ("App ID").
 It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Higher-assurance alternative (no standing bypass actor).** If a manual merge

--- a/i18n/zh-CN/skills/prepare-print-model/SKILL.md
+++ b/i18n/zh-CN/skills/prepare-print-model/SKILL.md
@@ -53,16 +53,14 @@ Export and optimize 3D models for additive manufacturing. This skill covers the 
 Export the 3D model in a suitable format for printing:
 
 **For FDM/SLA**:
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 **预期结果：** Model file exported with appropriate resolution (0.1mm chord tolerance for mechanical parts, 0.05mm for organic shapes).
 
@@ -129,16 +127,14 @@ Verify minimum wall thickness for chosen process:
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 **预期结果：** All walls meet minimum thickness for chosen process. Thin walls flagged for review.
 
@@ -210,15 +206,13 @@ Configure automatic or manual supports for overhangs:
 - Reduces surface marks
 - Slightly easier removal
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 **预期结果：** Supports generated for all overhangs exceeding threshold angle, preview shows no floating geometry.
 
@@ -274,17 +268,15 @@ retract_speed: 150-180mm/min
 
 Inspect sliced G-code for issues:
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **Red flags in preview**:
 - **White gaps in solid regions**: Walls too thin for current line width

--- a/i18n/zh-CN/skills/rotate-scraping-proxies/SKILL.md
+++ b/i18n/zh-CN/skills/rotate-scraping-proxies/SKILL.md
@@ -59,16 +59,15 @@ metadata:
 整个工作流的闸门是一份有书面记录的法律与伦理审查。跳过这一步是最大的危害
 来源。
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Inputs to confirm before writing any code:
+
+1. 数据是否公开（无需登录）？
+2. robots.txt 是否允许访问该路径？
+3. 站点的服务条款是否禁止自动化访问？（请通读）
+4. 抓取过程是否会处理个人数据？如果会，法律依据是什么？
+5. 此次访问是否会绕过地域授权、付费墙或身份认证？
+6. 是否存在公开 API 或数据转储，使抓取变得不必要？
+7. 如果范围较大，是否已与站点所有者联系？
 
 **Expected:** 每个问题都有可辩护的书面答案。出现第一个"否"或"未知"
 即停止流程，直到问题得到解决。

--- a/i18n/zh-CN/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/zh-CN/skills/troubleshoot-print-issues/SKILL.md
@@ -292,7 +292,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 **预期结果：** Consistent extrusion with no gaps in perimeters or infill.
 

--- a/i18n/zh-CN/skills/troubleshoot-print-issues/SKILL.md
+++ b/i18n/zh-CN/skills/troubleshoot-print-issues/SKILL.md
@@ -156,25 +156,23 @@ Implement immediate solutions for common issues:
 ### Poor Bed Adhesion
 
 **Immediate fixes**:
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **Slicer settings**:
 - First layer height: 0.2-0.3mm (thicker = better squish)
@@ -218,20 +216,18 @@ retraction_speed: 40-60mm/s
 ### Layer Shifts
 
 **Mechanical checks**:
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **Speed reduction**:
 ```yaml
@@ -277,30 +273,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Under-Extrusion
 
 **Quick fixes**:
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **E-steps calibration**:
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 **预期结果：** Consistent extrusion with no gaps in perimeters or infill.
 
@@ -320,13 +312,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **Dimensional accuracy test**:
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 **预期结果：** Accurate dimensions, smooth surfaces, no bulging.
 

--- a/skills/audit-dependency-versions/SKILL.md
+++ b/skills/audit-dependency-versions/SKILL.md
@@ -194,11 +194,9 @@ Color coding:
 Run ecosystem-specific security audit tools:
 
 **R:**
-```r
-# No built-in audit tool; check manually
-# Cross-reference with https://www.r-project.org/security.html
-# Check GitHub advisories for each package
-```
+- No built-in audit tool; check manually
+- Cross-reference with https://www.r-project.org/security.html
+- Check GitHub advisories for each package
 
 **Node.js:**
 ```bash

--- a/skills/evolve-skill/SKILL.md
+++ b/skills/evolve-skill/SKILL.md
@@ -116,14 +116,12 @@ Use this decision matrix to determine whether to refine in-place or create a var
 
 Edit the existing SKILL.md directly:
 
-```bash
-# Open for editing
-# Add/revise procedure steps
-# Strengthen Expected/On failure pairs
-# Add tables or examples
-# Update When to Use triggers
-# Revise Inputs if scope changed
-```
+- Open for editing
+- Add/revise procedure steps
+- Strengthen Expected/On failure pairs
+- Add tables or examples
+- Update When to Use triggers
+- Revise Inputs if scope changed
 
 Follow these editing rules:
 - Preserve all existing sections — add content, don't remove sections

--- a/skills/fit-drift-diffusion-model/SKILL.md
+++ b/skills/fit-drift-diffusion-model/SKILL.md
@@ -291,7 +291,7 @@ BIC difference interpretation (Kass & Raftery, 1995):
 - 0-2:   Not worth mentioning
 - 2-6:   Positive evidence
 - 6-10:  Strong evidence
-- >10:   Very strong evidence
+- `>10`:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/skills/fit-drift-diffusion-model/SKILL.md
+++ b/skills/fit-drift-diffusion-model/SKILL.md
@@ -286,13 +286,12 @@ for name, result in sorted(model_results.items(), key=lambda x: x[1]["bic"]):
 
 3. Interpret BIC differences using standard guidelines:
 
-```python
-# BIC difference interpretation (Kass & Raftery, 1995):
-# 0-2:   Not worth mentioning
-# 2-6:   Positive evidence
-# 6-10:  Strong evidence
-# >10:   Very strong evidence
-```
+BIC difference interpretation (Kass & Raftery, 1995):
+
+- 0-2:   Not worth mentioning
+- 2-6:   Positive evidence
+- 6-10:  Strong evidence
+- >10:   Very strong evidence
 
 4. For Bayesian models, use DIC or WAIC:
 

--- a/skills/generate-workflow-diagram/SKILL.md
+++ b/skills/generate-workflow-diagram/SKILL.md
@@ -79,23 +79,24 @@ Each `node_type` also receives a corresponding CSS class (e.g., `class nodeId in
 
 Choose a theme appropriate for the target audience.
 
+List all available themes:
+
 ```r
-# List all available themes
 get_diagram_themes()
-
-# Standard themes
-# "light"   — Default, bright colors
-# "dark"    — For dark mode environments
-# "auto"    — GitHub-adaptive with solid colors
-# "minimal" — Grayscale, print-friendly
-# "github"  — Optimized for GitHub README files
-
-# Colorblind-safe themes (viridis family)
-# "viridis" — Purple→Blue→Green→Yellow, general accessibility
-# "magma"   — Purple→Red→Yellow, high contrast for print
-# "plasma"  — Purple→Pink→Orange→Yellow, presentations
-# "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 ```
+
+Standard themes
+- "light"   — Default, bright colors
+- "dark"    — For dark mode environments
+- "auto"    — GitHub-adaptive with solid colors
+- "minimal" — Grayscale, print-friendly
+- "github"  — Optimized for GitHub README files
+
+Colorblind-safe themes (viridis family)
+- "viridis" — Purple→Blue→Green→Yellow, general accessibility
+- "magma"   — Purple→Red→Yellow, high contrast for print
+- "plasma"  — Purple→Pink→Orange→Yellow, presentations
+- "cividis" — Blue→Gray→Yellow, maximum accessibility (no red-green)
 
 Additional parameters:
 - `direction`: Diagram flow direction — `"TD"` (top-down, default), `"LR"` (left-right), `"RL"`, `"BT"`

--- a/skills/harden-github-repo-security/SKILL.md
+++ b/skills/harden-github-repo-security/SKILL.md
@@ -181,6 +181,8 @@ GitHub Apps), permission Repository > Contents: Read and write; install it
 on THIS repo. Store the App id as a repo variable and the private key as an
 Actions secret. In the workflow, mint a token and pass it to checkout + the
 commit action:
+
+```yaml
   - uses: actions/create-github-app-token@<sha>   # v2
     id: app-token
     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
@@ -188,9 +190,10 @@ commit action:
     with: { token: ${{ steps.app-token.outputs.token }} }
   - uses: stefanzweifel/git-auto-commit-action@<sha>
     with: { ... }   # inherits the app token via the checkout credentials
+```
 
 The numeric App id used in Step 3b is shown on the App's own page:
-Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+Settings > Developer settings > GitHub Apps > `<your app>` > About ("App ID").
 It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Deploy-key alternative (no App to maintain).** Register a write deploy key and

--- a/skills/harden-github-repo-security/SKILL.md
+++ b/skills/harden-github-repo-security/SKILL.md
@@ -176,24 +176,22 @@ Recommended: a GitHub App installation token. (Deploy key is a narrower
 single-repo alternative: add an SSH deploy key with write access and use
 `actor_type: DeployKey` in 3b.)
 
-```bash
-# Create a GitHub App (personal account, Settings > Developer settings >
-# GitHub Apps), permission Repository > Contents: Read and write; install it
-# on THIS repo. Store the App id as a repo variable and the private key as an
-# Actions secret. In the workflow, mint a token and pass it to checkout + the
-# commit action:
-#   - uses: actions/create-github-app-token@<sha>   # v2
-#     id: app-token
-#     with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
-#   - uses: actions/checkout@<sha>
-#     with: { token: ${{ steps.app-token.outputs.token }} }
-#   - uses: stefanzweifel/git-auto-commit-action@<sha>
-#     with: { ... }   # inherits the app token via the checkout credentials
-#
-# The numeric App id used in Step 3b is shown on the App's own page:
-# Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
-# It is unrelated to the repository id and cannot be derived from /repos/$R.
-```
+Create a GitHub App (personal account, Settings > Developer settings >
+GitHub Apps), permission Repository > Contents: Read and write; install it
+on THIS repo. Store the App id as a repo variable and the private key as an
+Actions secret. In the workflow, mint a token and pass it to checkout + the
+commit action:
+  - uses: actions/create-github-app-token@<sha>   # v2
+    id: app-token
+    with: { app-id: ${{ vars.APP_ID }}, private-key: ${{ secrets.APP_KEY }} }
+  - uses: actions/checkout@<sha>
+    with: { token: ${{ steps.app-token.outputs.token }} }
+  - uses: stefanzweifel/git-auto-commit-action@<sha>
+    with: { ... }   # inherits the app token via the checkout credentials
+
+The numeric App id used in Step 3b is shown on the App's own page:
+Settings > Developer settings > GitHub Apps > <your app> > About ("App ID").
+It is unrelated to the repository id and cannot be derived from /repos/$R.
 
 **Deploy-key alternative (no App to maintain).** Register a write deploy key and
 push over SSH; the checkout's `ssh-key` makes `git-auto-commit-action` push as

--- a/skills/prepare-print-model/SKILL.md
+++ b/skills/prepare-print-model/SKILL.md
@@ -48,16 +48,14 @@ Export and optimize 3D models for additive manufacturing. This skill covers the 
 Export the 3D model in a suitable format for printing:
 
 **For FDM/SLA**:
-```bash
-# If starting from CAD (Fusion 360, SolidWorks)
-# Export as: STL (binary) or 3MF
-# Resolution: High (triangle count sufficient for detail)
-# Units: mm (verify scale)
+If starting from CAD (Fusion 360, SolidWorks)
+Export as: STL (binary) or 3MF
+Resolution: High (triangle count sufficient for detail)
+Units: mm (verify scale)
 
-# Example export settings:
-# STL: Binary format, refinement 0.1mm
-# 3MF: Include color/material data if using multi-material printer
-```
+Example export settings:
+STL: Binary format, refinement 0.1mm
+3MF: Include color/material data if using multi-material printer
 
 **Expected:** Model file exported with appropriate resolution (0.1mm chord tolerance for mechanical parts, 0.05mm for organic shapes).
 
@@ -124,16 +122,14 @@ Verify minimum wall thickness for chosen process:
 | SLA (engineering) | 0.6mm | 1.2mm | 2.5mm+ |
 | SLS (nylon) | 0.7mm | 1.0mm | 2.0mm+ |
 
-```bash
-# Check wall thickness visually in slicer:
-# - Import model
-# - Enable "Thin walls" detection
-# - Slice with 0 infill to see wall structure
+Check wall thickness visually in slicer:
+- Import model
+- Enable "Thin walls" detection
+- Slice with 0 infill to see wall structure
 
-# For precise measurement, use CAD software:
-# - Measure distance between parallel surfaces
-# - Check in critical load-bearing areas
-```
+For precise measurement, use CAD software:
+- Measure distance between parallel surfaces
+- Check in critical load-bearing areas
 
 **Expected:** All walls meet minimum thickness for chosen process. Thin walls flagged for review.
 
@@ -206,15 +202,13 @@ Configure automatic or manual supports for overhangs:
 - Reduces surface marks
 - Slightly easier removal
 
-```bash
-# In slicer (PrusaSlicer example):
-# Print Settings → Support material
-# - Generate support material: Yes
-# - Overhang threshold: 45° (FDM) / 30° (SLA)
-# - Pattern: Rectilinear / Tree (auto)
-# - Interface layers: 3
-# - Interface pattern spacing: 0.2mm
-```
+In slicer (PrusaSlicer example):
+Print Settings → Support material
+- Generate support material: Yes
+- Overhang threshold: 45° (FDM) / 30° (SLA)
+- Pattern: Rectilinear / Tree (auto)
+- Interface layers: 3
+- Interface pattern spacing: 0.2mm
 
 **Expected:** Supports generated for all overhangs exceeding threshold angle, preview shows no floating geometry.
 
@@ -270,17 +264,15 @@ retract_speed: 150-180mm/min
 
 Inspect sliced G-code for issues:
 
-```bash
-# In slicer:
-# - Slice model
-# - Use layer preview slider to inspect each layer
-# - Check for:
-#   * Gaps in perimeters (indicates thin walls)
-#   * Floating regions (missing supports)
-#   * Excessive stringing paths (reduce travel)
-#   * First layer: proper squish and adhesion
-#   * Top layers: sufficient solid infill
-```
+In slicer:
+- Slice model
+- Use layer preview slider to inspect each layer
+- Check for:
+  * Gaps in perimeters (indicates thin walls)
+  * Floating regions (missing supports)
+  * Excessive stringing paths (reduce travel)
+  * First layer: proper squish and adhesion
+  * Top layers: sufficient solid infill
 
 **Red flags in preview**:
 - **White gaps in solid regions**: Walls too thin for current line width

--- a/skills/rotate-scraping-proxies/SKILL.md
+++ b/skills/rotate-scraping-proxies/SKILL.md
@@ -58,16 +58,15 @@ fraud / credential stuffing / sneaker bots / content piracy.
 Gate the entire workflow on a documented legal and ethical review. Skipping
 this step is the single biggest source of harm.
 
-```python
-# Inputs to confirm before writing any code:
-# 1. Is the data public (no login required)?
-# 2. Does robots.txt permit the path?
-# 3. Does the site's ToS prohibit automated access? (read it)
-# 4. Would the scraping process personal data? If yes, what is the legal basis?
-# 5. Could this access circumvent geo-licensing, paywalls, or auth?
-# 6. Is there a public API or data dump that would make scraping unnecessary?
-# 7. Have you contacted the site owner if scope is large?
-```
+Confirm all seven before writing any code:
+
+1. Is the data public (no login required)?
+2. Does robots.txt permit the path?
+3. Does the site's ToS prohibit automated access? (read it)
+4. Would the scraping process personal data? If yes, what is the legal basis?
+5. Could this access circumvent geo-licensing, paywalls, or auth?
+6. Is there a public API or data dump that would make scraping unnecessary?
+7. Have you contacted the site owner if scope is large?
 
 **Expected:** Every question has a defensible written answer. The first "no"
 or "unknown" stops the procedure until resolved.

--- a/skills/troubleshoot-print-issues/SKILL.md
+++ b/skills/troubleshoot-print-issues/SKILL.md
@@ -287,7 +287,7 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 2. Extrude 100mm: G1 E100 F100
 3. Measure remaining distance to mark
 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-5. Set: M92 E<new_steps>; M500 (save to EEPROM)
+5. Set: `M92 E<new_steps>`; M500 (save to EEPROM)
 
 **Expected:** Consistent extrusion with no gaps in perimeters or infill.
 

--- a/skills/troubleshoot-print-issues/SKILL.md
+++ b/skills/troubleshoot-print-issues/SKILL.md
@@ -151,25 +151,23 @@ Implement immediate solutions for common issues:
 ### Poor Bed Adhesion
 
 **Immediate fixes**:
-```bash
-# 1. Clean bed thoroughly
-# Glass/PEI: Isopropyl alcohol 90%+
-# BuildTak: Warm water and dish soap
+1. Clean bed thoroughly
+   Glass/PEI: Isopropyl alcohol 90%+
+   BuildTak: Warm water and dish soap
 
-# 2. Level bed (paper test at 4 corners + center)
-# Paper should drag slightly
+2. Level bed (paper test at 4 corners + center)
+   Paper should drag slightly
 
-# 3. Adjust Z-offset down (squish first layer more)
-# Start: -0.05mm increments until lines fuse
+3. Adjust Z-offset down (squish first layer more)
+   Start: -0.05mm increments until lines fuse
 
-# 4. Increase bed temperature +5°C
+4. Increase bed temperature +5°C
 
-# 5. Add adhesion aid:
-# - Glue stick (PLA/PETG)
-# - Hairspray (ABS)
-# - ABS juice (ABS) - ABS dissolved in acetone
-# - Magigoo/3D printing adhesive
-```
+5. Add adhesion aid:
+   - Glue stick (PLA/PETG)
+   - Hairspray (ABS)
+   - ABS juice (ABS) - ABS dissolved in acetone
+   - Magigoo/3D printing adhesive
 
 **Slicer settings**:
 - First layer height: 0.2-0.3mm (thicker = better squish)
@@ -213,20 +211,18 @@ retraction_speed: 40-60mm/s
 ### Layer Shifts
 
 **Mechanical checks**:
-```bash
-# 1. Check belt tension (should twang like guitar string)
-# Tighten if loose
+1. Check belt tension (should twang like guitar string)
+   Tighten if loose
 
-# 2. Check pulley set screws (motor shafts)
-# Must align with flat on motor shaft
+2. Check pulley set screws (motor shafts)
+   Must align with flat on motor shaft
 
-# 3. Check for mechanical resistance
-# Manually move X/Y axes - should glide smoothly
-# Binding indicates dirty rods, worn bearings, or misalignment
+3. Check for mechanical resistance
+   Manually move X/Y axes - should glide smoothly
+   Binding indicates dirty rods, worn bearings, or misalignment
 
-# 4. Check stepper motor current (advanced)
-# Too low → skipping; too high → overheating
-```
+4. Check stepper motor current (advanced)
+   Too low → skipping; too high → overheating
 
 **Speed reduction**:
 ```yaml
@@ -272,30 +268,26 @@ regular_fan: 25% max (ABS), 50% (PETG), 100% (PLA)
 ### Under-Extrusion
 
 **Quick fixes**:
-```bash
-# 1. Check for nozzle clog
-# Heat to print temp, manually push filament
-# Should extrude smoothly
+1. Check for nozzle clog
+   Heat to print temp, manually push filament
+   Should extrude smoothly
 
-# 2. Cold pull cleaning (if partial clog)
-# Heat to 220°C, push cleaning filament through
-# Cool to 90°C, pull sharply - should remove debris
+2. Cold pull cleaning (if partial clog)
+   Heat to 220°C, push cleaning filament through
+   Cool to 90°C, pull sharply - should remove debris
 
-# 3. Increase temperature +5-10°C
-# Higher temp = better flow
+3. Increase temperature +5-10°C
+   Higher temp = better flow
 
-# 4. Increase flow rate 2-5%
-# Slicer: Filament settings → Flow → 102-105%
-```
+4. Increase flow rate 2-5%
+   Slicer: Filament settings → Flow → 102-105%
 
 **E-steps calibration**:
-```bash
-# 1. Mark filament 120mm above extruder
-# 2. Extrude 100mm: G1 E100 F100
-# 3. Measure remaining distance to mark
-# 4. Calculate: new_steps = current_steps × (100 / actual_extruded)
-# 5. Set: M92 E<new_steps>; M500 (save to EEPROM)
-```
+1. Mark filament 120mm above extruder
+2. Extrude 100mm: G1 E100 F100
+3. Measure remaining distance to mark
+4. Calculate: new_steps = current_steps × (100 / actual_extruded)
+5. Set: M92 E<new_steps>; M500 (save to EEPROM)
 
 **Expected:** Consistent extrusion with no gaps in perimeters or infill.
 
@@ -315,13 +307,11 @@ extrusion_multiplier: 0.98 → 0.96 → 0.94
 ```
 
 **Dimensional accuracy test**:
-```bash
-# Print 20mm calibration cube
-# Measure with calipers:
-# X/Y dimensions should be 20.0mm ± 0.1mm
-# If consistently oversized → reduce flow
-# If undersized → increase flow
-```
+Print 20mm calibration cube
+Measure with calipers:
+X/Y dimensions should be 20.0mm ± 0.1mm
+If consistently oversized → reduce flow
+If undersized → increase flow
 
 **Expected:** Accurate dimensions, smooth surfaces, no bulging.
 


### PR DESCRIPTION
The #502 exemplar, plus the triage that issue asks for.

## What was wrong

`skills/rotate-scraping-proxies/SKILL.md` Step 1 held its **entire substance** — seven legality and ethics questions — as `#` comments inside a `python` fence containing no Python.

#472 freezes that fence to English, so #503 correctly restored the English body. The German, Spanish, Japanese and Chinese readers lost the questions, while their own `**Expected:**` line still said *"every question has a defensible written answer"* — referring to seven questions that no longer existed in their language.

The content is GDPR legal basis, ToS compliance and geo-licensing circumvention, in the step the skill itself calls the single biggest source of harm.

## The remedy was already written down

#472 prescribes it: *"if a comment carries the only statement of an instruction, lift it into the step's prose rather than translating it in place."* Nothing had ever done it. This is that lift.

## The translations were still in git

Rather than seed the mirrors with English, this **recovers what the freeze removed**. Every word in the four translated files is the original translator's, taken from `7fc83ef81^` and converted from `# N.` comments to a numbered list.

- **de, es, ja** — lead-in and all seven questions recovered
- **zh-CN** — seven questions recovered; its lead-in was already English pre-restore, so it stays English
- **six compressed tiers** — carried English pre-restore, stay English

German now reads `1. Sind die Daten öffentlich (kein Login erforderlich)?` again, as prose, where the freeze cannot take it back.

## Verified, not assumed

- The loss is real: German question 1 was `# Sind die Daten öffentlich…` before #503 and English at HEAD.
- My **first** check of which locales were recoverable matched only the fence's header line and would have discarded zh-CN as English. Its seven questions were Chinese all along. Redone against the questions.
- English 4 fences → 3; all ten mirrors aligned at 3 in the same tag sequence.
- Parity unchanged at 248 — correct, since these fences carried English and were never violations. What changes is that the content now lives where a translator may localise it.

## Scope corrections for #502 (full triage on the issue)

- The population is **21 distinct English fences across 12 skills**, not 196 — nine of the twelve are one fence mirrored into ten locales.
- Re-derivation gives 186/96, not 196/106. The gap is #502's `json` row: JSON has no comment syntax, so a `//`-commented JSON fence is **invalid JSON** — #507's class, not this one.
- **Four of the 21 must not be lifted.** `annotate-source-files` ×2 and `write-roxygen-docs` ×2 are putior `# put id:…` annotations and `#'` roxygen docblocks — languages where the comment *is* the code. Freezing them is correct; a future sweep should not "fix" them.