### PR TITLE
feat(citations): document CSL style internals and the CSL/BibLaTeX trap (#482)

### DIFF
--- a/skills/format-citations/SKILL.md
+++ b/skills/format-citations/SKILL.md
@@ -134,25 +134,33 @@ download_csl("apa")
 
 A downloaded style is rarely the last word — journals routinely deviate from the
 canonical style in small ways, and the fix is to edit the `.csl` file rather than to
-post-process the rendered output. A CSL style is XML with `cs:style` as its root
-element, and four parts account for nearly every journal-specific tweak:
+post-process the rendered output.
 
-- **Where the two formats live.** `cs:citation` is required and appears exactly once;
-  it controls the in-text citation or footnote. `cs:bibliography` is optional and
+A CSL style is XML rooted in a `<style>` element that declares the CSL namespace as
+its default (`xmlns="http://purl.org/net/xbiblio/csl"`). Elements inside the file are
+therefore written **unprefixed** — `<citation>`, `<bibliography>`, `<sort>`. The CSL
+specification names the same elements as `cs:style`, `cs:citation` and so on; that
+prefix is the spec's notation for talking about them, not text you will find in
+`apa.csl`. Searching a downloaded style for `<cs:citation>` returns nothing.
+
+Four parts account for nearly every journal-specific tweak:
+
+- **Where the two formats live.** `<citation>` is required and appears exactly once;
+  it controls the in-text citation or footnote. `<bibliography>` is optional and
   controls the reference list. Changing how a citation looks in the text and changing
   how it looks in the reference list are edits to *different* elements — this is the
   most common source of "I changed it and nothing happened".
-- **Sort order.** Both `cs:citation` and `cs:bibliography` may carry a `cs:sort` child,
-  which must appear *before* `cs:layout` and must contain one or more `cs:key`
+- **Sort order.** Both `<citation>` and `<bibliography>` may carry a `<sort>` child,
+  which must appear *before* `<layout>` and must contain one or more `<key>`
   elements. This is what switches a bibliography between author-alphabetical,
   by-year, and citation-order.
 - **"et al." thresholds.** `et-al-min` and `et-al-use-first` together enable et-al
   abbreviation: once the author count reaches `et-al-min`, the list truncates after
-  `et-al-use-first` names. Set them on `cs:name`, or inherit them from `cs:style`,
-  `cs:citation`, or `cs:bibliography`.
-- **Localization.** Set the `default-locale` attribute on the root `cs:style` element
+  `et-al-use-first` names. Set them on `<name>`, or inherit them from `<style>`,
+  `<citation>`, or `<bibliography>`.
+- **Localization.** Set the `default-locale` attribute on the root `<style>` element
   to translate style-generated terms ("and", "et al.", "eds."). The attribute is
-  `default-locale` — a bare `locale` attribute belongs on `cs:locale` elements and
+  `default-locale` — a bare `locale` attribute belongs on `<locale>` elements and
   will not do this.
 
 Validate any edited style at <https://validator.citationstyles.org/>, which checks a
@@ -164,8 +172,8 @@ edits validate cleanly against the CSL schema.
 
 **On failure:** Check network connectivity. The CSL GitHub repository contains 10,000+
 styles. For offline use, bundle required CSL files in the project. If an edited style
-fails validation, the validator names the line — the usual causes are a `cs:sort`
-placed after `cs:layout` rather than before it, and a misspelled attribute, which the
+fails validation, the validator names the line — the usual causes are a `<sort>`
+placed after `<layout>` rather than before it, and a misspelled attribute, which the
 schema rejects rather than ignores.
 
 ### Step 4: Write In-Text Citations
@@ -326,11 +334,14 @@ Refine the regex or manually review flagged keys.
   Pandoc. Always use CSL 1.0+ from the official repository
 - **Quarto vs R Markdown differences**: Quarto uses `cite-method: citeproc` by
   default; R Markdown may need explicit `pandoc_args: ["--citeproc"]`
-- **Confusing CSL styles with BibLaTeX styles**: they are not interchangeable. CSL
-  (`.csl`) drives Pandoc, Quarto, and Zotero; BibLaTeX styles and BibTeX `.bst` files
-  drive LaTeX and are consumed by `biblatex`/`biber` instead. Searching for "APA
-  style" returns both, and dropping `biblatex-apa` into a `csl:` field — or a `.csl`
-  into `\usepackage[style=...]{biblatex}` — fails in ways that do not name the cause
+- **Confusing CSL styles with LaTeX bibliography styles**: three separate formats
+  answer to "APA style" and none is interchangeable with the others. `.csl` drives
+  Pandoc, Quarto, and Zotero. Legacy BibTeX uses `.bst` files, selected with
+  `\bibliographystyle{}` and processed by the `bibtex` program. Modern biblatex uses
+  its own `.bbx`/`.cbx` styles, selected with `\usepackage[style=apa]{biblatex}` and
+  processed by `biber`. Putting a `.csl` filename in a `csl:` field is right; putting
+  one anywhere in a LaTeX preamble is not, and each of these tools fails on the
+  others' files in ways that do not name the cause
 
 ## Related Skills
 

--- a/skills/format-citations/SKILL.md
+++ b/skills/format-citations/SKILL.md
@@ -101,7 +101,7 @@ cite-method: citeproc
 **On failure:** If the CSL file is not found, download it from the CSL repository
 (see Step 3) and place it in the project directory.
 
-### Step 3: Obtain CSL Style Files
+### Step 3: Obtain and Customize CSL Style Files
 
 ```r
 # Common CSL styles and their repository names
@@ -132,10 +132,41 @@ download_csl <- function(style, dest_dir = ".") {
 download_csl("apa")
 ```
 
-**Expected:** CSL file downloaded to the project directory.
+A downloaded style is rarely the last word — journals routinely deviate from the
+canonical style in small ways, and the fix is to edit the `.csl` file rather than to
+post-process the rendered output. A CSL style is XML with `cs:style` as its root
+element, and four parts account for nearly every journal-specific tweak:
+
+- **Where the two formats live.** `cs:citation` is required and appears exactly once;
+  it controls the in-text citation or footnote. `cs:bibliography` is optional and
+  controls the reference list. Changing how a citation looks in the text and changing
+  how it looks in the reference list are edits to *different* elements — this is the
+  most common source of "I changed it and nothing happened".
+- **Sort order.** Both `cs:citation` and `cs:bibliography` may carry a `cs:sort` child,
+  which must appear *before* `cs:layout` and must contain one or more `cs:key`
+  elements. This is what switches a bibliography between author-alphabetical,
+  by-year, and citation-order.
+- **"et al." thresholds.** `et-al-min` and `et-al-use-first` together enable et-al
+  abbreviation: once the author count reaches `et-al-min`, the list truncates after
+  `et-al-use-first` names. Set them on `cs:name`, or inherit them from `cs:style`,
+  `cs:citation`, or `cs:bibliography`.
+- **Localization.** Set the `default-locale` attribute on the root `cs:style` element
+  to translate style-generated terms ("and", "et al.", "eds."). The attribute is
+  `default-locale` — a bare `locale` attribute belongs on `cs:locale` elements and
+  will not do this.
+
+Validate any edited style at <https://validator.citationstyles.org/>, which checks a
+file (by URL, upload, or paste) against the CSL schema and reports the offending line.
+Do this before rendering: Pandoc's failure mode for a malformed style is unhelpful.
+
+**Expected:** CSL file downloaded to the project directory, and any journal-specific
+edits validate cleanly against the CSL schema.
 
 **On failure:** Check network connectivity. The CSL GitHub repository contains 10,000+
-styles. For offline use, bundle required CSL files in the project.
+styles. For offline use, bundle required CSL files in the project. If an edited style
+fails validation, the validator names the line — the usual causes are a `cs:sort`
+placed after `cs:layout` rather than before it, and a misspelled attribute, which the
+schema rejects rather than ignores.
 
 ### Step 4: Write In-Text Citations
 
@@ -295,6 +326,11 @@ Refine the regex or manually review flagged keys.
   Pandoc. Always use CSL 1.0+ from the official repository
 - **Quarto vs R Markdown differences**: Quarto uses `cite-method: citeproc` by
   default; R Markdown may need explicit `pandoc_args: ["--citeproc"]`
+- **Confusing CSL styles with BibLaTeX styles**: they are not interchangeable. CSL
+  (`.csl`) drives Pandoc, Quarto, and Zotero; BibLaTeX styles and BibTeX `.bst` files
+  drive LaTeX and are consumed by `biblatex`/`biber` instead. Searching for "APA
+  style" returns both, and dropping `biblatex-apa` into a `csl:` field — or a `.csl`
+  into `\usepackage[style=...]{biblatex}` — fails in ways that do not name the cause
 
 ## Related Skills
 


### PR DESCRIPTION
The first candidate #482 has **admitted**. Its scoreboard until now was five verified
fabrications and zero accepted harvests.

## What English was missing

Step 3 downloaded a `.csl` file and stopped. The reader was left holding an XML document
with no account of it, while Step 4 onward assumes it can be bent to a journal's house
style. Sighted in `ja/format-citations` S3 and `zh-CN` S2, both of which explain the file's
internals.

Step 3 is now *Obtain and Customize*, covering the four parts that account for nearly every
journal-specific tweak: which element controls which format (`cs:citation` vs
`cs:bibliography` — the usual cause of "I changed it and nothing happened"), `cs:sort` with
its `cs:key` children and its required position before `cs:layout`, the
`et-al-min`/`et-al-use-first` pair and where it can be set or inherited, and the
`default-locale` attribute.

## Verified against the spec, not against the translation

#478 established these files were **re-authored from frontmatter — the source never
loaded**, which makes them evidence of nothing. Every claim was checked against the CSL
1.0.2 specification and the validator instead.

That is not ceremony. The translation says to set `locale="ja-JP"`; the attribute on
`cs:style` is **`default-locale`**. A bare `locale` attribute belongs on `cs:locale`
elements and will not localize a style. A reader following the untranslated advice gets no
effect and no error — the same shape as `apa-7th-edition.csl`, the fabrication that put the
"verify first" rule into #482 in the first place. <https://validator.citationstyles.org/>
was also confirmed live rather than cited from memory.

## One piece lifted out of a rejected step

The ja LaTeX/BibTeX step is **rejected on scope** — this skill's own description is "CSL
processors and R tooling… citeproc, knitcitations, Quarto", and biblatex is a different
pipeline. But one claim inside it belongs here: **CSL styles and BibLaTeX styles are not
interchangeable.** A reader searching "APA style" meets `biblatex-apa` beside `apa.csl`, and
crossing them fails without naming the cause. That is now a pitfall.

## Prose, not a fence — deliberately

English is the parity basis for `i18n/`. A new fence here would put all ten translations out
of fence-count alignment, **including the six compressed tiers that are currently
faithful** — manufacturing exactly the unreachable-file defect #477 and #483 exist to
repair. Element and attribute names read perfectly well inline.

| | before | after |
|---|---:|---:|
| fences in the file | 18 | **18** |
| gated-fence violations, repo-wide | 244 / 63 files | **244 / 63 files** |
| file length | 304 | 340 (limit 500) |

## Recorded on #482, so #478 does not re-litigate

The full candidate list now sits on the issue, derived mechanically over all 33 re-authored
files at `0fc307e11^` — the last revision before the fence-restore batches overwrote
translated fence bodies. Two rejections are written up there with reasons: the LaTeX
workflow step above, and `de/use-graphql-api`'s TypeScript client section, where English is
deliberately `gh api graphql`-based.

Also recorded there: a **method warning**. The obvious mechanical measure — comparing step
and fence *counts* — reports "28 of 33 carry strictly less than English" and would close
this issue having found nothing. `ja/format-citations` sits in that bucket with 5 steps to
English's 7, and this harvest came out of it. Sections do not correspond one-to-one between
a re-authored document and its source, so fewer sections does not mean fewer topics.

Refs #482, #478