### PR TITLE
feat(ci): block banned invocations corpus-wide, and clear the 30 already published (#526)

### DIFF
--- a/.github/workflows/validate-content-style.yml
+++ b/.github/workflows/validate-content-style.yml
@@ -10,6 +10,7 @@ on:
       - 'guides/**'
       - 'i18n/**'
       - 'scripts/check-yaml-fences.js'
+      - 'scripts/check-banned-invocations.js'
       - '.github/workflows/validate-content-style.yml'
   pull_request:
     paths:
@@ -19,6 +20,7 @@ on:
       - 'guides/**'
       - 'i18n/**'
       - 'scripts/check-yaml-fences.js'
+      - 'scripts/check-banned-invocations.js'
       - '.github/workflows/validate-content-style.yml'
   workflow_dispatch:
 
@@ -66,3 +68,18 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run validate:yaml-fences
+
+  # Blocks any command the repo forbids, in prose as well as in fences. The fence-parity
+  # gate cannot do this job: it accepts a match against ANY historical English revision,
+  # so a deliberate deletion in English never propagates and the old form stays green
+  # forever. See #526.
+  banned-invocations:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run validate:banned-invocations

--- a/i18n/de/skills/create-glyph/SKILL.md
+++ b/i18n/de/skills/create-glyph/SKILL.md
@@ -228,31 +228,21 @@ Das Icon im passenden Manifest registrieren.
 
 ### Schritt 5: Rendern — Icon generieren
 
-Die Build-Pipeline ausfuehren, um das WebP zu rendern.
+Die Icon-Pipeline ausfuehren, um die neue Glyphe zu rendern. Immer `build.sh` als Einstiegspunkt verwenden — es uebernimmt die Plattformerkennung und die Auswahl der R-Binary. Siehe [render-icon-pipeline](../render-icon-pipeline/SKILL.md) fuer die vollstaendige Flag-Referenz und die Pipeline-Architektur.
 
-1. Zum `viz/`-Verzeichnis navigieren
-2. Basierend auf dem Entitaetstyp rendern:
-
-**Fuer Skills:**
 ```bash
-cd viz && Rscript build-icons.R --only <domain>
-# Or skip existing: Rscript build-icons.R --only <domain> --skip-existing
+# From project root — renders all palettes, standard + HD, skips existing icons
+bash viz/build.sh --only <domain> --skip-existing          # skills
+bash viz/build.sh --type agent --only <id> --skip-existing # agents
+bash viz/build.sh --type team --only <id> --skip-existing  # teams
+
+# Dry run first:
+bash viz/build.sh --only <domain> --dry-run
 ```
 
-**Fuer Agents:**
-```bash
-cd viz && Rscript build-agent-icons.R --only <agent-id>
-# Or skip existing: Rscript build-agent-icons.R --only <agent-id> --skip-existing
-```
+`build.sh` fuehrt die vollstaendige Pipeline aus (Palette → Daten → Manifest → Rendering → Terminal-Glyphen). Die Schritte ausserhalb des Renderings kosten etwa 10 Sekunden, stellen aber sicher, dass alle Daten aktuell sind.
 
-**Fuer Teams:**
-```bash
-cd viz && Rscript build-team-icons.R --only <team-id>
-# Or skip existing: Rscript build-team-icons.R --only <team-id> --skip-existing
-```
-
-3. Fuer einen Probelauf zuerst `--dry-run` an einen beliebigen Befehl anhaengen
-4. Ausgabeorte:
+Ausgabeorte:
    - Skills: `viz/public/icons/<palette>/<domain>/<skill-id>.webp`
    - Agents: `viz/public/icons/<palette>/agents/<agent-id>.webp`
    - Teams: `viz/public/icons/<palette>/teams/<team-id>.webp`

--- a/i18n/de/skills/enhance-glyph/SKILL.md
+++ b/i18n/de/skills/enhance-glyph/SKILL.md
@@ -148,22 +148,11 @@ Die modifizierte Glyphe rendern und die Korrektur verifizieren.
 
 1. Basierend auf dem Entitaetstyp neu rendern:
 
-   **Fuer Skills:**
    ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-icons.R --only <domain> --no-cache
-   ```
-
-   **Fuer Agents:**
-   ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-agent-icons.R --only <agent-id> --no-cache
-   ```
-
-   **Fuer Teams:**
-   ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-team-icons.R --only <team-id> --no-cache
+   # From project root — use --no-cache to force re-render of modified glyph
+   bash viz/build.sh --only <domain> --no-cache          # skills
+   bash viz/build.sh --type agent --only <id> --no-cache # agents
+   bash viz/build.sh --type team --only <id> --no-cache  # teams
    ```
 
 2. Ausgabedateien am erwarteten Pfad fuer jede Palette pruefen

--- a/i18n/es/skills/enhance-glyph/SKILL.md
+++ b/i18n/es/skills/enhance-glyph/SKILL.md
@@ -149,22 +149,11 @@ Renderizar el glyph modificado y verificar la correccion.
 
 1. Re-renderizar segun el tipo de entidad:
 
-   **Para habilidades:**
    ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-icons.R --only <domain> --no-cache
-   ```
-
-   **Para agentes:**
-   ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-agent-icons.R --only <agent-id> --no-cache
-   ```
-
-   **Para equipos:**
-   ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-team-icons.R --only <team-id> --no-cache
+   # From project root — use --no-cache to force re-render of modified glyph
+   bash viz/build.sh --only <domain> --no-cache          # skills
+   bash viz/build.sh --type agent --only <id> --no-cache # agents
+   bash viz/build.sh --type team --only <id> --no-cache  # teams
    ```
 
 2. Verificar que los archivos de salida existen en la ruta esperada para cada paleta

--- a/i18n/ja/skills/create-glyph/SKILL.md
+++ b/i18n/ja/skills/create-glyph/SKILL.md
@@ -227,31 +227,21 @@ print(p)
 
 ### ステップ 5: レンダリング — アイコンの生成
 
-ビルドパイプラインを実行してWebPをレンダリングする。
+アイコンパイプラインを実行して新しいグリフをレンダリングする。エントリポイントには常に `build.sh` を使用する — プラットフォーム検出とRバイナリの選択を処理してくれる。フラグの完全なリファレンスとパイプラインの構成については [render-icon-pipeline](../render-icon-pipeline/SKILL.md) を参照。
 
-1. `viz/` ディレクトリに移動する
-2. エンティティタイプに基づいてレンダリングする:
-
-**スキルの場合:**
 ```bash
-cd viz && Rscript build-icons.R --only <domain>
-# Or skip existing: Rscript build-icons.R --only <domain> --skip-existing
+# From project root — renders all palettes, standard + HD, skips existing icons
+bash viz/build.sh --only <domain> --skip-existing          # skills
+bash viz/build.sh --type agent --only <id> --skip-existing # agents
+bash viz/build.sh --type team --only <id> --skip-existing  # teams
+
+# Dry run first:
+bash viz/build.sh --only <domain> --dry-run
 ```
 
-**エージェントの場合:**
-```bash
-cd viz && Rscript build-agent-icons.R --only <agent-id>
-# Or skip existing: Rscript build-agent-icons.R --only <agent-id> --skip-existing
-```
+`build.sh` はパイプライン全体（パレット → データ → マニフェスト → レンダリング → ターミナルグリフ）を実行する。レンダリング以外のステップで約10秒かかるが、すべてのデータが最新であることが保証される。
 
-**チームの場合:**
-```bash
-cd viz && Rscript build-team-icons.R --only <team-id>
-# Or skip existing: Rscript build-team-icons.R --only <team-id> --skip-existing
-```
-
-3. ドライランを先に行うには、任意のコマンドに `--dry-run` を追加する
-4. 出力先:
+出力先:
    - スキル: `viz/public/icons/<palette>/<domain>/<skill-id>.webp`
    - エージェント: `viz/public/icons/<palette>/agents/<agent-id>.webp`
    - チーム: `viz/public/icons/<palette>/teams/<team-id>.webp`

--- a/i18n/ja/skills/enhance-glyph/SKILL.md
+++ b/i18n/ja/skills/enhance-glyph/SKILL.md
@@ -146,22 +146,11 @@ Glyph Quality Dimensions:
 
 1. エンティティタイプに基づいて再レンダリングする:
 
-   **スキルの場合:**
    ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-icons.R --only <domain> --no-cache
-   ```
-
-   **エージェントの場合:**
-   ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-agent-icons.R --only <agent-id> --no-cache
-   ```
-
-   **チームの場合:**
-   ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-team-icons.R --only <team-id> --no-cache
+   # From project root — use --no-cache to force re-render of modified glyph
+   bash viz/build.sh --only <domain> --no-cache          # skills
+   bash viz/build.sh --type agent --only <id> --no-cache # agents
+   bash viz/build.sh --type team --only <id> --no-cache  # teams
    ```
 
 2. 各パレットの想定パスに出力ファイルが存在することを確認する

--- a/i18n/zh-CN/skills/create-glyph/SKILL.md
+++ b/i18n/zh-CN/skills/create-glyph/SKILL.md
@@ -224,31 +224,21 @@ print(p)
 
 ### 步骤 5：渲染 — 生成图标
 
-运行构建流水线渲染 WebP 文件。
+运行图标流水线渲染新字形。始终使用 `build.sh` 作为入口点 — 它会处理平台检测和 R 二进制文件的选择。完整的标志参考和流水线架构见 [render-icon-pipeline](../render-icon-pipeline/SKILL.md)。
 
-1. 切换到 `viz/` 目录
-2. 根据实体类型进行渲染：
-
-**技能：**
 ```bash
-cd viz && Rscript build-icons.R --only <domain>
-# Or skip existing: Rscript build-icons.R --only <domain> --skip-existing
+# From project root — renders all palettes, standard + HD, skips existing icons
+bash viz/build.sh --only <domain> --skip-existing          # skills
+bash viz/build.sh --type agent --only <id> --skip-existing # agents
+bash viz/build.sh --type team --only <id> --skip-existing  # teams
+
+# Dry run first:
+bash viz/build.sh --only <domain> --dry-run
 ```
 
-**代理：**
-```bash
-cd viz && Rscript build-agent-icons.R --only <agent-id>
-# Or skip existing: Rscript build-agent-icons.R --only <agent-id> --skip-existing
-```
+`build.sh` 会运行完整流水线（调色板 → 数据 → 清单 → 渲染 → 终端字形）。非渲染步骤约需 10 秒，但可确保所有数据都是最新的。
 
-**团队：**
-```bash
-cd viz && Rscript build-team-icons.R --only <team-id>
-# Or skip existing: Rscript build-team-icons.R --only <team-id> --skip-existing
-```
-
-3. 如需先进行试运行，在任何命令后添加 `--dry-run`
-4. 输出位置：
+输出位置：
    - 技能：`viz/public/icons/<palette>/<domain>/<skill-id>.webp`
    - 代理：`viz/public/icons/<palette>/agents/<agent-id>.webp`
    - 团队：`viz/public/icons/<palette>/teams/<team-id>.webp`

--- a/i18n/zh-CN/skills/enhance-glyph/SKILL.md
+++ b/i18n/zh-CN/skills/enhance-glyph/SKILL.md
@@ -144,22 +144,11 @@ Glyph Quality Dimensions:
 
 1. 根据实体类型重新渲染：
 
-   **技能：**
    ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-icons.R --only <domain> --no-cache
-   ```
-
-   **代理：**
-   ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-agent-icons.R --only <agent-id> --no-cache
-   ```
-
-   **团队：**
-   ```bash
-   cd /mnt/d/dev/p/agent-almanac/viz
-   Rscript build-team-icons.R --only <team-id> --no-cache
+   # From project root — use --no-cache to force re-render of modified glyph
+   bash viz/build.sh --only <domain> --no-cache          # skills
+   bash viz/build.sh --type agent --only <id> --no-cache # agents
+   bash viz/build.sh --type team --only <id> --no-cache  # teams
    ```
 
 2. 验证每个调色板的输出文件存在于预期路径

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "test:cli": "node --test cli/test/cli.test.js",
     "pretest:scripts": "node scripts/test/_assert-suite-nonempty.js",
     "test:scripts": "node --test scripts/test/*.test.js",
-    "prepublishOnly": "node --test cli/test/cli.test.js"
+    "prepublishOnly": "node --test cli/test/cli.test.js",
+    "validate:banned-invocations": "node scripts/check-banned-invocations.js"
   },
   "dependencies": {
     "chalk": "^6.0.0",

--- a/scripts/check-banned-invocations.js
+++ b/scripts/check-banned-invocations.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Fail when documentation instructs a reader to run a command the repository bans.
+ *
+ * WHY THIS EXISTS (#526)
+ *
+ * `check-i18n-fence-parity.js` freezes a translated code fence to a body appearing in
+ * *some* revision of the paired English file. That is deliberate — it lets a translation
+ * lag without being called a violation. But it makes the gate answer "was this ever
+ * English?", never "is this English now?", and those two questions differ in exactly one
+ * case: when English deletes something on purpose.
+ *
+ * English commit acc252e6d ("eliminate bare Rscript calls") replaced every
+ * `Rscript build-*-icons.R` with `bash viz/build.sh`, because direct Rscript calls bypass
+ * platform detection and can select the wrong R binary. Three locales never received it,
+ * and the parity checker prints "OK: every gated code fence matches an English source
+ * revision" over eighteen of them. A deletion cannot propagate through a historical-match
+ * gate; the old text stays frozen, valid and green forever.
+ *
+ * Two further instances of the same drift were prose — a bare `Rscript
+ * generate-palette-colors.R` in all four full locales, and a stale hardcoded count in all
+ * ten — so a fence-shaped fix could not have worked either. Half the corpus this needs to
+ * cover is not in fences at all.
+ *
+ * Hence: content-based, corpus-wide, prose and fences alike, matching a small enumerated
+ * list of forbidden strings. The scope is what is banned, not where it might hide.
+ *
+ * Usage:
+ *   node scripts/check-banned-invocations.js            # scan, exit 1 on any hit
+ *   node scripts/check-banned-invocations.js --root DIR # scan an alternate tree (tests)
+ *   node scripts/check-banned-invocations.js --list     # print the rule table and exit 0
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { join, relative } from 'path';
+
+/**
+ * The banned forms and what to use instead.
+ *
+ * `pattern` must be a literal substring, not a regex: the failure this tool exists to
+ * catch was a regex (`Rscript build-.*-icons\.R`) scoped so tightly it could not match
+ * `generate-palette-colors.R` and returned a confident zero. Literals cannot silently
+ * under-match.
+ */
+const BANNED = [
+  { pattern: 'Rscript build-icons.R',             use: 'bash viz/build.sh' },
+  { pattern: 'Rscript build-agent-icons.R',       use: 'bash viz/build.sh --type agent' },
+  { pattern: 'Rscript build-team-icons.R',        use: 'bash viz/build.sh --type team' },
+  { pattern: 'Rscript generate-palette-colors.R', use: 'bash viz/build.sh' },
+];
+
+/**
+ * Skills allowed to contain the banned strings, by skill id — which covers every locale
+ * mirror at once, so a translation cannot drift out of its own exemption.
+ *
+ * Default-deny: a skill is exempt only by appearing here, and every entry must name the
+ * reason. An allowlist of "documentation-ish" paths would be edited by moving a file.
+ */
+const EXEMPT_SKILLS = new Map([
+  ['render-icon-pipeline', 'Quotes the banned forms in order to ban them ("Never run ...").'],
+]);
+
+/** Trees to walk. `docs/` is excluded: it analyses what build.sh calls internally. */
+const TREES = ['skills', 'agents', 'teams', 'guides'];
+
+function parseArgs(argv) {
+  const out = { root: process.cwd(), list: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--list') out.list = true;
+    else if (argv[i] === '--root') {
+      out.root = argv[i + 1];
+      if (!out.root) { console.error('--root requires a directory'); process.exit(2); }
+      i += 1;
+    } else if (argv[i].startsWith('--')) {
+      console.error(`unknown flag: ${argv[i]}`);
+      process.exit(2);
+    }
+  }
+  return out;
+}
+
+/** Every markdown file under a content tree, recursively. */
+function markdownUnder(dir, acc = []) {
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) return acc;
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue;
+    const abs = join(dir, entry);
+    const st = statSync(abs);
+    if (st.isDirectory()) markdownUnder(abs, acc);
+    else if (st.isFile() && entry.endsWith('.md')) acc.push(abs);
+  }
+  return acc;
+}
+
+/**
+ * The skill id a path belongs to, or null.
+ * Handles both `skills/<id>/SKILL.md` and `i18n/<locale>/skills/<id>/SKILL.md`.
+ */
+function skillIdOf(relPath) {
+  const parts = relPath.split(/[/\\]/);
+  const i = parts.indexOf('skills');
+  if (i === -1 || i + 1 >= parts.length) return null;
+  return parts[i + 1];
+}
+
+function collectFiles(root) {
+  const roots = [];
+  for (const tree of TREES) roots.push(join(root, tree));
+  const i18n = join(root, 'i18n');
+  if (existsSync(i18n) && statSync(i18n).isDirectory()) {
+    for (const loc of readdirSync(i18n)) {
+      const locDir = join(i18n, loc);
+      if (!statSync(locDir).isDirectory()) continue;
+      for (const tree of TREES) roots.push(join(locDir, tree));
+    }
+  }
+  const files = [];
+  for (const r of roots) markdownUnder(r, files);
+  return files;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.list) {
+    console.log('Banned invocations (literal substring match, prose and fences alike):\n');
+    for (const b of BANNED) console.log(`  ${b.pattern}\n      use: ${b.use}`);
+    console.log('\nExempt skills (all locales):\n');
+    for (const [id, why] of EXEMPT_SKILLS) console.log(`  ${id}\n      ${why}`);
+    process.exit(0);
+  }
+
+  const files = collectFiles(args.root);
+  if (files.length === 0) {
+    console.error(`banned-invocations: no markdown found under ${args.root} — refusing to report success.`);
+    process.exit(2);
+  }
+
+  const hits = [];
+  let exemptFiles = 0;
+  for (const abs of files) {
+    const rel = relative(args.root, abs).split('\\').join('/');
+    const id = skillIdOf(rel);
+    if (id && EXEMPT_SKILLS.has(id)) { exemptFiles += 1; continue; }
+    const lines = readFileSync(abs, 'utf8').replace(/\r\n/g, '\n').split('\n');
+    lines.forEach((line, n) => {
+      for (const b of BANNED) {
+        if (line.includes(b.pattern)) hits.push({ rel, line: n + 1, text: line.trim(), banned: b });
+      }
+    });
+  }
+
+  console.log(`banned-invocations: scanned ${files.length} markdown file(s) ` +
+              `(${exemptFiles} skipped as exempt), ${BANNED.length} banned form(s).`);
+
+  if (hits.length === 0) {
+    console.log('OK: no banned invocation is published anywhere in the content trees.');
+    process.exit(0);
+  }
+
+  const byFile = new Map();
+  for (const h of hits) {
+    if (!byFile.has(h.rel)) byFile.set(h.rel, []);
+    byFile.get(h.rel).push(h);
+  }
+  console.log(`\n${hits.length} banned invocation(s) across ${byFile.size} file(s):\n`);
+  for (const [rel, list] of [...byFile.entries()].sort()) {
+    console.log(`  ${rel}`);
+    for (const h of list) {
+      console.log(`    ${String(h.line).padStart(5)}: ${h.text.slice(0, 96)}`);
+      console.log(`           use instead: ${h.banned.use}`);
+    }
+  }
+  console.log('\nThese are commands the repository bans (CLAUDE.md "Viz Deploy Model";');
+  console.log('skills/render-icon-pipeline/SKILL.md). A frozen fence that still carries one');
+  console.log('passes check-i18n-fence-parity.js, which asks whether a body was EVER English,');
+  console.log('never whether it is English NOW — see #526.');
+  process.exit(1);
+}
+
+main();

--- a/scripts/test/check-banned-invocations.test.js
+++ b/scripts/test/check-banned-invocations.test.js
@@ -1,0 +1,139 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, '..', 'check-banned-invocations.js');
+
+/** Run the checker against a throwaway tree, returning {status, stdout}. */
+function run(root, extra = []) {
+  try {
+    const stdout = execFileSync('node', [SCRIPT, '--root', root, ...extra], { encoding: 'utf8' });
+    return { status: 0, stdout };
+  } catch (e) {
+    return { status: e.status, stdout: String(e.stdout || '') + String(e.stderr || '') };
+  }
+}
+
+function tree(files) {
+  const root = mkdtempSync(join(tmpdir(), 'banned-'));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body, 'utf8');
+  }
+  return root;
+}
+
+const CLEAN = '# Render\n\nRun `bash viz/build.sh --only design` to render.\n';
+
+test('a clean tree passes', () => {
+  const root = tree({ 'skills/create-glyph/SKILL.md': CLEAN });
+  try {
+    const r = run(root);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /OK: no banned invocation/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// The point of the suite: break the subject, watch the gate go red. A checker that has
+// only ever been observed passing is evidence about nothing.
+test('a banned invocation in a FENCE is caught', () => {
+  const root = tree({
+    'skills/create-glyph/SKILL.md': '# Render\n\n```bash\ncd viz && Rscript build-icons.R --only design\n```\n',
+  });
+  try {
+    const r = run(root);
+    assert.equal(r.status, 1, 'must exit 1');
+    assert.match(r.stdout, /1 banned invocation\(s\) across 1 file\(s\)/);
+    assert.match(r.stdout, /use instead: bash viz\/build\.sh/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// Half of the real instances (#526) were prose, not fences. A fence-shaped checker would
+// have reported this file clean.
+test('a banned invocation in PROSE is caught', () => {
+  const root = tree({
+    'skills/create-glyph/SKILL.md': '# Palettes\n\n3. Run `Rscript generate-palette-colors.R` to regenerate JSON\n',
+  });
+  try {
+    const r = run(root);
+    assert.equal(r.status, 1, 'prose must be covered too');
+    assert.match(r.stdout, /generate-palette-colors/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('translated mirrors are scanned, not just English', () => {
+  const root = tree({
+    'skills/create-glyph/SKILL.md': CLEAN,
+    'i18n/de/skills/create-glyph/SKILL.md': '# Rendern\n\n```bash\nRscript build-team-icons.R --only x\n```\n',
+  });
+  try {
+    const r = run(root);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /i18n\/de\/skills\/create-glyph/);
+    assert.match(r.stdout, /--type team/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// The exemption must reach every locale, or a translation drifts out of its own carve-out
+// and the checker fires on text whose whole purpose is to forbid the command.
+test('render-icon-pipeline is exempt in English AND in every locale', () => {
+  const banned = '- Never run `Rscript build-icons.R` manually. Use `bash build.sh`.\n';
+  const root = tree({
+    'skills/render-icon-pipeline/SKILL.md': banned,
+    'i18n/ja/skills/render-icon-pipeline/SKILL.md': banned,
+    'i18n/wenyan/skills/render-icon-pipeline/SKILL.md': banned,
+  });
+  try {
+    const r = run(root);
+    assert.equal(r.status, 0, 'the skill that bans the command must not be flagged for naming it');
+    assert.match(r.stdout, /3 skipped as exempt/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// The exemption is keyed on skill id, so it must NOT leak to a neighbouring skill.
+test('the exemption does not leak to other skills', () => {
+  const root = tree({
+    'skills/render-icon-pipeline/SKILL.md': 'Never run `Rscript build-icons.R`.\n',
+    'skills/enhance-glyph/SKILL.md': '```bash\nRscript build-icons.R --only x\n```\n',
+  });
+  try {
+    const r = run(root);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /enhance-glyph/);
+    assert.doesNotMatch(r.stdout, /render-icon-pipeline\n/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+// A checker whose glob matches nothing exits 0 reporting success — the exact silence that
+// left a CI job green having run nothing (#486). Refuse to report a pass on an empty scan.
+test('an empty tree exits 2 rather than reporting success', () => {
+  const root = tree({ 'README.md': 'nothing here\n' });
+  try {
+    const r = run(root);
+    assert.equal(r.status, 2, 'must not report OK when it found nothing to scan');
+    assert.match(r.stdout, /refusing to report success/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('--list prints the rules and exits 0 without scanning', () => {
+  const root = tree({ 'skills/x/SKILL.md': '```bash\nRscript build-icons.R\n```\n' });
+  try {
+    const r = run(root, ['--list']);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /Rscript generate-palette-colors\.R/);
+    assert.match(r.stdout, /render-icon-pipeline/);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('an unknown flag exits 2 rather than being ignored', () => {
+  const root = tree({ 'skills/x/SKILL.md': CLEAN });
+  try {
+    assert.equal(run(root, ['--pretend']).status, 2);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
Closes **#526**.

## The gap

A gate that accepts a match against **any historical revision** of the source cannot see a
**deletion**. `check-i18n-fence-parity.js` freezes a translated fence to a body appearing in
*some* English revision — deliberately, so a lagging translation is not a violation. But that
makes it answer *"was this ever English?"*, never *"is this English now?"*, and those differ
in exactly one case: when English removes something on purpose.

`acc252e6d` ("eliminate bare Rscript calls") replaced every `Rscript build-*-icons.R` with
`bash viz/build.sh`. Four locales never received it:

```console
$ node scripts/check-i18n-fence-parity.js --locale de --id create-glyph
OK: every gated code fence matches an English source revision.
```

**30 banned invocations across 7 files, all green.** The gate is not broken — it is answering
the question it was asked.

## A fence-shaped fix could not have worked

Half this drift was never in a fence: `Rscript generate-palette-colors.R` in all four full
locales, and a stale "58 domain colors" in all ten, both in prose (fixed in #524). So the new
check is **content-based and corpus-wide** — a short enumerated list of forbidden strings
matched over every markdown file in every tree, fences and prose alike. The scope is *what is
banned*, not *where it might hide*.

Two design choices, both scar tissue from this session:

- **Literal substrings, not regexes.** The failure that started all of this was
  `rg 'Rscript build-.*-icons\.R'` — scoped so tightly it could not match
  `generate-palette-colors.R`, and it returned a confident zero. Literals cannot silently
  under-match.
- **Default-deny exemptions, keyed on skill id** so they cover every locale at once and a
  translation cannot drift out of its own carve-out. Each must name its reason.
  `render-icon-pipeline` is the only one — it quotes the banned forms in order to ban them.

## The 30 are repaired, so this ships blocking rather than warn-only

Same surgery #524 performed for `es/create-glyph`: drop the per-entity `**Label:**` headings
current English has no counterpart for, embed the current English fence verbatim at the same
ordinal. **Not** de-translating the old fences back — that would green the checker by
re-publishing the banned command, which is the regression this whole thread is about.

| skill | locales | invocations | fences |
|---|---|---:|---|
| `create-glyph` | de, ja, zh-CN | 18 | 17 → 15 |
| `enhance-glyph` | de, es, ja, zh-CN | 12 | 5 → 3 |

Translated prose is preserved; each file's own output-location lines are carried across
rather than re-authored.

## Proving the gate can fail

Per CLAUDE.md, a green check is evidence about the *check*. Nine tests, and the load-bearing
ones break the subject and watch it go red:

- a banned string in a **fence** → exit 1
- the same in **prose** → exit 1 (a fence-shaped checker would call this file clean)
- the same in a **locale mirror** → exit 1
- the exemption reaching **every locale**, and **not leaking** to a neighbouring skill
- an **empty scan exits 2** rather than reporting OK — the #486 silence where a glob matching
  nothing leaves a CI job green having run nothing

```console
$ node scripts/check-banned-invocations.js
banned-invocations: scanned 4196 markdown file(s) (11 skipped as exempt), 4 banned form(s).
OK: no banned invocation is published anywhere in the content trees.
```

Fence parity unchanged at **244 across 63 files**; all four repaired locales report OK
per-skill; no CRLF; 9/9 tests pass.

## Still open on #526

The last checklist item — whether parity should *warn* when a fence matches only a
**superseded** English revision — is the general signal, and deliberately not built here.
Only the specific, enumerable list is safe to block on. Filed thinking is in the issue.