### PR TITLE
feat(skills): harvest the six #482 candidates that survived both gates

### DIFF
--- a/skills/build-shiny-module/SKILL.md
+++ b/skills/build-shiny-module/SKILL.md
@@ -200,6 +200,8 @@ server <- function(input, output, session) {
 
 **On failure:** If the module UI doesn't render, verify the `id` string matches between UI and server calls. If the returned reactive is NULL, check that the server function actually returns a value.
 
+Sibling modules communicate through the parent, not directly with each other. Capture the first module's returned reactive and pass it as an argument into the second module's server call — `filtered_data <- dataFilterServer("filter1", data = raw_data, columns = cols)`, then `summaryServer("summary1", data = filtered_data)`. Pass the reactive itself, not `filtered_data()`: the receiving module has to re-run when the value changes, so it needs the reactive, not whatever value it happened to hold at the moment of the call. Reactive expressions are the most portable format for moving reactive information between modules — a module that takes a plain reactive argument works under any parent that can produce one.
+
 ### Step 5: Compose Nested Modules (Optional)
 
 For modules that contain other modules:

--- a/skills/manage-bibliography/SKILL.md
+++ b/skills/manage-bibliography/SKILL.md
@@ -123,6 +123,17 @@ message(sprintf("Merged: %d + %d = %d entries (before dedup)",
 
 **Expected:** A combined BibEntry object containing entries from both files.
 
+Regenerating keys after a merge is a separate job, and RefManageR gives you both
+halves: `names(bib)` returns the citation keys and `names(bib) <- new_keys` writes
+them back, so `names(bib)[1] <- "newkey"` renames a single entry. Do not assume the
+keys you assign survive verbatim — both `names<-` and `c()` push their result
+through `make.unique(keys, sep = ":")`, so a second `Smith2020` becomes
+`Smith2020:1`; `c()` therefore never drops an entry, but a collision you did not
+disambiguate yourself reaches the output .bib as a colon-suffixed key.
+Disambiguate first (`Smith2020a`/`Smith2020b`, a coauthor name, or a title word),
+then re-read `names(bib)` and keep the old-to-new pairing — every `@key` in an
+.Rmd or .qmd body still names the old key.
+
 ### Step 5: Deduplicate Entries
 
 ```r
@@ -206,8 +217,11 @@ supports UTF-8: `Sys.setlocale("LC_ALL", "en_US.UTF-8")`.
   balance before parsing large files
 - **DOI rate limiting**: CrossRef throttles unauthenticated requests. Set a polite
   email with `RefManageR::BibOptions(check.entries = FALSE)` and batch requests
-- **Key collisions**: Merging files with duplicate keys (e.g., both have `Smith2020`)
-  silently overwrites. Regenerate keys after merging
+- **Key collisions**: Merging files where both have `Smith2020` does not overwrite
+  either entry — `c.BibEntry` routes the combined keys through
+  `make.unique(keys, sep = ":")`, so the second becomes `Smith2020:1`. Nothing is
+  lost, but a colon-suffixed key you did not choose reaches the output `.bib` and
+  no longer matches the `@Smith2020` in your document. Disambiguate before merging
 - **LaTeX in titles**: Titles with `{DNA}` or `$\alpha$` need careful handling;
   RefManageR preserves these but downstream tools may strip them
 

--- a/skills/optimize-docker-build-cache/SKILL.md
+++ b/skills/optimize-docker-build-cache/SKILL.md
@@ -226,6 +226,7 @@ RUN --mount=type=cache,target=/root/.npm \
 - **Too many layers**: Each `RUN`, `COPY`, `ADD` creates a layer. Combine where logical.
 - **Not cleaning apt cache**: Always end apt-get installs with `&& rm -rf /var/lib/apt/lists/*`
 - **Platform-specific caches**: Cache layers are platform-specific. CI runners may not benefit from local caches.
+- **No cache between CI runs**: Ephemeral runners start with an empty local cache, so every run rebuilds from scratch. Export the cache to a registry with `--cache-to type=registry,ref=<registry>/<cache-image>,mode=max` and import it on the next run with `--cache-from type=registry,ref=<registry>/<cache-image>`; `mode=max` also caches layers from intermediate stages, where the default `mode=min` caches only layers present in the final image. Neither this backend nor the GitHub Actions one (`type=gha`) is available on the default `docker` driver without extra setup (`type=registry` requires the containerd image store enabled), so create a dedicated builder first with `docker buildx create --driver docker-container --use`.
 
 ## Related Skills
 

--- a/skills/validate-references/SKILL.md
+++ b/skills/validate-references/SKILL.md
@@ -379,6 +379,43 @@ generate_report(all_issues, bib, output_file = "validation-report.md")
   trigger fuzzy matching. Review flagged duplicates manually
 - **Missing DOIs for older works**: Pre-2000 publications often lack DOIs. Flag as
   informational, not as errors
+- **Author names are separated by `and`, not commas**: BibTeX splits an `author`
+  or `editor` field on the word `and` surrounded by spaces and not enclosed in
+  braces. A comma delimits parts inside a single name (`von Last, First` or
+  `von Last, Jr, First`), so a comma-joined list collapses silently into one
+  author rather than several, and a trailing comma makes BibTeX complain that a
+  name ends with a comma
+- **Organizations as authors need an extra pair of braces**: An institution left
+  bare in an `author` field is dissected into First/von/Last like a personal
+  name, and any internal `and` splits it into two people. Wrap it in its own
+  braces: `author = {{National Aeronautics and Space Administration}}`
+- **One person under two spellings**: `Donald E. Knuth` in one entry and `D. E. Knuth`
+  in another alphabetize as two different authors. Settle on one form per person,
+  or write `D[onald] E. Knuth`, which BibTeX alphabetizes as if the brackets were
+  absent
+- **Journal name inconsistency**: One entry writes `Journal of the American Chemical
+  Society`, another writes `J. Am. Chem. Soc.`, and nothing above notices, because
+  Step 6 compares DOIs and article titles and never looks at the `journal` field. The
+  CrossRef record fetched in Step 4 carries the journal's `ISSN` and `container-title`,
+  and often its `short-container-title` (`J. Am. Chem. Soc.` for this journal), so
+  group entries by `ISSN` and flag any group whose `journal` values disagree. Flag
+  rather than normalize: ISO 4 governs title-word abbreviation through the LTWA
+  maintained by the ISSN International Centre, but NLM/MEDLINE strips the punctuation
+  from that assignment, so PubMed writes `J Am Chem Soc` for the same journal. Pick the
+  form the target journal's style requires
+- **A resolving DOI is not a matching DOI**: HTTP 200 confirms the DOI is
+  registered, not that it points at the entry's work. A wrong but registered DOI
+  resolves exactly like a correct one, so compare the CrossRef record Step 4
+  already fetched against the entry: `title` (an array), the `family` names in
+  `author`, and `issued.date-parts`. Normalize both sides first, or LaTeX escapes
+  and Unicode accents will manufacture mismatches
+- **False mismatches from CrossRef's own shape**: a year off by one need not be an
+  error, because `published-online` and `published-print` are separate fields that
+  can fall in different years. `10.1093/bioinformatics/btz848` is online 2019 and
+  print 2020, with `issued` following the online date. `short-container-title` is
+  sometimes an empty array, so a missing journal abbreviation is not a mismatch,
+  and a record paginated by article number can carry `article-number` with no
+  `page` field at all
 
 ## Related Skills
 


### PR DESCRIPTION
Completes #482's verification pass over the 15 remaining sighted candidates. **Six admitted,
nine rejected**, each decided by two gates in order: the target skill's own stated scope,
then verification against primary sources.

## What landed

| target | topic |
|---|---|
| `manage-bibliography` | citation-key normalisation via `names(bib) <-` |
| `validate-references` | BibTeX author-name splitting rules |
| `validate-references` | journal-name inconsistency detection |
| `validate-references` | **a resolving DOI is not a matching DOI** |
| `build-shiny-module` | module-to-module communication through the parent |
| `optimize-docker-build-cache` | registry cache for ephemeral CI runners |

All **prose with inline code, no new fences.** English is the fence-parity basis for ten
translations; a new fence puts every one of them out of fence-count alignment and breaks the
normalizer. Fence counts verified unchanged in all four files (12, 14, 12, 22).

## Verification, not plausibility

#478 established this corpus was **re-authored from frontmatter with the source never
loaded** — model output, carrying no evidential weight. Nine to thirteen primary sources were
read per accepted candidate: the CRAN RefManageR 1.4.0 tarball down to `MakeKeysUnique` in
`R/04InternalFunctions.R`, a live `api.crossref.org` response, NLM's *Citing Medicine* and
title-abbreviation rules, `btxdoc`, *Mastering Shiny*, and the Docker buildx cache-backend
docs.

It kept paying. Among the rejections:

- an **inverted core claim** — a Docker test stage described as gating the production image,
  which held only under the legacy pre-BuildKit builder
- a **fabricated 85% similarity threshold** with no named metric
- a **non-existent `.headers` argument** on `rcrossref::cr_works`
- **APA retrieval-date rules stated backwards**
- an instruction to **commit `.env.example`** presented as satisfying a secrets check

Full per-candidate verdicts, sources and error lists go to the issue.

## One correction to English itself

The existing `manage-bibliography` pitfall said merging duplicate keys *"silently
overwrites"*. It does not — `c.BibEntry` routes the combined keys through
`make.unique(keys, sep = ":")`, so a second `Smith2020` becomes `Smith2020:1`. Nothing is
lost. But a colon-suffixed key you did not choose reaches the output `.bib` and no longer
matches the `@Smith2020` in your document, which is a different and considerably more
findable failure than data loss.

## Applied by anchor, not by hand

Proposals were read from the run's journal and placed by resolving each `insertAfter` anchor
to **exactly one** English skill, refusing rather than guessing on zero or multiple matches.
Transcription is precisely where a verified claim turns back into an unverified one — this
session already produced three spec-versus-reality errors that way.

Verified: fence gate unchanged at **244 across 63 files**; every file under the 500-line
budget (`validate-references` is longest at 425); no CRLF; content-style clean on added lines.

Refs #482