### PR TITLE
fix(i18n): repair es/create-glyph, the stale-section Class-B file (#483)

### DIFF
--- a/i18n/caveman-lite/skills/create-glyph/SKILL.md
+++ b/i18n/caveman-lite/skills/create-glyph/SKILL.md
@@ -310,7 +310,7 @@ Make adjustments and re-render.
 
 ### Domain and Entity Color Palettes
 
-All 58 domain colors (for skills) are defined in `viz/R/palettes.R` (the single source of truth). Agent and team colors are also managed in `palettes.R`. The cyberpunk palette (hand-tuned neon colors) is in `get_cyberpunk_colors()`. Viridis-family palettes are auto-generated via `viridisLite`.
+All domain colors (for skills) are defined in `viz/R/palettes.R` (the single source of truth). Agent and team colors are also managed in `palettes.R`. The cyberpunk palette (hand-tuned neon colors) is in `get_cyberpunk_colors()`. Viridis-family palettes are auto-generated via `viridisLite`.
 
 To look up a color:
 ```r

--- a/i18n/caveman-ultra/skills/create-glyph/SKILL.md
+++ b/i18n/caveman-ultra/skills/create-glyph/SKILL.md
@@ -302,7 +302,7 @@ Out:
 
 ### Domain + Entity Palettes
 
-All 58 domain colors (skills) in `viz/R/palettes.R` (single truth). Agent/team colors same. Cyberpunk (hand-tuned neon) in `get_cyberpunk_colors()`. Viridis auto via `viridisLite`.
+All domain colors (skills) in `viz/R/palettes.R` (single truth). Agent/team colors same. Cyberpunk (hand-tuned neon) in `get_cyberpunk_colors()`. Viridis auto via `viridisLite`.
 
 Lookup:
 ```r

--- a/i18n/caveman/skills/create-glyph/SKILL.md
+++ b/i18n/caveman/skills/create-glyph/SKILL.md
@@ -310,7 +310,7 @@ Adjust and re-render.
 
 ### Domain and Entity Color Palettes
 
-All 58 domain colors (for skills) in `viz/R/palettes.R` (single source of truth). Agent and team colors also in `palettes.R`. Cyberpunk palette (hand-tuned neon colors) in `get_cyberpunk_colors()`. Viridis-family palettes auto-generated via `viridisLite`.
+All domain colors (for skills) in `viz/R/palettes.R` (single source of truth). Agent and team colors also in `palettes.R`. Cyberpunk palette (hand-tuned neon colors) in `get_cyberpunk_colors()`. Viridis-family palettes auto-generated via `viridisLite`.
 
 Look up color:
 ```r

--- a/i18n/de/skills/create-glyph/SKILL.md
+++ b/i18n/de/skills/create-glyph/SKILL.md
@@ -334,7 +334,7 @@ get_palette_colors("cyberpunk")$teams[["tending"]]     # team
 Beim Hinzufuegen einer neuen Domaene an drei Stellen in `palettes.R` eintragen:
 1. `PALETTE_DOMAIN_ORDER` (alphabetisch)
 2. `get_cyberpunk_colors()` Domaenenliste
-3. `Rscript generate-palette-colors.R` ausfuehren, um JSON + JS zu regenerieren
+3. `bash viz/build.sh` ausfuehren, um Paletten, Daten und Manifeste zu regenerieren
 
 ### Glyphen-Funktionskatalog
 

--- a/i18n/de/skills/create-glyph/SKILL.md
+++ b/i18n/de/skills/create-glyph/SKILL.md
@@ -321,7 +321,7 @@ Anpassungen vornehmen und erneut rendern.
 
 ### Domaenen- und Entitaetsfarbpaletten
 
-Alle 58 Domaenenfarben (fuer Skills) sind in `viz/R/palettes.R` definiert (die einzige Quelle der Wahrheit). Agent- und Team-Farben werden ebenfalls in `palettes.R` verwaltet. Die Cyberpunk-Palette (handabgestimmte Neonfarben) ist in `get_cyberpunk_colors()`. Viridis-Familienpaletten werden automatisch ueber `viridisLite` generiert.
+Alle Domaenenfarben (fuer Skills) sind in `viz/R/palettes.R` definiert (die einzige Quelle der Wahrheit). Agent- und Team-Farben werden ebenfalls in `palettes.R` verwaltet. Die Cyberpunk-Palette (handabgestimmte Neonfarben) ist in `get_cyberpunk_colors()`. Viridis-Familienpaletten werden automatisch ueber `viridisLite` generiert.
 
 Zum Nachschlagen einer Farbe:
 ```r

--- a/i18n/es/skills/create-glyph/SKILL.md
+++ b/i18n/es/skills/create-glyph/SKILL.md
@@ -324,7 +324,7 @@ get_palette_colors("cyberpunk")$teams[["tending"]]     # team
 Al agregar un nuevo dominio, agregarlo en tres lugares de `palettes.R`:
 1. `PALETTE_DOMAIN_ORDER` (alfabeticamente)
 2. Lista de dominios en `get_cyberpunk_colors()`
-3. Ejecutar `Rscript generate-palette-colors.R` para regenerar JSON + JS
+3. Ejecutar `bash viz/build.sh` para regenerar paletas, datos y manifiestos
 
 ### Catalogo de Funciones de Glyph
 

--- a/i18n/es/skills/create-glyph/SKILL.md
+++ b/i18n/es/skills/create-glyph/SKILL.md
@@ -311,7 +311,7 @@ Realizar ajustes y re-renderizar.
 
 ### Paletas de Color por Dominio y Entidad
 
-Los 58 colores de dominio (para habilidades) estan definidos en `viz/R/palettes.R` (la unica fuente de verdad). Los colores de agentes y equipos tambien se gestionan en `palettes.R`. La paleta cyberpunk (colores neon ajustados manualmente) esta en `get_cyberpunk_colors()`. Las paletas de la familia viridis se generan automaticamente via `viridisLite`.
+Los colores de dominio (para habilidades) estan definidos en `viz/R/palettes.R` (la unica fuente de verdad). Los colores de agentes y equipos tambien se gestionan en `palettes.R`. La paleta cyberpunk (colores neon ajustados manualmente) esta en `get_cyberpunk_colors()`. Las paletas de la familia viridis se generan automaticamente via `viridisLite`.
 
 Para buscar un color:
 ```r

--- a/i18n/es/skills/create-glyph/SKILL.md
+++ b/i18n/es/skills/create-glyph/SKILL.md
@@ -228,31 +228,21 @@ Registrar el icono en el archivo de manifiesto correspondiente.
 
 ### Paso 5: Renderizar — Generar el Icono
 
-Ejecutar el pipeline de construccion para renderizar el WebP.
+Ejecutar el pipeline de iconos para renderizar el nuevo glifo. Usar siempre `build.sh` como punto de entrada — se encarga de la deteccion de plataforma y de la seleccion del binario de R. Ver [render-icon-pipeline](../render-icon-pipeline/SKILL.md) para la referencia completa de opciones y la arquitectura del pipeline.
 
-1. Navegar al directorio `viz/`
-2. Renderizar segun el tipo de entidad:
-
-**Para habilidades:**
 ```bash
-cd viz && Rscript build-icons.R --only <domain>
-# O saltar existentes: Rscript build-icons.R --only <domain> --skip-existing
+# From project root — renders all palettes, standard + HD, skips existing icons
+bash viz/build.sh --only <domain> --skip-existing          # skills
+bash viz/build.sh --type agent --only <id> --skip-existing # agents
+bash viz/build.sh --type team --only <id> --skip-existing  # teams
+
+# Dry run first:
+bash viz/build.sh --only <domain> --dry-run
 ```
 
-**Para agentes:**
-```bash
-cd viz && Rscript build-agent-icons.R --only <agent-id>
-# O saltar existentes: Rscript build-agent-icons.R --only <agent-id> --skip-existing
-```
+`build.sh` ejecuta el pipeline completo (paleta → datos → manifiesto → renderizado → glifos de terminal). Los pasos que no son de renderizado agregan unos 10 segundos, pero garantizan que todos los datos esten actualizados.
 
-**Para equipos:**
-```bash
-cd viz && Rscript build-team-icons.R --only <team-id>
-# O saltar existentes: Rscript build-team-icons.R --only <team-id> --skip-existing
-```
-
-3. Para una ejecucion en seco primero, agregar `--dry-run` a cualquier comando
-4. Ubicaciones de salida:
+Ubicaciones de salida:
    - Habilidades: `viz/public/icons/<palette>/<domain>/<skill-id>.webp`
    - Agentes: `viz/public/icons/<palette>/agents/<agent-id>.webp`
    - Equipos: `viz/public/icons/<palette>/teams/<team-id>.webp`
@@ -272,7 +262,7 @@ Comprobar que la salida renderizada cumple los estandares de calidad.
 1. Verificar que el archivo existe y tiene un tamano razonable:
    ```bash
    ls -la viz/public/icons/cyberpunk/<type-path>/<entity-id>.webp
-   # Esperado: rango tipico de 15-80 KB
+   # Expected: 15-80 KB typical range
    ```
 
 2. Abrir el WebP en un visor de imagenes para comprobar:

--- a/i18n/ja/skills/create-glyph/SKILL.md
+++ b/i18n/ja/skills/create-glyph/SKILL.md
@@ -333,7 +333,7 @@ get_palette_colors("cyberpunk")$teams[["tending"]]     # team
 新しいドメインを追加する場合は、`palettes.R` の3箇所に追加する:
 1. `PALETTE_DOMAIN_ORDER`（アルファベット順）
 2. `get_cyberpunk_colors()` のドメインリスト
-3. `Rscript generate-palette-colors.R` を実行してJSON + JSを再生成する
+3. `bash viz/build.sh` を実行してパレット、データ、マニフェストを再生成する
 
 ### グリフ関数カタログ
 

--- a/i18n/ja/skills/create-glyph/SKILL.md
+++ b/i18n/ja/skills/create-glyph/SKILL.md
@@ -320,7 +320,7 @@ cd viz && Rscript build-team-icons.R --only <team-id>
 
 ### ドメインとエンティティのカラーパレット
 
-全58ドメインのカラー（スキル用）は `viz/R/palettes.R` で定義されている（唯一の信頼できるソース）。エージェントとチームのカラーも `palettes.R` で管理されている。cyberpunkパレット（手動調整されたネオンカラー）は `get_cyberpunk_colors()` に格納されている。viridisファミリーのパレットは `viridisLite` で自動生成される。
+全ドメインのカラー（スキル用）は `viz/R/palettes.R` で定義されている（唯一の信頼できるソース）。エージェントとチームのカラーも `palettes.R` で管理されている。cyberpunkパレット（手動調整されたネオンカラー）は `get_cyberpunk_colors()` に格納されている。viridisファミリーのパレットは `viridisLite` で自動生成される。
 
 カラーを参照するには:
 ```r

--- a/i18n/wenyan-lite/skills/create-glyph/SKILL.md
+++ b/i18n/wenyan-lite/skills/create-glyph/SKILL.md
@@ -310,7 +310,7 @@ bash viz/build.sh --only <domain> --dry-run
 
 ### 領域與實體色板
 
-所有 58 領域色（技能用）於 `viz/R/palettes.R` 定義（單一真源）。代理與團隊之色亦於 `palettes.R` 管。cyberpunk 色板（手調霓虹色）於 `get_cyberpunk_colors()`。viridis 系色板自 `viridisLite` 生。
+所有領域色（技能用）於 `viz/R/palettes.R` 定義（單一真源）。代理與團隊之色亦於 `palettes.R` 管。cyberpunk 色板（手調霓虹色）於 `get_cyberpunk_colors()`。viridis 系色板自 `viridisLite` 生。
 
 查色：
 ```r

--- a/i18n/wenyan-ultra/skills/create-glyph/SKILL.md
+++ b/i18n/wenyan-ultra/skills/create-glyph/SKILL.md
@@ -262,7 +262,7 @@ bash viz/build.sh --only <domain> --dry-run
 
 ### 域與項色盤
 
-58 域色（技）定於 `viz/R/palettes.R`（唯真源）。代與團色亦理於 `palettes.R`。cyberpunk 色盤於 `get_cyberpunk_colors()`。
+域色（技）定於 `viz/R/palettes.R`（唯真源）。代與團色亦理於 `palettes.R`。cyberpunk 色盤於 `get_cyberpunk_colors()`。
 
 ```r
 source("viz/R/palettes.R")

--- a/i18n/wenyan/skills/create-glyph/SKILL.md
+++ b/i18n/wenyan/skills/create-glyph/SKILL.md
@@ -310,7 +310,7 @@ bash viz/build.sh --only <domain> --dry-run
 
 ### 域與實體色譜
 
-諸 58 域色（技用）定於 `viz/R/palettes.R`（單一真源）。行者與團色亦管於 `palettes.R`。賽博朋克譜（手調霓色）於 `get_cyberpunk_colors()`。viridis 族譜以 `viridisLite` 自動生。
+諸域色（技用）定於 `viz/R/palettes.R`（單一真源）。行者與團色亦管於 `palettes.R`。賽博朋克譜（手調霓色）於 `get_cyberpunk_colors()`。viridis 族譜以 `viridisLite` 自動生。
 
 查色：
 ```r

--- a/i18n/zh-CN/skills/create-glyph/SKILL.md
+++ b/i18n/zh-CN/skills/create-glyph/SKILL.md
@@ -317,7 +317,7 @@ cd viz && Rscript build-team-icons.R --only <team-id>
 
 ### 领域与实体调色板
 
-所有 58 个领域颜色（技能用）定义在 `viz/R/palettes.R` 中（唯一的真实数据来源）。代理和团队颜色也在 `palettes.R` 中管理。cyberpunk 调色板（手动调整的霓虹色）在 `get_cyberpunk_colors()` 中。Viridis 系列调色板通过 `viridisLite` 自动生成。
+所有领域颜色（技能用）定义在 `viz/R/palettes.R` 中（唯一的真实数据来源）。代理和团队颜色也在 `palettes.R` 中管理。cyberpunk 调色板（手动调整的霓虹色）在 `get_cyberpunk_colors()` 中。Viridis 系列调色板通过 `viridisLite` 自动生成。
 
 查找颜色：
 ```r

--- a/i18n/zh-CN/skills/create-glyph/SKILL.md
+++ b/i18n/zh-CN/skills/create-glyph/SKILL.md
@@ -330,7 +330,7 @@ get_palette_colors("cyberpunk")$teams[["tending"]]     # team
 添加新领域时，需在 `palettes.R` 的三个位置添加：
 1. `PALETTE_DOMAIN_ORDER`（按字母排序）
 2. `get_cyberpunk_colors()` 领域列表
-3. 运行 `Rscript generate-palette-colors.R` 重新生成 JSON + JS
+3. 运行 `bash viz/build.sh` 重新生成调色板、数据和清单
 
 ### 符号函数目录
 


### PR DESCRIPTION
Eleventh of #483's twelve. #522 did ten; this is the one that needed different surgery.

> **Review corrections** — three defects were found by adversarial review after opening.
> Two are fixed in this branch (`1fbcaf894`, `c81525c8d`), one is filed as #526, and two
> of my own claims below were wrong and are corrected in place. See the comment thread.

## Not a dropped gallery

The anchored insertion that fixed the other ten did not apply. `es/create-glyph` was in
**perfect ordinal parity with an older English revision**: `acc252e6d` ("eliminate bare
Rscript calls and add OS-check pitfalls") collapsed Step 5's three per-entity
`Rscript build-*-icons.R` fences into one consolidated `bash viz/build.sh`, and the
translation still mirrored the shape from before that. Its 17-vs-15 count was English
restructuring, not translator omission.

## The tempting repair was a trap

Each of the four failing fences differed from that older English by **exactly one translated
comment**. De-translating four lines would have turned the checker green — those bodies are
in the English history union the parity gate accepts — while **re-publishing bare `Rscript`
invocations that repo policy bans** (CLAUDE.md *Viz Deploy Model*, the `render-icon-pipeline`
skill, and the standing build.sh rule).

Greening a gate by restoring a forbidden command is a regression, not a fix.

## What was done

Paso 5's body replaced with Spanish prose for the current English step, embedding English
fence 12 verbatim, between the two anchors verified unique — the `### Paso 5` heading and
the `**Esperado:**` line. The `**Para habilidades/agentes/equipos:**` labels and the numbered
`cd viz` workflow are dropped because current English has no counterpart. Prose follows this
file's own accent-stripped convention. The last divergent fence, a one-line comment, is
restored from English fence 13 at the same ordinal.

| | before | after |
|---|---:|---:|
| fences (es / en) | 17 / 15 | **15 / 15**, same tag sequence |
| violations in this file | 4 | **0** |
| gate total | 248 | **244** |

Normalizer-reachable for the first time.

> The commit message for `2a218c04a` states this as "248 -> 245". That number is wrong; the
> measured value is 244, as above.

## Two follow-up commits, from review

`acc252e6d` has **two** hunks and only the first was absorbed here, so the file still
published `Rscript generate-palette-colors.R`. My verification could not have caught it:
`rg 'Rscript build-.*-icons\.R'` is scoped to one of the two banned binaries and returns
zero regardless. Fixed in all four full locales — de, ja and zh-CN carried the same line.

Separately, English dropped a hardcoded "58 domain colors" in `bcfb73ae5`; the real count is
66 and all ten locales still published 58. Also fixed.

Both are prose, so no fence gate covers them. The fenced half of the same drift — eighteen
banned `Rscript` calls still frozen inside de/ja/zh-CN Step 5, over which the checker reports
**OK** — is filed as **#526**.

## No `source_commit` bump

The field asserts *"this file reflects English at that commit"*, and after this PR it still
does not: Step 5 is absorbed, the rest of the file is not. Bumping it would make a
true-sounding claim that is false — #405's actual shape.

> An earlier version of this description said `validate:translations` read the file as
> **fresh**. That was wrong. It reports `STALE: i18n/es/skills/create-glyph/SKILL.md
> (translated at 33b561c9, source now at bcfb73ae5)`, and always has. The tool was never
> fooled; only my description of it was.

## The twelfth is a reclassification, not a repair

`es/configure-mcp-server` fails #483's own admission test — `metadata.tags` not
byte-identical (`r-mcptools` for `mcptools`), `complexity` `basic` vs `intermediate`, 4 steps
vs 6, two Related Skills in no English revision, two fences invented. Its de/ja/zh-CN
siblings are all 100% faithful, so it is one locale diverging — the #478 pattern. Recorded on
#478 and #483; its remedy is that issue's delete-and-re-scaffold, which #482's harvest must
precede.