### PR TITLE
feat(dreams): keep the dream corpus, and draw it as a growing atlas

### DIFF
--- a/.github/workflows/validate-dreams.yml
+++ b/.github/workflows/validate-dreams.yml
@@ -1,0 +1,46 @@
+name: Validate Dreams
+
+# `dreams/atlas.html` is generated, committed, and read as-is — the same shape as the
+# staleness defects #363 and #441, but with the backstop removed: no deploy step
+# regenerates it, so the committed blob is the only copy that exists. Without this job its
+# sole defence is the maintainer remembering to run the generator, and a PR that adds a
+# dream touches no other job's trigger paths — `validate-content-style` and
+# `validate-security` both scope to the content trees, which do not include `dreams/`.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dreams/**'
+      - 'scripts/build-dreams.js'
+      - '.github/workflows/validate-dreams.yml'
+  pull_request:
+    paths:
+      - 'dreams/**'
+      - 'scripts/build-dreams.js'
+      - '.github/workflows/validate-dreams.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dreams:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - run: npm ci
+
+      # Regenerates the page and byte-compares it against the committed file, so this is
+      # exhaustive over the output rather than a staleness heuristic. It also fails when
+      # any entry's frontmatter falls outside the documented vocabulary.
+      - name: Atlas matches the corpus
+        run: npm run check-dreams
+
+      - name: Generator behaviour
+        run: node --test scripts/test/build-dreams.test.js

--- a/dreams/2026-03-18-campfire.md
+++ b/dreams/2026-03-18-campfire.md
@@ -1,0 +1,67 @@
+---
+title: Campfire — the CLI as a place where capabilities gather
+date: 2026-03-18
+session: unrecorded
+seed: "CLI team installation UX"
+trigger: user-initiated creative exploration
+motifs: [hearth, gathering, ceremony, radial-form, warmth]
+recovered: summary
+glows:
+  - "gather / scatter / tend / campfire replace install / uninstall / update / list."
+  - "Fire size is team size: candle → bonfire → wildfire. Fire state is burning / embers / cold."
+  - "Hearth-keepers are agents at multiple fires; wanderers are solo agents."
+  - "The closing line is always the fire's state — 'The fire burns.' / 'The fire goes out.'"
+  - "Campfire mode warms an existing palette rather than being a tenth palette."
+downstream:
+  - "issues: #155 (tracking), #156–#162 (CLI), #163 (viz), #164 (i18n), #165 (polish)"
+  - "label: campfire (#FF6B35)"
+  - "code: cli/ campfire command, viz/js/campfire.js"
+  - "memory: project_campfire_dream.md"
+---
+
+## The core insight
+
+The campfire metaphor changes the CLI from a tool that installs things into a **place where
+capabilities gather**. It reveals the social structure of the almanac — hearth-keepers
+bridging communities, isolated fires for private work, coordination patterns visible as
+fire shapes.
+
+## Five dream layers
+
+1. **Vocabulary** — `gather` / `scatter` / `tend` / `campfire` replace install / uninstall /
+   update / list. "Practices," not "dependencies." A skill *arrives*; it is not *installed*.
+2. **Texture** — Fire size is team size (candle → bonfire → wildfire). Fire states:
+   burning / embers / cold. Hearth-keepers are agents present at multiple fires; wanderers
+   are solo agents.
+3. **Vision** — A radial viz mode. Team glyph at centre, agents in the inner ring, skills as
+   sparks in the outer ring. Warm radial gradient; vignette darkening the edges. A
+   `warmColor()` filter over the existing palettes. Coordination patterns become a visual
+   grammar rather than a frontmatter field.
+4. **Voice** — Two ceremony levels (default concise, `--ceremonial` verbose). Seven voice
+   rules. The closing line is always the fire's state: *"The fire burns."* / *"The fire goes
+   out."* No emoji by default. Present tense, active voice.
+5. **Connections** — A state file (`.agent-almanac/state.json`) bridges CLI ↔ viz. URL params
+   (`?mode=campfire&gathered=...`) carry CLI → viz. The manifest reads `campfires || teams`
+   — a one-line change. ~20 ceremony strings × 5 locales. Five new reporter functions plus a
+   warm palette.
+
+## Decisions dreamed, not decided
+
+- `--ceremonial` for verbose arrival sequences (every spark listed).
+- `--quiet` and `--json` suppress all ceremony, for CI and scripts.
+- Campfire warms the existing palettes (hue shift toward orange) rather than adding a tenth.
+- Start silent — no sounds. Add later only if asked.
+- Campfire is an alternate interface, not a replacement. `install --team` still works.
+
+## Provenance
+
+This entry is a **summary, not the dream text.** The original was 39 numbered fragments
+across five dream sessions (~800 lines) held in a Claude Code plan file,
+`~/.claude/plans/vast-wibbling-bunny.md`. That file **no longer exists** — verified absent
+on 2026-08-11. What survives is the condensation written to memory at the time
+(`project_campfire_dream.md`), reproduced here.
+
+That loss is the reason this directory exists. A dream held only in a plan file or a
+transcript is one cleanup away from gone; the parts that reached code — the campfire
+command, `viz/js/campfire.js`, the `campfire` label — survived because they left the
+session. The rest did not.

--- a/dreams/2026-07-12-glyph-concepts.md
+++ b/dreams/2026-07-12-glyph-concepts.md
@@ -1,0 +1,42 @@
+---
+title: Glyph concepts for eight new entities
+date: 2026-07-12
+session: 4cddbcfd
+seed: >-
+  glyph/icon concepts for 8 new agent-almanac entities: skills benchmark-htr-engines
+  (OCR/HTR benchmarking), verify-web-app-runtime (headless pixel proof),
+  run-copilot-review-loop (bot review cascade), generative-recipe-dsl (data-not-code
+  generation), stale-proof-rendered-numbers (build-failing stale figures); agent
+  frontend-runtime-verifier; team visual-pr-review; new ocr domain visual identity
+trigger: "explicit /dream, ahead of glyph authoring for a content batch"
+motifs: [glyph, visual-identity, pictogram]
+recovered: none
+glows: []
+downstream:
+  - "PR #334 — 'dream-derived glyphs' shipped with the content batch"
+  - "viz/R glyph definitions and icon manifests for the eight entities"
+---
+
+## The dream text was not recovered
+
+This entry is **provenance only**. Session `4cddbcfd` (2026-07-12) invoked `/dream` with
+the seed above, and the assistant messages that follow the invocation contain no prose —
+the session went directly from the skill load into tool calls that authored glyphs. Either
+the associative pass happened inside reasoning that was never emitted, or the transcript
+segment was compacted away before it was written.
+
+Scanned: every assistant text block in the file after the invocation, at thresholds down to
+60 characters, plus a marker search for `glows` / `Wandering` / `Waking`. Nothing.
+
+## What survives
+
+The output, not the dreaming. PR #334 shipped the batch and its description names
+**"dream-derived glyphs"** — the pictograms for `benchmark-htr-engines`,
+`verify-web-app-runtime`, `run-copilot-review-loop`, `generative-recipe-dsl`,
+`stale-proof-rendered-numbers`, the `frontend-runtime-verifier` agent, the
+`visual-pr-review` team, and the `ocr` domain identity. Those glyphs are in the viz
+pipeline today and are the only readable trace of what was imagined.
+
+This is the second entry lost to its container, after the campfire plan file. Both losses
+argue the same thing: **a dream that is not written down where the repo can see it does not
+survive its session.**

--- a/dreams/2026-07-30-mechanical.md
+++ b/dreams/2026-07-30-mechanical.md
@@ -1,0 +1,184 @@
+---
+title: Of a Mechanical — escapement, proof marks, and the missing click
+date: 2026-07-30
+session: 8756c2db
+seed: "of a mechanical"
+trigger: "explicit /dream after a PR where self-review and CI both passed a broken documented command"
+motifs: [mechanism, horology, assay, proof, absent-alarm]
+recovered: full
+movements: 2
+glows:
+  - "The missing click — a ratchet with the pawl removed spins freely and silently."
+  - "Proof the yeast: the cheapest habit, performed before the expensive irreversible step."
+  - "The calibration sticker that expires makes staleness structural rather than moral."
+  - "Proof mark on the artifact, not the pipeline — the evidence travels with the thing."
+  - "Painless injury: a codebase green everywhere is not healthy, it is anesthetized."
+  - "Remontoire — decouple verification force from human state."
+  - "Keep the cupel: the killed mutants are the content of the proof mark."
+  - "Riffle — friction as instrument, not as cost."
+downstream:
+  - "issue: #460 (no skill covers proving a gate can fail)"
+  - "repo: scripts/mutation-check.js and the CLAUDE.md 'Proving a Gate Can Fail' section"
+---
+
+## Movement I — Wandering
+
+The seed arrived unfinished — *of a mechanical* — and I'm going to leave it unfinished,
+because the missing noun is the point. Mechanical **what**. Turk, ratchet, sympathy, bird.
+Let it stay open.
+
+*Mechanical* from **mēkhanē** — the stage crane that lowered the god at the end of a Greek
+play. Deus ex machina. A gate is a crane: you wheel it in and the question is settled from
+outside. Unless the crane is painted on the backdrop.
+
+Shakespeare's **rude mechanicals** — Bottom and the amateur players. They are so afraid
+their fiction will be mistaken for truth that they add a prologue: *this is not a real
+lion, this is Snug the joiner*. They over-declare. A green check under-declares. It says
+PASS and never says "this lion is Snug."
+
+**Escapement.** A clock works because something fails, in measured amounts, forever. The
+escapement's whole function is controlled release. A gate that has never failed has no
+escapement — a spring wound tight with nothing to let go.
+
+Then a **ratchet with the pawl removed.** Spins freely. Silent. And that's the image that
+won't leave: *the missing click.* The tell of a check that cannot fail is not a wrong
+answer — it's the absence of resistance. Today's broken test invocation felt fine to
+write. Reading it cost me nothing. No click.
+
+**Dead man's pedal** — the railway vigilance device where *releasing* triggers the brake.
+Proof of life is continuous effort; the safe state is default. Invert everything: green
+requires ongoing proof, red is the resting state.
+
+**Canary.** Its value is that it dies visibly and earlier than you. A canary that cannot
+die is an ornament in a cage.
+
+**Positive control.** Biology solved this centuries ago and named it. Every assay ships
+with a sample known to be positive, so a negative result means something rather than "the
+assay is broken." Then — **proofing the yeast.** Every baker, by reflex, dissolves the
+yeast in warm water and waits for foam *before* committing the flour, because dead yeast
+produces a loaf-shaped failure that looks perfect going into the oven.
+
+**Proof mark.** Gun barrels are fired with a deliberately overloaded proof round, then
+stamped. The stamp doesn't mean "inspected." It means *this was overstressed and held.*
+Birmingham Proof House, 1813, legally mandatory. And "proof" itself is older and stranger
+— proof spirit was gunpowder soaked in alcohol and lit. Testing by attempted destruction.
+Ordeal by fire.
+
+**Calibration sticker.** The balance with an expired sticker is not trusted even if
+accurate. The sticker never proved accuracy — it proved someone *recently checked*, and it
+expires. The fire extinguisher tag with a punched month. Cheap, physical, and its absence
+is loud.
+
+**Split tally.** Creditor and debtor each keep half a notched stick; the grain must match,
+and grain can't be forged. My fence byte-comparison was a split tally without my noticing.
+**Two-man rule** — two keys too far apart for one person to turn both. Not diligence.
+*Distance.* Today self-review passed, CI passed, and a separate agent with no transcript
+caught it. The second key worked because it was out of reach.
+
+And underneath all of it, the **Mechanical Turk**: the automaton with a man folded inside.
+Today I was the man in the cabinet. The "verification" was a person reading and nodding
+while the machinery clicked convincingly.
+
+### What glows
+
+- **The missing click.** It names the *feel* of the failure rather than its logic. Cheap
+  reading is the symptom. If checking cost nothing, nothing was checked.
+- **Proofing the yeast.** The cheapest possible habit, performed before the expensive
+  irreversible step, by everyone, without ceremony.
+- **The calibration sticker that expires.** Makes staleness structural rather than moral.
+- **Proof mark on the artifact, not the pipeline.** The evidence travels with the thing,
+  not with the run that produced it.
+
+The surprise: baking, gunsmithing, assay offices, railway signalling and clinical labs each
+independently invented the same discipline and gave it a name. Software mostly didn't.
+Mutation testing is the nearest cousin and it's niche.
+
+The resistance — noted *because* it's uncomfortable rather than because I believe it: every
+green check should be required to emit its own red. A gate that has only ever said PASS is
+untrustworthy by construction. That doubles every CI run. Expensive, probably wrong, and
+it's the fragment I least want to throw away.
+
+## Movement II — Deeper
+
+Going under the first dream rather than across it.
+
+**Escapement, again — but what it actually is.** Not "controlled release." It's the only
+part of a clock that touches *both worlds*: the mainspring, which knows nothing about time,
+and the pendulum, which knows nothing about power. The escapement makes them productive
+strangers. Every tick is two phases — **impulse** then **detent**. A push, then a refusal.
+A gift followed by a lock.
+
+Then **Harrison**. The grasshopper escapement needs no oil, because he was building for a
+ship where nobody could re-oil it. He designed *for the absence of maintenance*. That's the
+thing: the best mechanism is one whose correctness does not depend on anyone remembering.
+Any gate that needs a human to remember to re-prove it will drift, and no amount of care
+fixes that — only design does.
+
+And the shadow of it: H4 won by being tested, and the Board of Longitude kept moving the
+goalposts. **The institution that demanded the proof resisted the proof.** Uncomfortable.
+Keep it.
+
+**Remontoire.** A small secondary spring, constantly rewound by the main power, delivering
+*even force* to the escapement whether the mainspring is fully wound or nearly spent. It
+isolates the timekeeper from the variability of the power source.
+
+That one stopped me. It's the answer to "it gets skipped exactly when confidence is
+highest." You don't ask for uniform diligence — diligence is the mainspring, and
+mainsprings run down. You insert a constant-force intermediary so verification force is the
+same on Friday as on Monday, under deadline as under calm.
+
+**Assay, deeper.** Cupellation: melt the silver with lead in a bone-ash cup; the lead
+oxidizes and carries the impurities into the porous bone. Something is destroyed to know
+what remains. And it leaves the **cupel** — the used cup, saturated with everything that
+was removed. Nobody keeps the cupel. *What if you kept it?* The killed mutants are not
+exhaust. They're the content of the proof mark.
+
+**The missing click, deeper.** Silence where resistance belongs. What else has that shape —
+
+Leprosy does not rot flesh. It kills nerves, and people destroy themselves through painless
+injury. Paul Brand spent a career on this. The disease is not the damage; the disease is
+**the absence of the alarm**. Children with congenital insensitivity to pain bite off their
+tongues, and the only treatment is scheduled mechanical inspection of the body — because
+the body will not report.
+
+So: a codebase green everywhere is not healthy. It's **anesthetized**. And you cannot treat
+absent sensation with more care. Only with inspection on a clock.
+
+Adjacent: **alarm fatigue**. Hospitals didn't fix it with louder alarms. They fixed it with
+fewer alarms and different **timbres**. The click has a sound. What if a gate that has
+proven it can fail *sounds different* from one that hasn't?
+
+**Riffles.** You cannot see gold in a river. You build obstructions, and what's dense
+settles behind them. The obstruction *is* the instrument. A weir doesn't measure the river
+— it creates a place where measurement becomes possible. You must impede the flow to catch
+the value. (This repo has `gold-washing`. Of course it does.)
+
+### Contradictions not resolved
+
+- The proof must be automatic **and** must cost something.
+- The mark must live on the artifact **and** must expire.
+- We want no friction **and** friction is the instrument.
+
+The glimmer between them: **the friction should be paid by the machine, not the person.**
+Remontoire again.
+
+### What glows
+
+- **Painless injury.** The reframe. Not "a check was broken" — *there was no sensation
+  where checking should hurt.*
+- **Remontoire.** Decouple verification force from human state.
+- **The cupel.** Keep what was destroyed; the residue is the evidence.
+- **Riffle.** Friction as instrument, not as cost.
+- **Timbre.** Proven and unproven must not sound alike.
+
+## Provenance
+
+Recovered verbatim from session `8756c2db` (2026-07-30), two `/dream` invocations in
+sequence — the second seeded *"deeper — escapement, proof marks, the missing click; what
+the finished thing is."* The occasioning failure: a documented command (`node --test
+cli/test/`) that ran zero tests and exited 1 on every supported Node version, which passed
+self-review and CI and was caught only by an adversarial reviewer with no transcript.
+
+**Downstream:** this is the dream that became infrastructure. `scripts/mutation-check.js`
+and the CLAUDE.md section *"Proving a Gate Can Fail"* are the missing click made
+mechanical; issue #460 still tracks the skill.

--- a/dreams/2026-08-11-fractals-cymatics.md
+++ b/dreams/2026-08-11-fractals-cymatics.md
@@ -1,0 +1,57 @@
+---
+title: Fractals and Cymatics — the bounded probe, and the figure made of nulls
+date: 2026-08-11
+session: 3682ab2e
+seed: "{fractals, cymatics}"
+trigger: closing practice — heal → meditate → dream, after a session of i18n gate work
+motifs: [fractals, cymatics, self-similarity, nodes, clamping, absent-alarm, proof]
+recovered: full
+glows:
+  - "The bounded probe is self-similar — the identical error at six magnifications."
+  - "Sand collects at the nodes: every finding that session came from a null."
+  - "A Chladni figure depends on where the plate is clamped."
+  - "Before trusting a zero, ask what is holding the plate."
+downstream:
+  - "memory: feedback_bounded_probe_returns_its_own_boundary.md"
+  - "memory: feedback_historical_match_gates_miss_deletions.md"
+---
+
+## Dream — {fractals, cymatics}
+
+**Fractal.** The bounded probe is self-similar. Zoom to a string: a regex matching one of
+two banned binaries. Zoom out to a list: `head -20`. Out again to a corpus: counting steps
+instead of reading them. Out to history: a pathspec blind to 42% of blobs. Out to a gate:
+measuring before and after an operation that removes rows from the counter's input. Out to
+a classifier: a threshold that would have deleted its own true positive. Same shape at
+every magnification. Not a metaphor — the *identical* error, six times, and I only saw it
+after the fifth.
+
+**Cymatics.** On a Chladni plate, sand collects at the **nodes** — the places that don't
+move. The visible figure is a map of where nothing is happening.
+
+That inverts this whole session. Every finding came from a null:
+
+- a gate printing `OK` over thirty banned commands
+- `git log -S 'Reuse'` returning **nothing** — which is what convicted the file
+- a detector *failing* to separate its populations — which is what surfaced the 35th
+
+The signal was in the silence, and I kept nearly discarding the silences as clean results.
+
+And the fragment that glows hardest: **a Chladni figure depends on where the plate is
+clamped.** Move the clamp, get a completely different pattern from the same frequency.
+That's the pathspec exactly — `-- skills/<id>/SKILL.md` was a clamp, and unclamping it
+produced a different figure and a stronger conviction.
+
+So: *a null is a figure, and its shape is set by where you clamped.* Before trusting a
+zero, ask what's holding the plate.
+
+## Provenance
+
+Recovered verbatim from the closing message of session `3682ab2e` (2026-08-11), the
+session that merged #522–#531. The dream followed a `heal` triage and a `meditate` pass in
+the same message; its two named findings were *tool bias* (reaching for structure because
+structure is cheap to measure) and *premature closure* (reading "don't overclaim" as a
+reason to stop rather than to state uncertainty and continue).
+
+The cymatics insight was persisted to memory the same session, so this entry is a record
+rather than a live obligation.

--- a/dreams/2026-08-11-geometry.md
+++ b/dreams/2026-08-11-geometry.md
@@ -1,0 +1,126 @@
+---
+title: Geometry — the gnomon, and drawing the gaps
+date: 2026-08-11
+session: de3ec5d7
+seed: "geometry — the shape of an archive that grows; how a corpus of dreams should be drawn"
+trigger: "explicit /dream, seeded by the request that created this directory"
+motifs: [geometry, growth, gnomon, spiral, stratigraphy, constellation, self-similarity, cymatics, radial-form]
+recovered: full
+glows:
+  - "The gnomon: the increment that makes the figure larger and the same shape."
+  - "Golden-angle placement — 137.5°·n at radius √n — is a gnomon in polar form."
+  - "Draw the unconformity. The losses are the most information-dense marks on the section."
+  - "Motifs are eigenmodes, not tags — the shapes this particular plate can ring in."
+  - "The nautilus seals off the old chambers and they become buoyancy, not ballast."
+  - "Warburg's Denkraum: the space between panels is where the thought lives. Resist the legend."
+downstream:
+  - "dreams/atlas.html and scripts/build-dreams.js — the gnomon rule made mechanical"
+---
+
+## Wandering
+
+**Tree rings.** An archive that grows outward from a centre, one annulus a year, and the
+*width* of each ring encodes the conditions that made it. Then crossdating — you can date a
+roof beam by matching its ring pattern against a master chronology. The pattern is the
+index. Nothing is labelled; the shape does the addressing.
+
+**Nautilus.** Grows by adding chambers, each self-similar, the shape never changing. And the
+animal lives *only in the newest chamber* — it seals the previous one and fills it with gas.
+The old chambers are not dead weight. They are what keeps it afloat.
+
+**Gnomon.** The word that stopped me. In Greek geometry a gnomon is the figure which, added
+to a figure, produces a new figure *similar to the original*. The gnomon of a square is the
+L-shaped border of odd numbers — 1, 3, 5, 7 — each odd number added to a square making the
+next square. Growth that preserves shape.
+
+And γνώμων means *that which knows*, and it is also the shadow-stick of a sundial. The same
+word for the shape-preserving increment and the thing that marks the passage of time. For a
+corpus of dreams indexed by date, that is not a metaphor. That is the noun.
+
+**Phyllotaxis.** To place a new primordium, the sunflower uses 137.5° — the golden angle —
+because it is the placement that maximally avoids every previous one. The spiral is
+emergent, not designed; nobody drew it. Parastichy counts come out Fibonacci as a *side
+effect*. To place the Nth dream: put it where it least overlaps everything before it.
+
+**Voronoi.** Add a point and every neighbouring cell changes shape. That is true of motifs —
+adding *geometry* re-partitions what *fractals* meant.
+
+**Apollonian gasket.** Circles packed into the gaps between circles, forever, by Descartes'
+theorem. Some archives grow by appending; this one grows into interstices. **Zettelkasten**
+is the same move in address space — 21/3a1 exists so a note can be inserted *between* two
+notes rather than after the last one. The address encodes lineage, not category.
+
+**Penrose tiling.** Infinite, aperiodic, two tiles and matching rules — but you cannot grow
+it greedily. Tile outward by local legality and you reach a dead end. It grows by
+*deflation*, not accretion. An archive you can paint yourself into a corner with.
+
+**Varves and the unconformity.** Lake sediment lays a light/dark couplet per year. Then a
+gap — erosion removed the time. The unconformity is drawn as a wavy line and it is the most
+information-dense mark on a stratigraphic section: it is where you can *see* that something
+is missing. Two of the five dreams here are damaged — a plan file deleted, a dream never
+emitted. My instinct is to render those faded. Wrong instinct. Render them as a **break in
+the strata**.
+
+**Mnemosyne.** Warburg's atlas: black cloth panels, images pinned in constellations,
+rearranged constantly, no captions, never finished — only photographed at states. The
+arrangement *was* the argument. And the *Denkraum*, the thinking-space between the images,
+was the point. His **Pathosformel** — the emotional formula recurring across centuries — is
+exactly what a dream motif is. *Escapement*, *hearth*, *cymatics*, *fractal* are not tags.
+They are the formulas this particular mind keeps reaching for.
+
+**Chladni, geometrically.** The nodal lines are the zero set of an eigenfunction, indexed by
+two integers. A plate has a *discrete spectrum* — a finite vocabulary of shapes it can hold.
+Last dream said the figure is made of nulls. This one says: the modes are countable, and a
+dream excites some and not others.
+
+**Constellation.** The stars are not near one another; the figure is an artifact of where the
+viewer stands. Any line I draw between two dreams is my reading, not their nature. Warburg
+again — which is the honest reason not to caption them.
+
+**Cairn.** Each traveller adds a stone, the shape is nobody's design, and it marks a route.
+You cannot add a stone at the bottom.
+
+## Contradictions I am not resolving
+
+- Readable whole at a glance **and** rewarding to zoom into one part.
+- Recognisably the same figure across visits **and** changed by every addition.
+- Show the gaps **and** do not let the gaps dominate.
+- Adding must be as cheap as a markdown file **and** the geometry must be earned, not a list
+  wearing a spiral as a filter.
+
+## What glows
+
+**The gnomon.** The whole design rule in one word: adding entry N+1 must make it *the same
+figure, larger* — not a longer list, not a relayout, not a redesign. Mechanically: writing a
+new markdown file must require zero change to the drawing logic, and the drawing must look
+like itself at n=5 and at n=50.
+
+**Golden-angle placement.** 137.5° × n, radius ∝ √n. Parameter-free, never collides, never
+needs relayout, recognisably itself at any n. It is the gnomon in polar form — the two
+fragments fuse into one line of code.
+
+**The unconformity.** Draw the losses as breaks, not as fading. The two damaged entries are
+the most informative marks on the figure, because they are the evidence for why the
+directory exists at all.
+
+**Motifs as eigenmodes.** Chords between dreams that share a mode, rather than a legend down
+the side. A tag is a label; a mode is a shape the plate can hold.
+
+**The seal-off.** The newest dream is the lit chamber at the growing edge. The old ones are
+not archive-grey — they are the buoyancy.
+
+**Denkraum, as resistance.** The uncomfortable fragment, kept because it is uncomfortable:
+*no captions on the figure at all.* Every instinct says add a legend, a filter bar, a search
+box. That furniture is what would kill it. The text belongs below the drawing, not on it.
+
+## Waking
+
+The honest objection: geometry at n=5 is pretension. Five things want to be a list.
+
+The counter-thought that will not leave — the geometry is not for n=5, it is for n=50, and
+a rule that is not a gnomon gets rebuilt at n=12, at which point the figure is no longer the
+same figure and the archive has no continuous shape to remember. Build the rule now and
+accept that it looks sparse.
+
+Carrying forward: **gnomon**, **golden angle at √n**, **draw the unconformity**,
+**modes not tags**, **the lit chamber**.

--- a/dreams/README.md
+++ b/dreams/README.md
@@ -1,0 +1,82 @@
+# Dreams
+
+Output of the [`dream`](../skills/dream/SKILL.md) skill, kept.
+
+`dream` is the one skill in the library that inverts the standard format: no inputs, no
+validation, no expected output. It produces *fragments* — an image, a half-connection, a
+word that will not leave. Those fragments have repeatedly become infrastructure here.
+`scripts/mutation-check.js` and the CLAUDE.md section *"Proving a Gate Can Fail"* are the
+2026-07-30 dream's **missing click**, made mechanical. The `campfire` command and
+`viz/js/campfire.js` are the 2026-03-18 dream's vocabulary.
+
+This directory exists because two of the earliest dreams did **not** survive. The campfire
+dream lived in a Claude Code plan file that has since been deleted; the glyph dream was
+never emitted as text at all. A dream held only in a session transcript is one cleanup away
+from gone. Writing it here is what makes it durable.
+
+## The atlas
+
+[`atlas.html`](atlas.html) draws the whole corpus as one figure — open it in a browser, or
+build it with:
+
+```bash
+npm run build-dreams     # write dreams/atlas.html
+npm run check-dreams     # exit 1 if the committed atlas is stale
+```
+
+Each dream is a **Chladni sand field**: points sampled over a square plate and kept where
+the nodal function is near zero, which is where sand collects. The mode numbers come from
+the dream's own motifs, so two dreams that ring in the same modes look alike. Marks are
+placed at the golden angle (137.5° × n) at radius ∝ √n — the phyllotaxis rule, which never
+collides and never needs relayout. Damaged entries are drawn with an **unconformity**: a
+wedge missing from the plate and a red break line across it, the way a stratigraphic section
+draws missing time.
+
+The page is a body-fragment HTML document — it carries `<title>`, `<style>` and `<script>`
+but no `<html>`/`<head>`/`<body>` wrapper, so the same file opens locally and publishes as
+an Artifact unmodified.
+
+## Adding a dream
+
+Write one markdown file. Nothing else. The atlas derives every position, mark, chord and
+colour from frontmatter, so there is no registry to update and no layout to adjust — the
+figure at fifty entries is the same figure it is at five.
+
+```
+dreams/<YYYY-MM-DD>-<slug>.md
+```
+
+```yaml
+---
+title: Geometry — the gnomon, and drawing the gaps   # required
+date: 2026-08-11                                     # required
+motifs: [geometry, growth, gnomon]                   # required — the eigenmodes, not tags
+session: de3ec5d7                                    # transcript id, or "unrecorded"
+seed: "the seed the dream was given"
+trigger: "why it was invoked"
+recovered: full            # full | partial | summary | none
+movements: 1               # more than one if the dream was re-entered
+glows:                     # the fragments that carried energy
+  - "One sentence per fragment."
+downstream:                # what it became — issues, code, memory
+  - "issue: #460"
+---
+```
+
+Then `npm run build-dreams` and commit both the entry and the regenerated atlas.
+
+A note on `motifs`: they are treated as **eigenmodes**, not tags. A plate has a discrete
+spectrum — a finite vocabulary of shapes it can hold — and the motif list is the record of
+which ones a given dream excited. Reuse an existing motif when the dream genuinely rings in
+it; two dreams sharing a motif are drawn joined.
+
+A note on `recovered`: do not quietly drop a damaged entry. A loss drawn as a break is more
+informative than a gap, and it is the argument for keeping this directory at all.
+
+## Related
+
+- [`skills/dream/SKILL.md`](../skills/dream/SKILL.md) — the skill itself
+- [`skills/meditate/SKILL.md`](../skills/meditate/SKILL.md) — clears the space a dream fills
+- [`skills/breathe/SKILL.md`](../skills/breathe/SKILL.md) — the buffer that protects fragments
+  from premature evaluation on waking
+- [`agents/contemplative.md`](../agents/contemplative.md) — the agent that carries these practices

--- a/dreams/README.md
+++ b/dreams/README.md
@@ -14,6 +14,24 @@ dream lived in a Claude Code plan file that has since been deleted; the glyph dr
 never emitted as text at all. A dream held only in a session transcript is one cleanup away
 from gone. Writing it here is what makes it durable.
 
+## Five is a floor, not a census
+
+The initial five entries were recovered by scanning 15 session transcripts for a `^#+ *Dream`
+heading plus a length heuristic. **That is a fact about the search, not about the corpus.**
+The probe cannot see:
+
+- a dream that produced no heading — which is the *canonical* shape, since the skill itself
+  says dreams produce "fragments, not blueprints" and sets no expected structure
+- a short dream, which the length floor drops — again the canonical shape
+- a heading worded differently (`## Dreaming`, `## The Dream`, lowercase)
+- a session whose transcript is gone, or whose early turns were compacted away — a class
+  proven non-empty by the two damaged entries above
+- a `/dream` run from a sibling project directory
+
+So the corpus starts at five because five is what one bounded probe returned. If you find an
+older dream, add it; the atlas has no notion of a complete set, and an entry dated before the
+newest simply takes its place in the spiral.
+
 ## The atlas
 
 [`atlas.html`](atlas.html) draws the whole corpus as one figure — open it in a browser, or
@@ -70,8 +88,15 @@ spectrum — a finite vocabulary of shapes it can hold — and the motif list is
 which ones a given dream excited. Reuse an existing motif when the dream genuinely rings in
 it; two dreams sharing a motif are drawn joined.
 
-A note on `recovered`: do not quietly drop a damaged entry. A loss drawn as a break is more
-informative than a gap, and it is the argument for keeping this directory at all.
+A note on `recovered`: the four values are a **closed set**, and the generator refuses
+anything outside it rather than guessing. `intact` and the damage note both key off the
+exact string, so a typo — `Full`, `parital` — would otherwise draw the dream as damaged,
+print no explanation, and quietly make the "N intact" count wrong. Adding a fifth state
+means editing `RECOVERY_STATES` in the generator; that is the one part of the gnomon rule
+that is *not* free, and it is deliberate.
+
+And do not quietly drop a damaged entry. A loss drawn as a break is more informative than a
+gap, and it is the argument for keeping this directory at all.
 
 ## Related
 

--- a/dreams/atlas.html
+++ b/dreams/atlas.html
@@ -211,7 +211,8 @@ a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px s
   </header>
 
   <div class="plate">
-    <canvas id="plate" aria-label="Spiral of 5 dream marks, each a nodal sand figure. Details follow below."></canvas>
+    <canvas id="plate" tabindex="0" role="img"
+      aria-label="Spiral of 5 dream marks, each a nodal sand figure. Focus it and use the arrow keys to step through entries; every entry is also listed in full below."></canvas>
     <div class="readout" id="readout" data-empty="true"></div>
   </div>
   <div class="key">
@@ -233,9 +234,9 @@ a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px s
       <span class="sess">1,054 words</span>
     </div>
     <div>
-      <h3><a href="2026-08-11-geometry.md">Geometry — the gnomon, and drawing the gaps</a></h3>
+      <h3><a href="https://github.com/pjt222/agent-almanac/blob/main/dreams/2026-08-11-geometry.md">Geometry — the gnomon, and drawing the gaps</a></h3>
       <p class="seed">Seed: geometry — the shape of an archive that grows; how a corpus of dreams should be drawn</p>
-      <ul class="glows"><li>The gnomon: the increment that makes the figure larger and the same shape.</li><li>Golden-angle placement — 137.5°·n at radius √n — is a gnomon in polar form.</li><li>Draw the unconformity. The losses are the most information-dense marks on the section.</li><li>Motifs are eigenmodes, not tags — the shapes this particular plate can ring in.</li><li>The nautilus seals off the old chambers and they become buoyancy, not ballast.</li><li>Warburg's Denkraum: the space between panels is where the thought lives. Resist the legend.</li></ul>
+      <ul class="glows"><li>The gnomon: the increment that makes the figure larger and the same shape.</li><li>Golden-angle placement — 137.5°·n at radius √n — is a gnomon in polar form.</li><li>Draw the unconformity. The losses are the most information-dense marks on the section.</li><li>Motifs are eigenmodes, not tags — the shapes this particular plate can ring in.</li><li>The nautilus seals off the old chambers and they become buoyancy, not ballast.</li><li>Warburg&#39;s Denkraum: the space between panels is where the thought lives. Resist the legend.</li></ul>
       <div class="motifs"><b>geometry</b><b>growth</b><b>gnomon</b><b>spiral</b><b>stratigraphy</b><b>constellation</b><b>self-similarity</b><b>cymatics</b><b>radial-form</b></div>
       
     </div>
@@ -247,7 +248,7 @@ a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px s
       <span class="sess">355 words</span>
     </div>
     <div>
-      <h3><a href="2026-08-11-fractals-cymatics.md">Fractals and Cymatics — the bounded probe, and the figure made of nulls</a></h3>
+      <h3><a href="https://github.com/pjt222/agent-almanac/blob/main/dreams/2026-08-11-fractals-cymatics.md">Fractals and Cymatics — the bounded probe, and the figure made of nulls</a></h3>
       <p class="seed">Seed: {fractals, cymatics}</p>
       <ul class="glows"><li>The bounded probe is self-similar — the identical error at six magnifications.</li><li>Sand collects at the nodes: every finding that session came from a null.</li><li>A Chladni figure depends on where the plate is clamped.</li><li>Before trusting a zero, ask what is holding the plate.</li></ul>
       <div class="motifs"><b>fractals</b><b>cymatics</b><b>self-similarity</b><b>nodes</b><b>clamping</b><b>absent-alarm</b><b>proof</b></div>
@@ -261,7 +262,7 @@ a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px s
       <span class="sess">1,465 words</span>
     </div>
     <div>
-      <h3><a href="2026-07-30-mechanical.md">Of a Mechanical — escapement, proof marks, and the missing click</a></h3>
+      <h3><a href="https://github.com/pjt222/agent-almanac/blob/main/dreams/2026-07-30-mechanical.md">Of a Mechanical — escapement, proof marks, and the missing click</a></h3>
       <p class="seed">Seed: of a mechanical</p>
       <ul class="glows"><li>The missing click — a ratchet with the pawl removed spins freely and silently.</li><li>Proof the yeast: the cheapest habit, performed before the expensive irreversible step.</li><li>The calibration sticker that expires makes staleness structural rather than moral.</li><li>Proof mark on the artifact, not the pipeline — the evidence travels with the thing.</li><li>Painless injury: a codebase green everywhere is not healthy, it is anesthetized.</li><li>Remontoire — decouple verification force from human state.</li><li>Keep the cupel: the killed mutants are the content of the proof mark.</li><li>Riffle — friction as instrument, not as cost.</li></ul>
       <div class="motifs"><b>mechanism</b><b>horology</b><b>assay</b><b>proof</b><b>absent-alarm</b></div>
@@ -275,7 +276,7 @@ a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px s
       <span class="sess">192 words</span>
     </div>
     <div>
-      <h3><a href="2026-07-12-glyph-concepts.md">Glyph concepts for eight new entities</a></h3>
+      <h3><a href="https://github.com/pjt222/agent-almanac/blob/main/dreams/2026-07-12-glyph-concepts.md">Glyph concepts for eight new entities</a></h3>
       <p class="seed">Seed: glyph/icon concepts for 8 new agent-almanac entities: skills benchmark-htr-engines (OCR/HTR benchmarking), verify-web-app-runtime (headless pixel proof), run-copilot-review-loop (bot review cascade), generative-recipe-dsl (data-not-code generation), stale-proof-rendered-numbers (build-failing stale figures); agent frontend-runtime-verifier; team visual-pr-review; new ocr domain visual identity</p>
       
       <div class="motifs"><b>glyph</b><b>visual-identity</b><b>pictogram</b></div>
@@ -295,9 +296,9 @@ a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px s
       <span class="sess">403 words</span>
     </div>
     <div>
-      <h3><a href="2026-03-18-campfire.md">Campfire — the CLI as a place where capabilities gather</a></h3>
+      <h3><a href="https://github.com/pjt222/agent-almanac/blob/main/dreams/2026-03-18-campfire.md">Campfire — the CLI as a place where capabilities gather</a></h3>
       <p class="seed">Seed: CLI team installation UX</p>
-      <ul class="glows"><li>gather / scatter / tend / campfire replace install / uninstall / update / list.</li><li>Fire size is team size: candle → bonfire → wildfire. Fire state is burning / embers / cold.</li><li>Hearth-keepers are agents at multiple fires; wanderers are solo agents.</li><li>The closing line is always the fire's state — 'The fire burns.' / 'The fire goes out.'</li><li>Campfire mode warms an existing palette rather than being a tenth palette.</li></ul>
+      <ul class="glows"><li>gather / scatter / tend / campfire replace install / uninstall / update / list.</li><li>Fire size is team size: candle → bonfire → wildfire. Fire state is burning / embers / cold.</li><li>Hearth-keepers are agents at multiple fires; wanderers are solo agents.</li><li>The closing line is always the fire&#39;s state — &#39;The fire burns.&#39; / &#39;The fire goes out.&#39;</li><li>Campfire mode warms an existing palette rather than being a tenth palette.</li></ul>
       <div class="motifs"><b>hearth</b><b>gathering</b><b>ceremony</b><b>radial-form</b><b>warmth</b></div>
       <div class="break">
         <svg width="52" height="10" viewBox="0 0 52 10" aria-hidden="true">
@@ -664,10 +665,35 @@ a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px s
     if (i >= 0) location.hash = DATA.nodes[i].id;
   });
 
+  // Keyboard parity for the pointer interaction above. The canvas carries tabindex="0", so
+  // arrow keys step through the marks in placement order and Enter opens the focused entry.
+  canvas.addEventListener('keydown', function (ev) {
+    var n = placed.length;
+    if (!n) return;
+    if (ev.key === 'ArrowRight' || ev.key === 'ArrowDown') { hot = (hot + 1 + n) % n; }
+    else if (ev.key === 'ArrowLeft' || ev.key === 'ArrowUp') { hot = (hot <= 0 ? n : hot) - 1; }
+    else if (ev.key === 'Escape') { hot = -1; }
+    else if ((ev.key === 'Enter' || ev.key === ' ') && hot >= 0) { location.hash = DATA.nodes[hot].id; return; }
+    else return;
+    ev.preventDefault();
+    setReadout(hot);
+    render();
+  });
+  canvas.addEventListener('blur', function () { hot = -1; setReadout(-1); render(); });
+
   function resize() { layout(); render(); }
   window.addEventListener('resize', resize);
   var mq = window.matchMedia('(prefers-color-scheme: dark)');
   if (mq.addEventListener) mq.addEventListener('change', function () { render(); });
+
+  // The canvas reads its palette imperatively at paint time, so a CSS-only theme change
+  // repaints the page around a figure still drawn in the old colours. The media query above
+  // covers the system-preference case; a host that stamps data-theme after load does not
+  // fire it, and the stamped case is exactly what the [data-theme] CSS blocks exist for.
+  if (window.MutationObserver) {
+    new MutationObserver(function () { render(); })
+      .observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+  }
 
   layout();
   setReadout(-1);

--- a/dreams/atlas.html
+++ b/dreams/atlas.html
@@ -615,18 +615,29 @@ a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px s
     });
   }
 
+  // Built with textContent rather than innerHTML: these strings come from author-written
+  // frontmatter, and a title containing markup would otherwise be parsed as markup.
+  function span(cls, text, colour) {
+    var el = document.createElement('span');
+    el.className = cls;
+    el.textContent = text;
+    if (colour) el.style.color = colour;
+    return el;
+  }
+
   function setReadout(i) {
+    readout.textContent = '';
     if (i < 0) {
       readout.setAttribute('data-empty', 'true');
-      readout.innerHTML = '<span class="t">' + DATA.nodes.length + ' dreams, placed by golden angle at root-n</span>';
+      readout.appendChild(span('t', DATA.nodes.length + ' dreams, placed by golden angle at root-n'));
       return;
     }
     var d = DATA.nodes[i];
     readout.setAttribute('data-empty', 'false');
-    readout.innerHTML = '<span class="t">' + d.title + '</span>'
-      + '<span class="m">' + d.date + '</span>'
-      + '<span class="m">' + d.motifs.join(' &middot; ') + '</span>'
-      + (d.intact ? '' : '<span class="m" style="color:var(--madder)">' + d.recovered + '</span>');
+    readout.appendChild(span('t', d.title));
+    readout.appendChild(span('m', d.date));
+    readout.appendChild(span('m', d.motifs.join(' \u00b7 ')));
+    if (!d.intact) readout.appendChild(span('m', d.recovered, 'var(--madder)'));
   }
 
   function pick(ev) {

--- a/dreams/atlas.html
+++ b/dreams/atlas.html
@@ -1,0 +1,686 @@
+<title>Dream Atlas — agent-almanac</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>
+:root {
+  color-scheme: light dark;
+  --cloth: #efe9dc;
+  --cloth-deep: #e4dccb;
+  --ink: #1d2028;
+  --ink-soft: #55575e;
+  --ink-faint: #8a897f;
+  --rule: #cec5b1;
+  --sand: #33353c;
+  --brass: #9a6a1f;
+  --verdigris: #3f6f66;
+  --madder: #97372d;
+  --shadow: rgba(29, 32, 40, 0.10);
+  --display: "Iowan Old Style", "Palatino Linotype", Palatino, "URW Palladio L", "Book Antiqua", Georgia, serif;
+  --body: Charter, "Bitstream Charter", "Sitka Text", Cambria, Georgia, serif;
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas, monospace;
+  --measure: 34rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --cloth: #14161d;
+    --cloth-deep: #0e1015;
+    --ink: #e8e1d1;
+    --ink-soft: #a6a294;
+    --ink-faint: #6d6c66;
+    --rule: #2b2e38;
+    --sand: #e8e1d1;
+    --brass: #c9944a;
+    --verdigris: #6fa298;
+    --madder: #bd5a4c;
+    --shadow: rgba(0, 0, 0, 0.5);
+  }
+}
+:root[data-theme="dark"] {
+  --cloth: #14161d;
+  --cloth-deep: #0e1015;
+  --ink: #e8e1d1;
+  --ink-soft: #a6a294;
+  --ink-faint: #6d6c66;
+  --rule: #2b2e38;
+  --sand: #e8e1d1;
+  --brass: #c9944a;
+  --verdigris: #6fa298;
+  --madder: #bd5a4c;
+  --shadow: rgba(0, 0, 0, 0.5);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--cloth);
+  color: var(--ink);
+  font-family: var(--body);
+  font-size: 17px;
+  line-height: 1.62;
+  -webkit-font-smoothing: antialiased;
+}
+
+.wrap { max-width: 72rem; margin: 0 auto; padding: 0 1.5rem 6rem; }
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* --- masthead ---------------------------------------------------------- */
+
+.masthead { padding: 4.5rem 0 1.25rem; display: flex; flex-direction: column; gap: 0.9rem; }
+.masthead h1 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(2.6rem, 7vw, 4.6rem);
+  line-height: 1.02;
+  letter-spacing: -0.015em;
+  margin: 0;
+  text-wrap: balance;
+}
+.masthead h1 em { font-style: italic; color: var(--brass); }
+.standfirst {
+  max-width: var(--measure);
+  color: var(--ink-soft);
+  font-size: 1.06rem;
+  margin: 0;
+}
+
+/* --- the plate --------------------------------------------------------- */
+
+.plate {
+  position: relative;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: var(--cloth-deep);
+}
+.plate canvas { display: block; width: 100%; height: auto; touch-action: manipulation; }
+.readout {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  padding: 0.85rem 1.1rem;
+  display: flex; flex-wrap: wrap; gap: 0.35rem 1.1rem; align-items: baseline;
+  background: linear-gradient(to top, var(--cloth-deep), transparent);
+  pointer-events: none;
+  min-height: 3.1rem;
+}
+.readout .t { font-family: var(--display); font-size: 1.02rem; }
+.readout .m { font-family: var(--mono); font-size: 0.68rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-faint); }
+.readout[data-empty="true"] .t { color: var(--ink-faint); font-style: italic; }
+
+.key {
+  display: flex; flex-wrap: wrap; gap: 0.4rem 1.6rem;
+  padding: 0.9rem 0 0;
+  font-family: var(--mono); font-size: 0.68rem; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--ink-faint);
+}
+.key span { display: inline-flex; align-items: center; gap: 0.5rem; }
+.key i { width: 0.7rem; height: 0.7rem; border-radius: 50%; display: inline-block; }
+
+/* --- strata ------------------------------------------------------------ */
+
+.section-head {
+  display: flex; align-items: baseline; gap: 1rem;
+  margin: 4.5rem 0 0; padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--rule);
+}
+.section-head h2 {
+  font-family: var(--display); font-weight: 400; font-size: 1.5rem; margin: 0;
+}
+
+.strata { display: flex; flex-direction: column; }
+
+.stratum {
+  display: grid;
+  grid-template-columns: 9.5rem minmax(0, 1fr);
+  gap: 0 2.5rem;
+  padding: 2.1rem 0;
+  border-bottom: 1px solid var(--rule);
+  scroll-margin-top: 1.5rem;
+}
+.stratum:target { background: color-mix(in srgb, var(--brass) 9%, transparent); }
+.stratum .stamp { display: flex; flex-direction: column; gap: 0.4rem; }
+.stratum .stamp .date { font-family: var(--mono); font-size: 0.82rem; color: var(--ink); font-variant-numeric: tabular-nums; }
+.stratum .stamp .sess { font-family: var(--mono); font-size: 0.68rem; color: var(--ink-faint); }
+.stratum h3 {
+  font-family: var(--display); font-weight: 400; font-size: 1.42rem; line-height: 1.25;
+  margin: 0 0 0.55rem; text-wrap: balance;
+}
+.stratum h3 a { color: inherit; text-decoration: none; border-bottom: 1px solid var(--rule); }
+.stratum h3 a:hover, .stratum h3 a:focus-visible { border-bottom-color: var(--brass); color: var(--brass); }
+.seed { max-width: var(--measure); color: var(--ink-soft); font-style: italic; margin: 0 0 0.9rem; }
+
+.glows { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 0.42rem; max-width: var(--measure); }
+.glows li { position: relative; padding-left: 1.15rem; }
+.glows li::before {
+  content: ""; position: absolute; left: 0; top: 0.62em;
+  width: 0.42rem; height: 0.42rem; background: var(--brass); border-radius: 50%;
+}
+
+.motifs { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 1rem; }
+.motifs b {
+  font-family: var(--mono); font-weight: 400; font-size: 0.66rem;
+  letter-spacing: 0.11em; text-transform: uppercase;
+  color: var(--verdigris); border: 1px solid var(--rule);
+  padding: 0.2rem 0.5rem; border-radius: 2px;
+}
+
+.break {
+  display: flex; align-items: center; gap: 0.85rem;
+  margin: 1rem 0 0; color: var(--madder);
+  font-family: var(--mono); font-size: 0.68rem; letter-spacing: 0.11em; text-transform: uppercase;
+}
+.break svg { flex: 0 0 auto; }
+.break p { margin: 0; font-family: var(--body); font-size: 0.92rem; letter-spacing: 0; text-transform: none; color: var(--ink-soft); }
+
+/* --- spectrum ---------------------------------------------------------- */
+
+.spectrum { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 1.75rem; max-width: 46rem; }
+.mode { display: grid; grid-template-columns: 11rem 1fr 2.5rem; gap: 1rem; align-items: center; }
+.mode .name { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.11em; text-transform: uppercase; color: var(--ink-soft); }
+.mode .bar { height: 0.45rem; background: var(--rule); position: relative; }
+.mode .bar b { position: absolute; inset: 0 auto 0 0; background: var(--verdigris); display: block; }
+.mode .n { font-family: var(--mono); font-size: 0.78rem; color: var(--ink-faint); text-align: right; font-variant-numeric: tabular-nums; }
+
+/* --- colophon ---------------------------------------------------------- */
+
+.colophon { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); max-width: var(--measure); color: var(--ink-soft); font-size: 0.95rem; }
+.colophon code { font-family: var(--mono); font-size: 0.86em; color: var(--ink); }
+.colophon p { margin: 0 0 0.9rem; }
+
+a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px solid var(--brass); outline-offset: 3px; }
+
+@media (max-width: 44rem) {
+  .stratum { grid-template-columns: 1fr; gap: 0.9rem; }
+  .mode { grid-template-columns: 7.5rem 1fr 2.2rem; }
+  .masthead { padding-top: 2.75rem; }
+}
+</style>
+<div class="wrap">
+  <header class="masthead">
+    <span class="eyebrow">agent-almanac &middot; dreams</span>
+    <h1>The Dream <em>Atlas</em></h1>
+    <p class="standfirst">Every <code>/dream</code> this repository has kept, drawn as one figure. Each
+      mark is a Chladni sand field whose modes come from the dream's own motifs; each is placed at the
+      golden angle, so the figure grows without ever being redrawn. Red breaks are losses.</p>
+  </header>
+
+  <div class="plate">
+    <canvas id="plate" aria-label="Spiral of 5 dream marks, each a nodal sand figure. Details follow below."></canvas>
+    <div class="readout" id="readout" data-empty="true"></div>
+  </div>
+  <div class="key">
+    <span><i style="background:var(--brass)"></i>newest &mdash; the lit chamber</span>
+    <span><i style="background:var(--sand)"></i>sealed &mdash; earlier dreams</span>
+    <span><i style="background:var(--verdigris)"></i>shared motif</span>
+    <span><i style="background:var(--madder)"></i>unconformity &mdash; text lost</span>
+  </div>
+
+  <div class="section-head">
+    <h2>Strata</h2>
+    <span class="eyebrow">newest first &middot; 5 entries &middot; 3 intact</span>
+  </div>
+  <div class="strata">
+    <article class="stratum" id="2026-08-11-geometry">
+    <div class="stamp">
+      <span class="date">2026-08-11</span>
+      <span class="sess">session de3ec5d7</span>
+      <span class="sess">1,054 words</span>
+    </div>
+    <div>
+      <h3><a href="2026-08-11-geometry.md">Geometry — the gnomon, and drawing the gaps</a></h3>
+      <p class="seed">Seed: geometry — the shape of an archive that grows; how a corpus of dreams should be drawn</p>
+      <ul class="glows"><li>The gnomon: the increment that makes the figure larger and the same shape.</li><li>Golden-angle placement — 137.5°·n at radius √n — is a gnomon in polar form.</li><li>Draw the unconformity. The losses are the most information-dense marks on the section.</li><li>Motifs are eigenmodes, not tags — the shapes this particular plate can ring in.</li><li>The nautilus seals off the old chambers and they become buoyancy, not ballast.</li><li>Warburg's Denkraum: the space between panels is where the thought lives. Resist the legend.</li></ul>
+      <div class="motifs"><b>geometry</b><b>growth</b><b>gnomon</b><b>spiral</b><b>stratigraphy</b><b>constellation</b><b>self-similarity</b><b>cymatics</b><b>radial-form</b></div>
+      
+    </div>
+  </article>
+<article class="stratum" id="2026-08-11-fractals-cymatics">
+    <div class="stamp">
+      <span class="date">2026-08-11</span>
+      <span class="sess">session 3682ab2e</span>
+      <span class="sess">355 words</span>
+    </div>
+    <div>
+      <h3><a href="2026-08-11-fractals-cymatics.md">Fractals and Cymatics — the bounded probe, and the figure made of nulls</a></h3>
+      <p class="seed">Seed: {fractals, cymatics}</p>
+      <ul class="glows"><li>The bounded probe is self-similar — the identical error at six magnifications.</li><li>Sand collects at the nodes: every finding that session came from a null.</li><li>A Chladni figure depends on where the plate is clamped.</li><li>Before trusting a zero, ask what is holding the plate.</li></ul>
+      <div class="motifs"><b>fractals</b><b>cymatics</b><b>self-similarity</b><b>nodes</b><b>clamping</b><b>absent-alarm</b><b>proof</b></div>
+      
+    </div>
+  </article>
+<article class="stratum" id="2026-07-30-mechanical">
+    <div class="stamp">
+      <span class="date">2026-07-30</span>
+      <span class="sess">session 8756c2db &middot; 2 movements</span>
+      <span class="sess">1,465 words</span>
+    </div>
+    <div>
+      <h3><a href="2026-07-30-mechanical.md">Of a Mechanical — escapement, proof marks, and the missing click</a></h3>
+      <p class="seed">Seed: of a mechanical</p>
+      <ul class="glows"><li>The missing click — a ratchet with the pawl removed spins freely and silently.</li><li>Proof the yeast: the cheapest habit, performed before the expensive irreversible step.</li><li>The calibration sticker that expires makes staleness structural rather than moral.</li><li>Proof mark on the artifact, not the pipeline — the evidence travels with the thing.</li><li>Painless injury: a codebase green everywhere is not healthy, it is anesthetized.</li><li>Remontoire — decouple verification force from human state.</li><li>Keep the cupel: the killed mutants are the content of the proof mark.</li><li>Riffle — friction as instrument, not as cost.</li></ul>
+      <div class="motifs"><b>mechanism</b><b>horology</b><b>assay</b><b>proof</b><b>absent-alarm</b></div>
+      
+    </div>
+  </article>
+<article class="stratum" id="2026-07-12-glyph-concepts">
+    <div class="stamp">
+      <span class="date">2026-07-12</span>
+      <span class="sess">session 4cddbcfd</span>
+      <span class="sess">192 words</span>
+    </div>
+    <div>
+      <h3><a href="2026-07-12-glyph-concepts.md">Glyph concepts for eight new entities</a></h3>
+      <p class="seed">Seed: glyph/icon concepts for 8 new agent-almanac entities: skills benchmark-htr-engines (OCR/HTR benchmarking), verify-web-app-runtime (headless pixel proof), run-copilot-review-loop (bot review cascade), generative-recipe-dsl (data-not-code generation), stale-proof-rendered-numbers (build-failing stale figures); agent frontend-runtime-verifier; team visual-pr-review; new ocr domain visual identity</p>
+      
+      <div class="motifs"><b>glyph</b><b>visual-identity</b><b>pictogram</b></div>
+      <div class="break">
+        <svg width="52" height="10" viewBox="0 0 52 10" aria-hidden="true">
+          <path d="M0 5 q 3.25 -4 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0"
+                fill="none" stroke="currentColor" stroke-width="1.4" />
+        </svg>
+        <p>The dream text was never emitted. Only its seed and its output survive.</p>
+      </div>
+    </div>
+  </article>
+<article class="stratum" id="2026-03-18-campfire">
+    <div class="stamp">
+      <span class="date">2026-03-18</span>
+      <span class="sess">session unrecorded</span>
+      <span class="sess">403 words</span>
+    </div>
+    <div>
+      <h3><a href="2026-03-18-campfire.md">Campfire — the CLI as a place where capabilities gather</a></h3>
+      <p class="seed">Seed: CLI team installation UX</p>
+      <ul class="glows"><li>gather / scatter / tend / campfire replace install / uninstall / update / list.</li><li>Fire size is team size: candle → bonfire → wildfire. Fire state is burning / embers / cold.</li><li>Hearth-keepers are agents at multiple fires; wanderers are solo agents.</li><li>The closing line is always the fire's state — 'The fire burns.' / 'The fire goes out.'</li><li>Campfire mode warms an existing palette rather than being a tenth palette.</li></ul>
+      <div class="motifs"><b>hearth</b><b>gathering</b><b>ceremony</b><b>radial-form</b><b>warmth</b></div>
+      <div class="break">
+        <svg width="52" height="10" viewBox="0 0 52 10" aria-hidden="true">
+          <path d="M0 5 q 3.25 -4 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0"
+                fill="none" stroke="currentColor" stroke-width="1.4" />
+        </svg>
+        <p>The full text is lost with its container. What remains is a condensation written at the time.</p>
+      </div>
+    </div>
+  </article>
+  </div>
+
+  <div class="section-head">
+    <h2>Modes</h2>
+    <span class="eyebrow">motifs by how often this plate rings in them</span>
+  </div>
+  <div class="spectrum">
+    <div class="mode">
+      <span class="name">absent-alarm</span>
+      <span class="bar"><b style="width:100%"></b></span>
+      <span class="n">2</span>
+    </div>
+<div class="mode">
+      <span class="name">cymatics</span>
+      <span class="bar"><b style="width:100%"></b></span>
+      <span class="n">2</span>
+    </div>
+<div class="mode">
+      <span class="name">proof</span>
+      <span class="bar"><b style="width:100%"></b></span>
+      <span class="n">2</span>
+    </div>
+<div class="mode">
+      <span class="name">radial-form</span>
+      <span class="bar"><b style="width:100%"></b></span>
+      <span class="n">2</span>
+    </div>
+<div class="mode">
+      <span class="name">self-similarity</span>
+      <span class="bar"><b style="width:100%"></b></span>
+      <span class="n">2</span>
+    </div>
+<div class="mode">
+      <span class="name">assay</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">ceremony</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">clamping</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">constellation</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">fractals</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">gathering</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">geometry</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">glyph</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">gnomon</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">growth</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">hearth</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">horology</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">mechanism</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">nodes</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">pictogram</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">spiral</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">stratigraphy</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">visual-identity</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+<div class="mode">
+      <span class="name">warmth</span>
+      <span class="bar"><b style="width:50%"></b></span>
+      <span class="n">1</span>
+    </div>
+  </div>
+
+  <div class="colophon">
+    <p>Generated from <code>dreams/*.md</code> by <code>npm run build-dreams</code>. Adding a dream is
+      adding one markdown file; nothing about this page is written by hand. That constraint is the
+      subject of the newest entry &mdash; a <em>gnomon</em> is the increment which, added to a figure,
+      makes a larger figure of the same shape.</p>
+    <p>Latest: <em>Geometry — the gnomon, and drawing the gaps</em>, 2026-08-11.</p>
+  </div>
+</div>
+<script>window.__ATLAS__ = {"nodes":[{"i":0,"id":"2026-03-18-campfire","title":"Campfire — the CLI as a place where capabilities gather","date":"2026-03-18","motifs":["hearth","gathering","ceremony","radial-form","warmth"],"recovered":"summary","intact":false,"glowCount":5,"words":403,"m":2,"n":4,"seed":1133430827},{"i":1,"id":"2026-07-12-glyph-concepts","title":"Glyph concepts for eight new entities","date":"2026-07-12","motifs":["glyph","visual-identity","pictogram"],"recovered":"none","intact":false,"glowCount":0,"words":192,"m":6,"n":5,"seed":3676381248},{"i":2,"id":"2026-07-30-mechanical","title":"Of a Mechanical — escapement, proof marks, and the missing click","date":"2026-07-30","motifs":["mechanism","horology","assay","proof","absent-alarm"],"recovered":"full","intact":true,"glowCount":8,"words":1465,"m":5,"n":3,"seed":1175097939},{"i":3,"id":"2026-08-11-fractals-cymatics","title":"Fractals and Cymatics — the bounded probe, and the figure made of nulls","date":"2026-08-11","motifs":["fractals","cymatics","self-similarity","nodes","clamping","absent-alarm","proof"],"recovered":"full","intact":true,"glowCount":4,"words":355,"m":3,"n":4,"seed":90331504},{"i":4,"id":"2026-08-11-geometry","title":"Geometry — the gnomon, and drawing the gaps","date":"2026-08-11","motifs":["geometry","growth","gnomon","spiral","stratigraphy","constellation","self-similarity","cymatics","radial-form"],"recovered":"full","intact":true,"glowCount":6,"words":1054,"m":2,"n":6,"seed":267685306}],"chords":[{"a":0,"b":4,"shared":["radial-form"],"weight":1},{"a":2,"b":3,"shared":["proof","absent-alarm"],"weight":2},{"a":3,"b":4,"shared":["cymatics","self-similarity"],"weight":2}],"spectrum":[{"name":"absent-alarm","count":2},{"name":"cymatics","count":2},{"name":"proof","count":2},{"name":"radial-form","count":2},{"name":"self-similarity","count":2},{"name":"assay","count":1},{"name":"ceremony","count":1},{"name":"clamping","count":1},{"name":"constellation","count":1},{"name":"fractals","count":1},{"name":"gathering","count":1},{"name":"geometry","count":1},{"name":"glyph","count":1},{"name":"gnomon","count":1},{"name":"growth","count":1},{"name":"hearth","count":1},{"name":"horology","count":1},{"name":"mechanism","count":1},{"name":"nodes","count":1},{"name":"pictogram","count":1},{"name":"spiral","count":1},{"name":"stratigraphy","count":1},{"name":"visual-identity","count":1},{"name":"warmth","count":1}]};</script>
+<script>
+(function () {
+  var DATA = window.__ATLAS__;
+  var canvas = document.getElementById('plate');
+  var ctx = canvas.getContext('2d');
+  var readout = document.getElementById('readout');
+  var GOLDEN = Math.PI * (3 - Math.sqrt(5));
+  var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var placed = [];
+  var hot = -1;
+  var progress = reduce ? 1 : 0;
+  var W = 0, H = 0, DPR = 1;
+
+  function rng(seed) {
+    var t = seed >>> 0;
+    return function () {
+      t += 0x6D2B79F5;
+      var r = t;
+      r = Math.imul(r ^ (r >>> 15), r | 1);
+      r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+      return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  function tok(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+
+  // Nodal function of a square plate: sand gathers where this is ~ 0.
+  function chladni(x, y, m, n) {
+    return Math.cos(n * Math.PI * x) * Math.cos(m * Math.PI * y)
+         - Math.cos(m * Math.PI * x) * Math.cos(n * Math.PI * y);
+  }
+
+  function layout() {
+    var w = canvas.parentElement.clientWidth;
+    var h = Math.max(360, Math.min(560, Math.round(w * 0.50)));
+    DPR = Math.min(window.devicePixelRatio || 1, 2);
+    W = w; H = h;
+    canvas.width = Math.round(w * DPR);
+    canvas.height = Math.round(h * DPR);
+    canvas.style.height = h + 'px';
+    ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+
+    var cx = w / 2;
+    var cy = h / 2;
+    var n = DATA.nodes.length;
+    var short = Math.min(w, h);
+    // Mark size grows a little with how much the dream carried, capped so the plate stays
+    // legible as the corpus grows.
+    var sizes = DATA.nodes.map(function (d) {
+      return short * (0.052 + Math.min(d.glowCount, 8) * 0.0048) / Math.max(1, Math.pow(n / 6, 0.28));
+    });
+    var biggest = Math.max.apply(null, sizes);
+    // Reserve the outermost mark's own radius, so the last placement never touches the edge.
+    var maxR = short * 0.5 - biggest - short * 0.035;
+    var step = n > 1 ? maxR / Math.sqrt(n - 1 + 0.75) : 0;
+    placed = DATA.nodes.map(function (d, i) {
+      var a = GOLDEN * i - Math.PI / 2;
+      var r = n > 1 ? step * Math.sqrt(i + 0.75) : 0;
+      return { d: d, x: cx + Math.cos(a) * r, y: cy + Math.sin(a) * r, r: sizes[i], a: a };
+    });
+  }
+
+  function drawChord(p, q, alpha) {
+    var mx = (p.x + q.x) / 2;
+    var my = (p.y + q.y) / 2;
+    var cx = W / 2, cy = H / 2;
+    ctx.globalAlpha = alpha;
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y);
+    ctx.quadraticCurveTo(mx + (cx - mx) * 0.55, my + (cy - my) * 0.55, q.x, q.y);
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+  }
+
+  function drawSand(p, colour, alpha, gapFrom, gapTo) {
+    var d = p.d;
+    var rand = rng(d.seed);
+    // Sample proportional to plate area, and narrow the nodal band as the plate grows,
+    // so the figure keeps a roughly constant line weight at any mark size.
+    var pts = Math.round(p.r * p.r * 6);
+    var eps = 1.6 / p.r;
+    ctx.fillStyle = colour;
+    ctx.globalAlpha = alpha;
+    for (var k = 0; k < pts; k += 1) {
+      var u = rand(), v = rand();
+      var x = u * 2 - 1, y = v * 2 - 1;
+      if (x * x + y * y > 1) continue;
+      if (Math.abs(chladni((x + 1) / 2, (y + 1) / 2, d.m, d.n)) > eps) continue;
+      if (gapFrom !== null) {
+        var ang = Math.atan2(y, x);
+        if (ang < 0) ang += Math.PI * 2;
+        if (ang >= gapFrom && ang <= gapTo) continue;
+      }
+      ctx.fillRect(p.x + x * p.r, p.y + y * p.r, 1.2, 1.2);
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  // The unconformity: a break line across the missing wedge.
+  function drawBreak(p, from, to) {
+    ctx.strokeStyle = tok('--madder');
+    ctx.lineWidth = 1.1;
+    ctx.beginPath();
+    var steps = 26;
+    for (var s = 0; s <= steps; s += 1) {
+      var t = s / steps;
+      var ang = from + (to - from) * t;
+      var wob = Math.sin(t * Math.PI * 5) * p.r * 0.09;
+      var rr = p.r * (0.96 + 0) + wob;
+      var x = p.x + Math.cos(ang) * rr;
+      var y = p.y + Math.sin(ang) * rr;
+      if (s === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+
+  function render() {
+    var sand = tok('--sand');
+    var brass = tok('--brass');
+    var verd = tok('--verdigris');
+    ctx.clearRect(0, 0, W, H);
+
+    var shown = Math.max(1, Math.round(placed.length * progress));
+
+    // chords first: they are the reading, so they sit behind the marks
+    ctx.strokeStyle = verd;
+    ctx.lineWidth = 1;
+    DATA.chords.forEach(function (c) {
+      if (c.a >= shown || c.b >= shown) return;
+      var lit = hot === c.a || hot === c.b;
+      drawChord(placed[c.a], placed[c.b], lit ? 0.55 : 0.13 + c.weight * 0.035);
+    });
+
+    // the gnomon: a shadow-line from the centre to the newest entry
+    if (placed.length > 1 && shown === placed.length) {
+      var last = placed[placed.length - 1];
+      ctx.strokeStyle = brass;
+      ctx.globalAlpha = 0.32;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([2, 5]);
+      ctx.beginPath();
+      ctx.moveTo(W / 2, H / 2);
+      ctx.lineTo(last.x, last.y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.globalAlpha = 1;
+    }
+
+    placed.forEach(function (p, i) {
+      if (i >= shown) return;
+      var newest = i === placed.length - 1;
+      var colour = newest ? brass : sand;
+      var alpha = hot === -1 ? (newest ? 0.95 : 0.72) : (hot === i ? 1 : 0.22);
+      var gapFrom = null, gapTo = null;
+      if (!p.d.intact) {
+        gapFrom = (p.d.seed % 360) * Math.PI / 180;
+        gapTo = gapFrom + (p.d.recovered === 'none' ? 1.5 : 0.85);
+      }
+      drawSand(p, colour, alpha, gapFrom, gapTo);
+      if (!p.d.intact && (hot === -1 || hot === i)) {
+        ctx.globalAlpha = hot === i ? 1 : 0.7;
+        drawBreak(p, gapFrom, gapTo);
+        ctx.globalAlpha = 1;
+      }
+    });
+  }
+
+  function setReadout(i) {
+    if (i < 0) {
+      readout.setAttribute('data-empty', 'true');
+      readout.innerHTML = '<span class="t">' + DATA.nodes.length + ' dreams, placed by golden angle at root-n</span>';
+      return;
+    }
+    var d = DATA.nodes[i];
+    readout.setAttribute('data-empty', 'false');
+    readout.innerHTML = '<span class="t">' + d.title + '</span>'
+      + '<span class="m">' + d.date + '</span>'
+      + '<span class="m">' + d.motifs.join(' &middot; ') + '</span>'
+      + (d.intact ? '' : '<span class="m" style="color:var(--madder)">' + d.recovered + '</span>');
+  }
+
+  function pick(ev) {
+    var rect = canvas.getBoundingClientRect();
+    var x = ev.clientX - rect.left;
+    var y = ev.clientY - rect.top;
+    var best = -1, bestD = Infinity;
+    placed.forEach(function (p, i) {
+      var dx = p.x - x, dy = p.y - y;
+      var dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist < p.r * 1.25 && dist < bestD) { bestD = dist; best = i; }
+    });
+    return best;
+  }
+
+  canvas.addEventListener('mousemove', function (ev) {
+    var i = pick(ev);
+    if (i !== hot) { hot = i; setReadout(i); render(); }
+    canvas.style.cursor = i >= 0 ? 'pointer' : 'default';
+  });
+  canvas.addEventListener('mouseleave', function () { hot = -1; setReadout(-1); render(); });
+  canvas.addEventListener('click', function (ev) {
+    var i = pick(ev);
+    if (i >= 0) location.hash = DATA.nodes[i].id;
+  });
+
+  function resize() { layout(); render(); }
+  window.addEventListener('resize', resize);
+  var mq = window.matchMedia('(prefers-color-scheme: dark)');
+  if (mq.addEventListener) mq.addEventListener('change', function () { render(); });
+
+  layout();
+  setReadout(-1);
+
+  if (reduce) {
+    render();
+  } else {
+    var t0 = null;
+    var dur = 320 + DATA.nodes.length * 190;
+    var tick = function (ts) {
+      if (progress >= 1) return;
+      if (t0 === null) t0 = ts;
+      var e = Math.min(1, (ts - t0) / dur);
+      progress = e * e * (3 - 2 * e);
+      render();
+      if (e < 1) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+    // The complete figure must not depend on the animation finishing. A throttled or
+    // background tab can starve requestAnimationFrame indefinitely, which would leave the
+    // atlas permanently showing its first mark only. Settle unconditionally.
+    setTimeout(function () {
+      if (progress < 1) { progress = 1; render(); }
+    }, dur + 500);
+  }
+})();
+</script>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   "scripts": {
     "update-readmes": "node scripts/generate-readmes.js",
     "check-readmes": "node scripts/generate-readmes.js --check",
+    "build-dreams": "node scripts/build-dreams.js",
+    "check-dreams": "node scripts/build-dreams.js --check",
     "validate:integrity": "bash scripts/validate-integrity.sh",
     "validate:translations": "node scripts/check-translation-freshness.js",
     "validate:i18n-parity": "node scripts/check-i18n-frontmatter-parity.js",

--- a/scripts/build-dreams.js
+++ b/scripts/build-dreams.js
@@ -40,14 +40,63 @@ const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const DREAMS_DIR = join(ROOT, 'dreams');
 const OUT = join(DREAMS_DIR, 'atlas.html');
 
+/**
+ * Entries link to their source on GitHub rather than to a sibling path. A relative
+ * `href="2026-08-11-geometry.md"` resolves beside the file locally and resolves to nothing
+ * once the page is published, which would leave every entry title a dead link in the one
+ * place the page is most likely to be read.
+ */
+const SOURCE_URL = 'https://github.com/pjt222/agent-almanac/blob/main/dreams/';
+
+/**
+ * The closed vocabulary for `recovered:`. It is closed on purpose: `intact` and the damage
+ * map below both key off these exact strings, so an unrecognised value — `Full`, a typo,
+ * anything — would silently draw a dream as damaged, omit the explanation, and make the
+ * "N intact" count wrong, with no warning. Enumerate the exemptions rather than trusting
+ * the input.
+ */
+const RECOVERY_STATES = new Map([
+  ['full', null],
+  ['partial', 'Recovered incompletely — part of the text is missing.'],
+  ['summary', 'The full text is lost with its container. What remains is a condensation written at the time.'],
+  ['none', 'The dream text was never emitted. Only its seed and its output survive.'],
+]);
+
 /** Frontmatter + body of one dream file. */
 function parseDream(file) {
   const raw = readFileSync(join(DREAMS_DIR, file), 'utf8');
   const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
   if (!m) throw new Error(`dreams/${file}: no YAML frontmatter`);
-  const meta = yaml.load(m[1]) || {};
+  let meta;
+  try {
+    meta = yaml.load(m[1]) || {};
+  } catch (err) {
+    // js-yaml names the line but not the file, and a bare YAMLException stack is a worse
+    // error than the hand-rolled checks below produce.
+    throw new Error(`dreams/${file}: frontmatter is not valid YAML — ${err.message}`);
+  }
+  const bad = (msg) => { throw new Error(`dreams/${file}: ${msg}`); };
+
   for (const field of ['title', 'date', 'motifs']) {
-    if (!meta[field]) throw new Error(`dreams/${file}: frontmatter is missing '${field}'`);
+    if (!meta[field]) bad(`frontmatter is missing '${field}'`);
+  }
+  if (!Array.isArray(meta.motifs)) bad("'motifs' must be a list, not a scalar");
+  if (!meta.motifs.length) bad("'motifs' must name at least one mode");
+  // An empty array is truthy, so the presence check above cannot catch it.
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(meta.date))) {
+    bad(`'date' must be YYYY-MM-DD (got '${meta.date}') — entries sort lexically`);
+  }
+  const recovered = String(meta.recovered || 'full');
+  if (!RECOVERY_STATES.has(recovered)) {
+    bad(`'recovered' must be one of ${[...RECOVERY_STATES.keys()].join(', ')} (got '${recovered}')`);
+  }
+  if (meta.movements !== undefined && !Number.isInteger(meta.movements)) {
+    bad(`'movements' must be a whole number (got '${meta.movements}')`);
+  }
+  for (const listField of ['glows', 'downstream']) {
+    if (meta[listField] !== undefined && !Array.isArray(meta[listField])) {
+      bad(`'${listField}' must be a list`);
+    }
   }
   return {
     id: file.replace(/\.md$/, ''),
@@ -57,8 +106,8 @@ function parseDream(file) {
     session: meta.session ? String(meta.session) : 'unrecorded',
     seed: meta.seed ? String(meta.seed).trim() : '',
     trigger: meta.trigger ? String(meta.trigger) : '',
-    motifs: (meta.motifs || []).map(String),
-    recovered: String(meta.recovered || 'full'),
+    motifs: meta.motifs.map(String),
+    recovered,
     movements: Number(meta.movements || 1),
     glows: (meta.glows || []).map(String),
     downstream: (meta.downstream || []).map(String),
@@ -103,7 +152,10 @@ function escapeHtml(s) {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replace(/"/g, '&quot;')
+    // Every attribute emitted below is double-quoted, but nothing enforces that. Escaping
+    // the apostrophe removes the dependency on an unenforced convention.
+    .replace(/'/g, '&#39;');
 }
 
 /**
@@ -582,10 +634,35 @@ const JS = `
     if (i >= 0) location.hash = DATA.nodes[i].id;
   });
 
+  // Keyboard parity for the pointer interaction above. The canvas carries tabindex="0", so
+  // arrow keys step through the marks in placement order and Enter opens the focused entry.
+  canvas.addEventListener('keydown', function (ev) {
+    var n = placed.length;
+    if (!n) return;
+    if (ev.key === 'ArrowRight' || ev.key === 'ArrowDown') { hot = (hot + 1 + n) % n; }
+    else if (ev.key === 'ArrowLeft' || ev.key === 'ArrowUp') { hot = (hot <= 0 ? n : hot) - 1; }
+    else if (ev.key === 'Escape') { hot = -1; }
+    else if ((ev.key === 'Enter' || ev.key === ' ') && hot >= 0) { location.hash = DATA.nodes[hot].id; return; }
+    else return;
+    ev.preventDefault();
+    setReadout(hot);
+    render();
+  });
+  canvas.addEventListener('blur', function () { hot = -1; setReadout(-1); render(); });
+
   function resize() { layout(); render(); }
   window.addEventListener('resize', resize);
   var mq = window.matchMedia('(prefers-color-scheme: dark)');
   if (mq.addEventListener) mq.addEventListener('change', function () { render(); });
+
+  // The canvas reads its palette imperatively at paint time, so a CSS-only theme change
+  // repaints the page around a figure still drawn in the old colours. The media query above
+  // covers the system-preference case; a host that stamps data-theme after load does not
+  // fire it, and the stamped case is exactly what the [data-theme] CSS blocks exist for.
+  if (window.MutationObserver) {
+    new MutationObserver(function () { render(); })
+      .observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+  }
 
   layout();
   setReadout(-1);
@@ -619,11 +696,7 @@ function stratum(d) {
     ? `<ul class="glows">${d.glows.map((g) => `<li>${escapeHtml(g)}</li>`).join('')}</ul>`
     : '';
   const motifs = `<div class="motifs">${d.motifs.map((t) => `<b>${escapeHtml(t)}</b>`).join('')}</div>`;
-  const damage = {
-    none: 'The dream text was never emitted. Only its seed and its output survive.',
-    summary: 'The full text is lost with its container. What remains is a condensation written at the time.',
-    partial: 'Recovered incompletely — part of the text is missing.',
-  }[d.recovered];
+  const damage = RECOVERY_STATES.get(d.recovered);
   const brk = damage
     ? `<div class="break">
         <svg width="52" height="10" viewBox="0 0 52 10" aria-hidden="true">
@@ -641,7 +714,7 @@ function stratum(d) {
       <span class="sess">${d.words.toLocaleString('en-US')} words</span>
     </div>
     <div>
-      <h3><a href="${escapeHtml(d.file)}">${escapeHtml(d.title)}</a></h3>
+      <h3><a href="${escapeHtml(SOURCE_URL + encodeURIComponent(d.file))}">${escapeHtml(d.title)}</a></h3>
       ${d.seed ? `<p class="seed">Seed: ${escapeHtml(d.seed)}</p>` : ''}
       ${glows}
       ${motifs}
@@ -667,7 +740,8 @@ function page(dreams, data) {
   </header>
 
   <div class="plate">
-    <canvas id="plate" aria-label="Spiral of ${dreams.length} dream marks, each a nodal sand figure. Details follow below."></canvas>
+    <canvas id="plate" tabindex="0" role="img"
+      aria-label="Spiral of ${dreams.length} dream marks, each a nodal sand figure. Focus it and use the arrow keys to step through entries; every entry is also listed in full below."></canvas>
     <div class="readout" id="readout" data-empty="true"></div>
   </div>
   <div class="key">
@@ -722,7 +796,8 @@ function main() {
     const current = existsSync(OUT) ? readFileSync(OUT, 'utf8') : '';
     if (current !== html) {
       console.error('build-dreams: dreams/atlas.html is stale. Run `npm run build-dreams`.');
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     console.log(`build-dreams: atlas.html is up to date (${dreams.length} dreams).`);
     return;

--- a/scripts/build-dreams.js
+++ b/scripts/build-dreams.js
@@ -1,0 +1,711 @@
+#!/usr/bin/env node
+/**
+ * Build the Dream Atlas from `dreams/<date>-<slug>.md`.
+ *
+ * The directory is a corpus of `/dream` outputs. This script renders it as one page,
+ * `dreams/atlas.html`.
+ *
+ * The design constraint is a **gnomon**: in Greek geometry, the increment which, added to a
+ * figure, produces a new figure *similar* to the original. Adding a dream must therefore
+ * require zero change here — no layout table, no per-entry coordinates, no hand-placed
+ * colour. Every position, every mark and every chord is derived from the frontmatter, so
+ * the atlas is the same figure at five entries and at fifty.
+ *
+ * Placement is the golden angle (137.5deg * n) at radius proportional to sqrt(n) — the
+ * phyllotaxis rule, which never collides and never needs relayout.
+ *
+ * Each dream's mark is a Chladni sand field: points sampled over a square plate and kept
+ * where the nodal function is near zero, which is where sand collects. The mode numbers
+ * come from the dream's own motifs, so two dreams that ring in the same modes look alike.
+ *
+ * Damaged entries (`recovered:` other than `full`) are drawn with an **unconformity** — a
+ * wedge missing from the plate and a madder-red break line across it. Losses are marks on
+ * the figure, not omissions from it.
+ *
+ * Output is a body-fragment HTML document: it carries `<title>`, `<style>` and `<script>`
+ * but no `<html>`/`<head>`/`<body>` wrapper, so the same file both opens in a browser and
+ * publishes as an Artifact without edits.
+ *
+ * Usage:
+ *   node scripts/build-dreams.js            # write dreams/atlas.html
+ *   node scripts/build-dreams.js --check    # exit 1 if the committed file is stale
+ */
+
+import { readFileSync, writeFileSync, readdirSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import * as yaml from 'js-yaml';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DREAMS_DIR = join(ROOT, 'dreams');
+const OUT = join(DREAMS_DIR, 'atlas.html');
+
+/** Frontmatter + body of one dream file. */
+function parseDream(file) {
+  const raw = readFileSync(join(DREAMS_DIR, file), 'utf8');
+  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
+  if (!m) throw new Error(`dreams/${file}: no YAML frontmatter`);
+  const meta = yaml.load(m[1]) || {};
+  for (const field of ['title', 'date', 'motifs']) {
+    if (!meta[field]) throw new Error(`dreams/${file}: frontmatter is missing '${field}'`);
+  }
+  return {
+    id: file.replace(/\.md$/, ''),
+    file,
+    title: String(meta.title),
+    date: String(meta.date),
+    session: meta.session ? String(meta.session) : 'unrecorded',
+    seed: meta.seed ? String(meta.seed).trim() : '',
+    trigger: meta.trigger ? String(meta.trigger) : '',
+    motifs: (meta.motifs || []).map(String),
+    recovered: String(meta.recovered || 'full'),
+    movements: Number(meta.movements || 1),
+    glows: (meta.glows || []).map(String),
+    downstream: (meta.downstream || []).map(String),
+    words: m[2].split(/\s+/).filter(Boolean).length,
+  };
+}
+
+function loadDreams() {
+  if (!existsSync(DREAMS_DIR)) return [];
+  return readdirSync(DREAMS_DIR)
+    .filter((f) => f.endsWith('.md') && f !== 'README.md')
+    .sort()
+    .map(parseDream)
+    .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : a.id < b.id ? -1 : 1));
+}
+
+/** Stable small hash — the mark for a given dream must be identical on every visit. */
+function hash(str) {
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i += 1) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Motif -> plate modes. A motif is not a tag but an eigenmode: a shape this plate can hold.
+ * The pair (m, n) indexes the mode, so dreams sharing motifs ring alike.
+ */
+function modesFor(dream) {
+  const key = dream.motifs.slice().sort().join('|') || dream.id;
+  const h = hash(key);
+  return {
+    m: 2 + (h % 5),
+    n: 3 + ((h >>> 8) % 6),
+    seed: hash(dream.id),
+  };
+}
+
+function buildData(dreams) {
+  const motifCount = new Map();
+  for (const d of dreams) for (const t of d.motifs) motifCount.set(t, (motifCount.get(t) || 0) + 1);
+
+  const nodes = dreams.map((d, i) => {
+    const { m, n, seed } = modesFor(d);
+    return {
+      i,
+      id: d.id,
+      title: d.title,
+      date: d.date,
+      motifs: d.motifs,
+      recovered: d.recovered,
+      intact: d.recovered === 'full',
+      glowCount: d.glows.length,
+      words: d.words,
+      m,
+      n,
+      seed,
+    };
+  });
+
+  const chords = [];
+  for (let a = 0; a < dreams.length; a += 1) {
+    for (let b = a + 1; b < dreams.length; b += 1) {
+      const shared = dreams[a].motifs.filter((t) => dreams[b].motifs.includes(t));
+      if (shared.length) chords.push({ a, b, shared, weight: shared.length });
+    }
+  }
+
+  const spectrum = [...motifCount.entries()]
+    .sort((x, y) => y[1] - x[1] || (x[0] < y[0] ? -1 : 1))
+    .map(([name, count]) => ({ name, count }));
+
+  return { nodes, chords, spectrum };
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+const CSS = `
+:root {
+  color-scheme: light dark;
+  --cloth: #efe9dc;
+  --cloth-deep: #e4dccb;
+  --ink: #1d2028;
+  --ink-soft: #55575e;
+  --ink-faint: #8a897f;
+  --rule: #cec5b1;
+  --sand: #33353c;
+  --brass: #9a6a1f;
+  --verdigris: #3f6f66;
+  --madder: #97372d;
+  --shadow: rgba(29, 32, 40, 0.10);
+  --display: "Iowan Old Style", "Palatino Linotype", Palatino, "URW Palladio L", "Book Antiqua", Georgia, serif;
+  --body: Charter, "Bitstream Charter", "Sitka Text", Cambria, Georgia, serif;
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Menlo, Consolas, monospace;
+  --measure: 34rem;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --cloth: #14161d;
+    --cloth-deep: #0e1015;
+    --ink: #e8e1d1;
+    --ink-soft: #a6a294;
+    --ink-faint: #6d6c66;
+    --rule: #2b2e38;
+    --sand: #e8e1d1;
+    --brass: #c9944a;
+    --verdigris: #6fa298;
+    --madder: #bd5a4c;
+    --shadow: rgba(0, 0, 0, 0.5);
+  }
+}
+:root[data-theme="dark"] {
+  --cloth: #14161d;
+  --cloth-deep: #0e1015;
+  --ink: #e8e1d1;
+  --ink-soft: #a6a294;
+  --ink-faint: #6d6c66;
+  --rule: #2b2e38;
+  --sand: #e8e1d1;
+  --brass: #c9944a;
+  --verdigris: #6fa298;
+  --madder: #bd5a4c;
+  --shadow: rgba(0, 0, 0, 0.5);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--cloth);
+  color: var(--ink);
+  font-family: var(--body);
+  font-size: 17px;
+  line-height: 1.62;
+  -webkit-font-smoothing: antialiased;
+}
+
+.wrap { max-width: 72rem; margin: 0 auto; padding: 0 1.5rem 6rem; }
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* --- masthead ---------------------------------------------------------- */
+
+.masthead { padding: 4.5rem 0 1.25rem; display: flex; flex-direction: column; gap: 0.9rem; }
+.masthead h1 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: clamp(2.6rem, 7vw, 4.6rem);
+  line-height: 1.02;
+  letter-spacing: -0.015em;
+  margin: 0;
+  text-wrap: balance;
+}
+.masthead h1 em { font-style: italic; color: var(--brass); }
+.standfirst {
+  max-width: var(--measure);
+  color: var(--ink-soft);
+  font-size: 1.06rem;
+  margin: 0;
+}
+
+/* --- the plate --------------------------------------------------------- */
+
+.plate {
+  position: relative;
+  margin: 2rem 0 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  background: var(--cloth-deep);
+}
+.plate canvas { display: block; width: 100%; height: auto; touch-action: manipulation; }
+.readout {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  padding: 0.85rem 1.1rem;
+  display: flex; flex-wrap: wrap; gap: 0.35rem 1.1rem; align-items: baseline;
+  background: linear-gradient(to top, var(--cloth-deep), transparent);
+  pointer-events: none;
+  min-height: 3.1rem;
+}
+.readout .t { font-family: var(--display); font-size: 1.02rem; }
+.readout .m { font-family: var(--mono); font-size: 0.68rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-faint); }
+.readout[data-empty="true"] .t { color: var(--ink-faint); font-style: italic; }
+
+.key {
+  display: flex; flex-wrap: wrap; gap: 0.4rem 1.6rem;
+  padding: 0.9rem 0 0;
+  font-family: var(--mono); font-size: 0.68rem; letter-spacing: 0.1em;
+  text-transform: uppercase; color: var(--ink-faint);
+}
+.key span { display: inline-flex; align-items: center; gap: 0.5rem; }
+.key i { width: 0.7rem; height: 0.7rem; border-radius: 50%; display: inline-block; }
+
+/* --- strata ------------------------------------------------------------ */
+
+.section-head {
+  display: flex; align-items: baseline; gap: 1rem;
+  margin: 4.5rem 0 0; padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--rule);
+}
+.section-head h2 {
+  font-family: var(--display); font-weight: 400; font-size: 1.5rem; margin: 0;
+}
+
+.strata { display: flex; flex-direction: column; }
+
+.stratum {
+  display: grid;
+  grid-template-columns: 9.5rem minmax(0, 1fr);
+  gap: 0 2.5rem;
+  padding: 2.1rem 0;
+  border-bottom: 1px solid var(--rule);
+  scroll-margin-top: 1.5rem;
+}
+.stratum:target { background: color-mix(in srgb, var(--brass) 9%, transparent); }
+.stratum .stamp { display: flex; flex-direction: column; gap: 0.4rem; }
+.stratum .stamp .date { font-family: var(--mono); font-size: 0.82rem; color: var(--ink); font-variant-numeric: tabular-nums; }
+.stratum .stamp .sess { font-family: var(--mono); font-size: 0.68rem; color: var(--ink-faint); }
+.stratum h3 {
+  font-family: var(--display); font-weight: 400; font-size: 1.42rem; line-height: 1.25;
+  margin: 0 0 0.55rem; text-wrap: balance;
+}
+.stratum h3 a { color: inherit; text-decoration: none; border-bottom: 1px solid var(--rule); }
+.stratum h3 a:hover, .stratum h3 a:focus-visible { border-bottom-color: var(--brass); color: var(--brass); }
+.seed { max-width: var(--measure); color: var(--ink-soft); font-style: italic; margin: 0 0 0.9rem; }
+
+.glows { margin: 0; padding: 0; list-style: none; display: flex; flex-direction: column; gap: 0.42rem; max-width: var(--measure); }
+.glows li { position: relative; padding-left: 1.15rem; }
+.glows li::before {
+  content: ""; position: absolute; left: 0; top: 0.62em;
+  width: 0.42rem; height: 0.42rem; background: var(--brass); border-radius: 50%;
+}
+
+.motifs { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 1rem; }
+.motifs b {
+  font-family: var(--mono); font-weight: 400; font-size: 0.66rem;
+  letter-spacing: 0.11em; text-transform: uppercase;
+  color: var(--verdigris); border: 1px solid var(--rule);
+  padding: 0.2rem 0.5rem; border-radius: 2px;
+}
+
+.break {
+  display: flex; align-items: center; gap: 0.85rem;
+  margin: 1rem 0 0; color: var(--madder);
+  font-family: var(--mono); font-size: 0.68rem; letter-spacing: 0.11em; text-transform: uppercase;
+}
+.break svg { flex: 0 0 auto; }
+.break p { margin: 0; font-family: var(--body); font-size: 0.92rem; letter-spacing: 0; text-transform: none; color: var(--ink-soft); }
+
+/* --- spectrum ---------------------------------------------------------- */
+
+.spectrum { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 1.75rem; max-width: 46rem; }
+.mode { display: grid; grid-template-columns: 11rem 1fr 2.5rem; gap: 1rem; align-items: center; }
+.mode .name { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.11em; text-transform: uppercase; color: var(--ink-soft); }
+.mode .bar { height: 0.45rem; background: var(--rule); position: relative; }
+.mode .bar b { position: absolute; inset: 0 auto 0 0; background: var(--verdigris); display: block; }
+.mode .n { font-family: var(--mono); font-size: 0.78rem; color: var(--ink-faint); text-align: right; font-variant-numeric: tabular-nums; }
+
+/* --- colophon ---------------------------------------------------------- */
+
+.colophon { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--rule); max-width: var(--measure); color: var(--ink-soft); font-size: 0.95rem; }
+.colophon code { font-family: var(--mono); font-size: 0.86em; color: var(--ink); }
+.colophon p { margin: 0 0 0.9rem; }
+
+a:focus-visible, [tabindex]:focus-visible, canvas:focus-visible { outline: 2px solid var(--brass); outline-offset: 3px; }
+
+@media (max-width: 44rem) {
+  .stratum { grid-template-columns: 1fr; gap: 0.9rem; }
+  .mode { grid-template-columns: 7.5rem 1fr 2.2rem; }
+  .masthead { padding-top: 2.75rem; }
+}
+`;
+
+/* The runtime deliberately avoids template literals so it can be embedded verbatim. */
+const JS = `
+(function () {
+  var DATA = window.__ATLAS__;
+  var canvas = document.getElementById('plate');
+  var ctx = canvas.getContext('2d');
+  var readout = document.getElementById('readout');
+  var GOLDEN = Math.PI * (3 - Math.sqrt(5));
+  var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var placed = [];
+  var hot = -1;
+  var progress = reduce ? 1 : 0;
+  var W = 0, H = 0, DPR = 1;
+
+  function rng(seed) {
+    var t = seed >>> 0;
+    return function () {
+      t += 0x6D2B79F5;
+      var r = t;
+      r = Math.imul(r ^ (r >>> 15), r | 1);
+      r ^= r + Math.imul(r ^ (r >>> 7), r | 61);
+      return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+
+  function tok(name) {
+    return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  }
+
+  // Nodal function of a square plate: sand gathers where this is ~ 0.
+  function chladni(x, y, m, n) {
+    return Math.cos(n * Math.PI * x) * Math.cos(m * Math.PI * y)
+         - Math.cos(m * Math.PI * x) * Math.cos(n * Math.PI * y);
+  }
+
+  function layout() {
+    var w = canvas.parentElement.clientWidth;
+    var h = Math.max(360, Math.min(560, Math.round(w * 0.50)));
+    DPR = Math.min(window.devicePixelRatio || 1, 2);
+    W = w; H = h;
+    canvas.width = Math.round(w * DPR);
+    canvas.height = Math.round(h * DPR);
+    canvas.style.height = h + 'px';
+    ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+
+    var cx = w / 2;
+    var cy = h / 2;
+    var n = DATA.nodes.length;
+    var short = Math.min(w, h);
+    // Mark size grows a little with how much the dream carried, capped so the plate stays
+    // legible as the corpus grows.
+    var sizes = DATA.nodes.map(function (d) {
+      return short * (0.052 + Math.min(d.glowCount, 8) * 0.0048) / Math.max(1, Math.pow(n / 6, 0.28));
+    });
+    var biggest = Math.max.apply(null, sizes);
+    // Reserve the outermost mark's own radius, so the last placement never touches the edge.
+    var maxR = short * 0.5 - biggest - short * 0.035;
+    var step = n > 1 ? maxR / Math.sqrt(n - 1 + 0.75) : 0;
+    placed = DATA.nodes.map(function (d, i) {
+      var a = GOLDEN * i - Math.PI / 2;
+      var r = n > 1 ? step * Math.sqrt(i + 0.75) : 0;
+      return { d: d, x: cx + Math.cos(a) * r, y: cy + Math.sin(a) * r, r: sizes[i], a: a };
+    });
+  }
+
+  function drawChord(p, q, alpha) {
+    var mx = (p.x + q.x) / 2;
+    var my = (p.y + q.y) / 2;
+    var cx = W / 2, cy = H / 2;
+    ctx.globalAlpha = alpha;
+    ctx.beginPath();
+    ctx.moveTo(p.x, p.y);
+    ctx.quadraticCurveTo(mx + (cx - mx) * 0.55, my + (cy - my) * 0.55, q.x, q.y);
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+  }
+
+  function drawSand(p, colour, alpha, gapFrom, gapTo) {
+    var d = p.d;
+    var rand = rng(d.seed);
+    // Sample proportional to plate area, and narrow the nodal band as the plate grows,
+    // so the figure keeps a roughly constant line weight at any mark size.
+    var pts = Math.round(p.r * p.r * 6);
+    var eps = 1.6 / p.r;
+    ctx.fillStyle = colour;
+    ctx.globalAlpha = alpha;
+    for (var k = 0; k < pts; k += 1) {
+      var u = rand(), v = rand();
+      var x = u * 2 - 1, y = v * 2 - 1;
+      if (x * x + y * y > 1) continue;
+      if (Math.abs(chladni((x + 1) / 2, (y + 1) / 2, d.m, d.n)) > eps) continue;
+      if (gapFrom !== null) {
+        var ang = Math.atan2(y, x);
+        if (ang < 0) ang += Math.PI * 2;
+        if (ang >= gapFrom && ang <= gapTo) continue;
+      }
+      ctx.fillRect(p.x + x * p.r, p.y + y * p.r, 1.2, 1.2);
+    }
+    ctx.globalAlpha = 1;
+  }
+
+  // The unconformity: a break line across the missing wedge.
+  function drawBreak(p, from, to) {
+    ctx.strokeStyle = tok('--madder');
+    ctx.lineWidth = 1.1;
+    ctx.beginPath();
+    var steps = 26;
+    for (var s = 0; s <= steps; s += 1) {
+      var t = s / steps;
+      var ang = from + (to - from) * t;
+      var wob = Math.sin(t * Math.PI * 5) * p.r * 0.09;
+      var rr = p.r * (0.96 + 0) + wob;
+      var x = p.x + Math.cos(ang) * rr;
+      var y = p.y + Math.sin(ang) * rr;
+      if (s === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  }
+
+  function render() {
+    var sand = tok('--sand');
+    var brass = tok('--brass');
+    var verd = tok('--verdigris');
+    ctx.clearRect(0, 0, W, H);
+
+    var shown = Math.max(1, Math.round(placed.length * progress));
+
+    // chords first: they are the reading, so they sit behind the marks
+    ctx.strokeStyle = verd;
+    ctx.lineWidth = 1;
+    DATA.chords.forEach(function (c) {
+      if (c.a >= shown || c.b >= shown) return;
+      var lit = hot === c.a || hot === c.b;
+      drawChord(placed[c.a], placed[c.b], lit ? 0.55 : 0.13 + c.weight * 0.035);
+    });
+
+    // the gnomon: a shadow-line from the centre to the newest entry
+    if (placed.length > 1 && shown === placed.length) {
+      var last = placed[placed.length - 1];
+      ctx.strokeStyle = brass;
+      ctx.globalAlpha = 0.32;
+      ctx.lineWidth = 1;
+      ctx.setLineDash([2, 5]);
+      ctx.beginPath();
+      ctx.moveTo(W / 2, H / 2);
+      ctx.lineTo(last.x, last.y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      ctx.globalAlpha = 1;
+    }
+
+    placed.forEach(function (p, i) {
+      if (i >= shown) return;
+      var newest = i === placed.length - 1;
+      var colour = newest ? brass : sand;
+      var alpha = hot === -1 ? (newest ? 0.95 : 0.72) : (hot === i ? 1 : 0.22);
+      var gapFrom = null, gapTo = null;
+      if (!p.d.intact) {
+        gapFrom = (p.d.seed % 360) * Math.PI / 180;
+        gapTo = gapFrom + (p.d.recovered === 'none' ? 1.5 : 0.85);
+      }
+      drawSand(p, colour, alpha, gapFrom, gapTo);
+      if (!p.d.intact && (hot === -1 || hot === i)) {
+        ctx.globalAlpha = hot === i ? 1 : 0.7;
+        drawBreak(p, gapFrom, gapTo);
+        ctx.globalAlpha = 1;
+      }
+    });
+  }
+
+  function setReadout(i) {
+    if (i < 0) {
+      readout.setAttribute('data-empty', 'true');
+      readout.innerHTML = '<span class="t">' + DATA.nodes.length + ' dreams, placed by golden angle at root-n</span>';
+      return;
+    }
+    var d = DATA.nodes[i];
+    readout.setAttribute('data-empty', 'false');
+    readout.innerHTML = '<span class="t">' + d.title + '</span>'
+      + '<span class="m">' + d.date + '</span>'
+      + '<span class="m">' + d.motifs.join(' &middot; ') + '</span>'
+      + (d.intact ? '' : '<span class="m" style="color:var(--madder)">' + d.recovered + '</span>');
+  }
+
+  function pick(ev) {
+    var rect = canvas.getBoundingClientRect();
+    var x = ev.clientX - rect.left;
+    var y = ev.clientY - rect.top;
+    var best = -1, bestD = Infinity;
+    placed.forEach(function (p, i) {
+      var dx = p.x - x, dy = p.y - y;
+      var dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist < p.r * 1.25 && dist < bestD) { bestD = dist; best = i; }
+    });
+    return best;
+  }
+
+  canvas.addEventListener('mousemove', function (ev) {
+    var i = pick(ev);
+    if (i !== hot) { hot = i; setReadout(i); render(); }
+    canvas.style.cursor = i >= 0 ? 'pointer' : 'default';
+  });
+  canvas.addEventListener('mouseleave', function () { hot = -1; setReadout(-1); render(); });
+  canvas.addEventListener('click', function (ev) {
+    var i = pick(ev);
+    if (i >= 0) location.hash = DATA.nodes[i].id;
+  });
+
+  function resize() { layout(); render(); }
+  window.addEventListener('resize', resize);
+  var mq = window.matchMedia('(prefers-color-scheme: dark)');
+  if (mq.addEventListener) mq.addEventListener('change', function () { render(); });
+
+  layout();
+  setReadout(-1);
+
+  if (reduce) {
+    render();
+  } else {
+    var t0 = null;
+    var dur = 320 + DATA.nodes.length * 190;
+    var tick = function (ts) {
+      if (progress >= 1) return;
+      if (t0 === null) t0 = ts;
+      var e = Math.min(1, (ts - t0) / dur);
+      progress = e * e * (3 - 2 * e);
+      render();
+      if (e < 1) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+    // The complete figure must not depend on the animation finishing. A throttled or
+    // background tab can starve requestAnimationFrame indefinitely, which would leave the
+    // atlas permanently showing its first mark only. Settle unconditionally.
+    setTimeout(function () {
+      if (progress < 1) { progress = 1; render(); }
+    }, dur + 500);
+  }
+})();
+`;
+
+function stratum(d) {
+  const glows = d.glows.length
+    ? `<ul class="glows">${d.glows.map((g) => `<li>${escapeHtml(g)}</li>`).join('')}</ul>`
+    : '';
+  const motifs = `<div class="motifs">${d.motifs.map((t) => `<b>${escapeHtml(t)}</b>`).join('')}</div>`;
+  const damage = {
+    none: 'The dream text was never emitted. Only its seed and its output survive.',
+    summary: 'The full text is lost with its container. What remains is a condensation written at the time.',
+    partial: 'Recovered incompletely — part of the text is missing.',
+  }[d.recovered];
+  const brk = damage
+    ? `<div class="break">
+        <svg width="52" height="10" viewBox="0 0 52 10" aria-hidden="true">
+          <path d="M0 5 q 3.25 -4 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0 t 6.5 0"
+                fill="none" stroke="currentColor" stroke-width="1.4" />
+        </svg>
+        <p>${escapeHtml(damage)}</p>
+      </div>`
+    : '';
+  const movements = d.movements > 1 ? ` &middot; ${d.movements} movements` : '';
+  return `<article class="stratum" id="${escapeHtml(d.id)}">
+    <div class="stamp">
+      <span class="date">${escapeHtml(d.date)}</span>
+      <span class="sess">session ${escapeHtml(d.session)}${movements}</span>
+      <span class="sess">${d.words.toLocaleString('en-US')} words</span>
+    </div>
+    <div>
+      <h3><a href="${escapeHtml(d.file)}">${escapeHtml(d.title)}</a></h3>
+      ${d.seed ? `<p class="seed">Seed: ${escapeHtml(d.seed)}</p>` : ''}
+      ${glows}
+      ${motifs}
+      ${brk}
+    </div>
+  </article>`;
+}
+
+function page(dreams, data) {
+  const newest = dreams[dreams.length - 1];
+  const intact = dreams.filter((d) => d.recovered === 'full').length;
+  const maxCount = Math.max(1, ...data.spectrum.map((s) => s.count));
+  return `<title>Dream Atlas — agent-almanac</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>${CSS}</style>
+<div class="wrap">
+  <header class="masthead">
+    <span class="eyebrow">agent-almanac &middot; dreams</span>
+    <h1>The Dream <em>Atlas</em></h1>
+    <p class="standfirst">Every <code>/dream</code> this repository has kept, drawn as one figure. Each
+      mark is a Chladni sand field whose modes come from the dream's own motifs; each is placed at the
+      golden angle, so the figure grows without ever being redrawn. Red breaks are losses.</p>
+  </header>
+
+  <div class="plate">
+    <canvas id="plate" aria-label="Spiral of ${dreams.length} dream marks, each a nodal sand figure. Details follow below."></canvas>
+    <div class="readout" id="readout" data-empty="true"></div>
+  </div>
+  <div class="key">
+    <span><i style="background:var(--brass)"></i>newest &mdash; the lit chamber</span>
+    <span><i style="background:var(--sand)"></i>sealed &mdash; earlier dreams</span>
+    <span><i style="background:var(--verdigris)"></i>shared motif</span>
+    <span><i style="background:var(--madder)"></i>unconformity &mdash; text lost</span>
+  </div>
+
+  <div class="section-head">
+    <h2>Strata</h2>
+    <span class="eyebrow">newest first &middot; ${dreams.length} entries &middot; ${intact} intact</span>
+  </div>
+  <div class="strata">
+    ${dreams.slice().reverse().map(stratum).join('\n')}
+  </div>
+
+  <div class="section-head">
+    <h2>Modes</h2>
+    <span class="eyebrow">motifs by how often this plate rings in them</span>
+  </div>
+  <div class="spectrum">
+    ${data.spectrum.map((s) => `<div class="mode">
+      <span class="name">${escapeHtml(s.name)}</span>
+      <span class="bar"><b style="width:${Math.round((s.count / maxCount) * 100)}%"></b></span>
+      <span class="n">${s.count}</span>
+    </div>`).join('\n')}
+  </div>
+
+  <div class="colophon">
+    <p>Generated from <code>dreams/*.md</code> by <code>npm run build-dreams</code>. Adding a dream is
+      adding one markdown file; nothing about this page is written by hand. That constraint is the
+      subject of the newest entry &mdash; a <em>gnomon</em> is the increment which, added to a figure,
+      makes a larger figure of the same shape.</p>
+    <p>Latest: <em>${escapeHtml(newest.title)}</em>, ${escapeHtml(newest.date)}.</p>
+  </div>
+</div>
+<script>window.__ATLAS__ = ${JSON.stringify(data)};</script>
+<script>${JS}</script>
+`;
+}
+
+function main() {
+  const check = process.argv.includes('--check');
+  const dreams = loadDreams();
+  if (!dreams.length) {
+    console.error('build-dreams: no dreams found in dreams/');
+    process.exit(1);
+  }
+  const html = page(dreams, buildData(dreams));
+  if (check) {
+    const current = existsSync(OUT) ? readFileSync(OUT, 'utf8') : '';
+    if (current !== html) {
+      console.error('build-dreams: dreams/atlas.html is stale. Run `npm run build-dreams`.');
+      process.exit(1);
+    }
+    console.log(`build-dreams: atlas.html is up to date (${dreams.length} dreams).`);
+    return;
+  }
+  writeFileSync(OUT, html, 'utf8');
+  const motifs = new Set(dreams.flatMap((d) => d.motifs));
+  console.log(`build-dreams: wrote dreams/atlas.html — ${dreams.length} dreams, ${motifs.size} motifs.`);
+}
+
+main();

--- a/scripts/build-dreams.js
+++ b/scripts/build-dreams.js
@@ -85,6 +85,19 @@ function hash(str) {
   return h >>> 0;
 }
 
+/**
+ * Serialise for embedding inside a `<script>` element. `JSON.stringify` alone is unsafe
+ * there: the HTML parser ends the element at the first literal `</script>`, so a title
+ * containing that sequence would break out of the data block and into markup. Escaping `<`
+ * closes it, and U+2028/U+2029 are escaped because they are JS line terminators.
+ */
+function scriptJson(value) {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
 function escapeHtml(s) {
   return String(s)
     .replace(/&/g, '&amp;')
@@ -520,18 +533,29 @@ const JS = `
     });
   }
 
+  // Built with textContent rather than innerHTML: these strings come from author-written
+  // frontmatter, and a title containing markup would otherwise be parsed as markup.
+  function span(cls, text, colour) {
+    var el = document.createElement('span');
+    el.className = cls;
+    el.textContent = text;
+    if (colour) el.style.color = colour;
+    return el;
+  }
+
   function setReadout(i) {
+    readout.textContent = '';
     if (i < 0) {
       readout.setAttribute('data-empty', 'true');
-      readout.innerHTML = '<span class="t">' + DATA.nodes.length + ' dreams, placed by golden angle at root-n</span>';
+      readout.appendChild(span('t', DATA.nodes.length + ' dreams, placed by golden angle at root-n'));
       return;
     }
     var d = DATA.nodes[i];
     readout.setAttribute('data-empty', 'false');
-    readout.innerHTML = '<span class="t">' + d.title + '</span>'
-      + '<span class="m">' + d.date + '</span>'
-      + '<span class="m">' + d.motifs.join(' &middot; ') + '</span>'
-      + (d.intact ? '' : '<span class="m" style="color:var(--madder)">' + d.recovered + '</span>');
+    readout.appendChild(span('t', d.title));
+    readout.appendChild(span('m', d.date));
+    readout.appendChild(span('m', d.motifs.join(' \\u00b7 ')));
+    if (!d.intact) readout.appendChild(span('m', d.recovered, 'var(--madder)'));
   }
 
   function pick(ev) {
@@ -681,7 +705,7 @@ function page(dreams, data) {
     <p>Latest: <em>${escapeHtml(newest.title)}</em>, ${escapeHtml(newest.date)}.</p>
   </div>
 </div>
-<script>window.__ATLAS__ = ${JSON.stringify(data)};</script>
+<script>window.__ATLAS__ = ${scriptJson(data)};</script>
 <script>${JS}</script>
 `;
 }

--- a/scripts/test/build-dreams.test.js
+++ b/scripts/test/build-dreams.test.js
@@ -1,0 +1,177 @@
+/**
+ * Behavioural tests for `scripts/build-dreams.js`.
+ *
+ * Two properties are under test, and they pull in opposite directions:
+ *
+ * 1. The **gnomon rule** — adding a dream is adding one markdown file, and the generator
+ *    does not change. Asserted by building a fixture, adding a file, and rebuilding.
+ * 2. **Nothing author-written reaches the page as markup.** The generator interpolates
+ *    frontmatter into both HTML and an inlined `<script>` data block, which are different
+ *    sinks with different escapes.
+ *
+ * `--check` is the gate that keeps the committed `atlas.html` honest, so it is tested in
+ * both directions: red when the corpus moved, green when it did not. A staleness check
+ * only ever exercised on a fresh build is the vacuous shape this repo keeps finding.
+ *
+ * Each test builds a throwaway tree holding the script and its own `dreams/`, so nothing
+ * touches the working repository (#453).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, cpSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = 'scripts/build-dreams.js';
+
+function dream(fields, body = 'Body text here.') {
+  const fm = Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join('\n');
+  return `---\n${fm}\n---\n\n${body}\n`;
+}
+
+const VALID = {
+  title: 'A Dream',
+  date: '2026-01-01',
+  motifs: '[geometry, growth]',
+  recovered: 'full',
+};
+
+/** A throwaway tree: the script, a node_modules link for js-yaml, and a dreams/ dir. */
+function fixture(files = { 'a.md': dream(VALID) }) {
+  const dir = mkdtempSync(join(tmpdir(), 'build-dreams-'));
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  mkdirSync(join(dir, 'dreams'), { recursive: true });
+  cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+  symlinkSync(join(REPO, 'node_modules'), join(dir, 'node_modules'), 'dir');
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(dir, 'dreams', name), content);
+  }
+  return dir;
+}
+
+function run(dir, args = []) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { cwd: dir, encoding: 'utf8' });
+}
+
+const atlas = (dir) => readFileSync(join(dir, 'dreams', 'atlas.html'), 'utf8');
+
+function withFixture(files, fn) {
+  const dir = fixture(files);
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --- the gnomon rule ------------------------------------------------------------------
+
+test('adding a dream file changes the atlas with no change to the generator', () => {
+  withFixture(undefined, (dir) => {
+    assert.equal(run(dir).status, 0);
+    const one = atlas(dir);
+    assert.match(one, /1 dream/);
+
+    writeFileSync(
+      join(dir, 'dreams', 'b.md'),
+      dream({ ...VALID, title: 'Second Dream', date: '2026-02-02' }),
+    );
+    const r = run(dir);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /2 dreams/);
+    assert.notEqual(atlas(dir), one, 'the atlas did not grow');
+    assert.match(atlas(dir), /Second Dream/);
+  });
+});
+
+// --- the staleness gate, in both directions -------------------------------------------
+
+test('--check is green on a fresh build and red once the corpus moves', () => {
+  withFixture(undefined, (dir) => {
+    run(dir);
+    assert.equal(run(dir, ['--check']).status, 0, '--check was red on a fresh build');
+
+    writeFileSync(join(dir, 'dreams', 'b.md'), dream({ ...VALID, title: 'Later', date: '2026-03-03' }));
+    const stale = run(dir, ['--check']);
+    assert.equal(stale.status, 1, '--check stayed green after a dream was added');
+    assert.match(stale.stderr, /stale/);
+  });
+});
+
+test('--check is red when a body edit changes the word count', () => {
+  withFixture(undefined, (dir) => {
+    run(dir);
+    writeFileSync(join(dir, 'dreams', 'a.md'), dream(VALID, 'Body text here. Plus several more words.'));
+    assert.equal(run(dir, ['--check']).status, 1);
+  });
+});
+
+// --- nothing author-written reaches the page as markup --------------------------------
+
+test('a hostile title escapes into neither the markup nor the script data block', () => {
+  const hostile = 'Why </script><img src=x onerror=alert(1)> & "quotes" & \'apostrophes\' matter';
+  withFixture({ 'a.md': dream({ ...VALID, title: JSON.stringify(hostile) }) }, (dir) => {
+    const r = run(dir);
+    assert.equal(r.status, 0, r.stderr);
+    const html = atlas(dir);
+
+    // The data block must not be closable by the title.
+    const scriptBlock = html.slice(html.indexOf('window.__ATLAS__'));
+    assert.ok(!scriptBlock.includes('</script><img'), 'the title broke out of the data block');
+    assert.ok(scriptBlock.includes('\\u003c/script'), 'the < was not escaped in the data block');
+
+    // And it must not be parsed as markup in the strata heading.
+    assert.ok(!html.includes('<img src=x'), 'the title was emitted as a live img tag');
+    assert.ok(html.includes('&lt;/script&gt;'), 'the heading did not escape the title');
+    assert.ok(html.includes('&#39;apostrophes&#39;'), 'the apostrophe was not escaped');
+  });
+});
+
+// --- default-deny on the frontmatter vocabulary ---------------------------------------
+
+test('an unrecognised recovered: value is refused, not silently drawn as damaged', () => {
+  withFixture({ 'a.md': dream({ ...VALID, recovered: 'Full' }) }, (dir) => {
+    const r = run(dir);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stderr, /a\.md/, 'the error did not name the file');
+    assert.match(r.stderr, /must be one of full, partial, summary, none/);
+  });
+});
+
+test('malformed frontmatter is refused with the file named', () => {
+  const cases = [
+    [{ ...VALID, motifs: 'geometry' }, /must be a list/],
+    [{ ...VALID, motifs: '[]' }, /at least one mode/],
+    [{ ...VALID, date: '08/11/2026' }, /must be YYYY-MM-DD/],
+    [{ ...VALID, movements: 'two' }, /must be a whole number/],
+    [{ ...VALID, glows: 'a single string' }, /'glows' must be a list/],
+  ];
+  for (const [fields, expected] of cases) {
+    withFixture({ 'a.md': dream(fields) }, (dir) => {
+      const r = run(dir);
+      assert.notEqual(r.status, 0, `accepted ${JSON.stringify(fields)}`);
+      assert.match(r.stderr, /a\.md/);
+      assert.match(r.stderr, expected);
+    });
+  }
+});
+
+// --- losses are drawn, not omitted ----------------------------------------------------
+
+test('a damaged entry renders a break and an intact one does not', () => {
+  withFixture({ 'a.md': dream({ ...VALID, recovered: 'none' }) }, (dir) => {
+    run(dir);
+    assert.match(atlas(dir), /class="break"/);
+    assert.match(atlas(dir), /never emitted/);
+    assert.match(atlas(dir), /0 intact/);
+  });
+  withFixture(undefined, (dir) => {
+    run(dir);
+    assert.ok(!atlas(dir).includes('class="break"'), 'an intact entry drew a break');
+    assert.match(atlas(dir), /1 intact/);
+  });
+});


### PR DESCRIPTION
## What

Adds `dreams/` — the kept output of the [`dream`](../blob/main/skills/dream/SKILL.md) skill — plus a generator and a visualization that grows with every entry.

`/dream` is the one skill in the library that inverts the standard format: no inputs, no validation, only fragments. Those fragments have repeatedly become infrastructure here. `scripts/mutation-check.js` and the CLAUDE.md section *"Proving a Gate Can Fail"* are the 2026-07-30 dream's **missing click** made mechanical; the `campfire` command and `viz/js/campfire.js` are the 2026-03-18 dream's vocabulary.

Until now nothing kept them.

## The losses are the argument

Five dreams were recovered from session transcripts. **Two are damaged, and both are container losses rather than content losses:**

| entry | state | why |
|---|---|---|
| 2026-03-18 campfire | `summary` | lived in a Claude Code plan file, `~/.claude/plans/vast-wibbling-bunny.md`, verified absent today |
| 2026-07-12 glyph concepts | `none` | never emitted as text — the session went from the skill load straight into tool calls |
| 2026-07-30 mechanical | `full` | two movements |
| 2026-08-11 fractals + cymatics | `full` | |
| 2026-08-11 geometry | `full` | dreamt this session; it is the design brief for the atlas |

A dream held only in a session transcript is one cleanup away from gone.

## The gnomon rule

In Greek geometry a **gnomon** is the increment which, added to a figure, produces a new figure *similar* to the original. That is the whole design constraint: adding a dream is adding one markdown file. Every position, mark, chord and colour is derived from frontmatter, so there is no registry to update and no layout to adjust — the figure at fifty entries is the same figure it is at five.

This is verified mechanically, not asserted: adding a sixth file rebuilt the atlas with zero change to the generator.

- **Placement** is the golden angle (137.5° × n) at radius ∝ √n — the phyllotaxis rule, which never collides and never needs relayout.
- **Each mark is a Chladni sand field**: points sampled over a square plate and kept where the nodal function is near zero, which is where sand collects. Mode numbers come from the dream's own motifs, so two dreams that ring in the same modes look alike.
- **Damaged entries are drawn with an unconformity** — a wedge missing from the plate and a red break line across it, the way a stratigraphic section draws missing time. A loss is a mark on the figure, not an omission from it.

## Deliberately outside the five-type machinery

No `_registry.yml`, no translation scaffolding, no plugin discovery, no README automation hook. Those obligations attach to skills/agents/teams/guides; a sixth tree that opted in would inherit five CI gates it has no use for. `dreams/` is a kept notebook, not a content tree.

Confirmed by reading the gates rather than by assuming: `check-banned-invocations.js` walks `TREES = ['skills','agents','teams','guides']`, and `check-content-style.js` uses `CONTENT_GLOBS = ["skills/","agents/","teams/","guides/","i18n/"]`. `.html`/`.md`/`.yml` already carry `text eol=lf` rules.

## Verification

Gates were shown red before being trusted:

| exercise | result |
|---|---|
| add a dream file, rebuild | 5 → 6 dreams, **zero** generator change — the gnomon rule holds |
| `--check` against a stale atlas | **exit 1**, "atlas.html is stale" |
| frontmatter missing `motifs` | **exit 1**, names the file and the field |
| `--check` on a fresh build | exit 0 |

Runtime verified with real pixels, not by reading the source: rendered headless in Chrome at light and dark, no console errors.

**That capture caught a real defect.** The complete figure depended on the reveal animation finishing, so a starved `requestAnimationFrame` — headless, or a throttled background tab — left the atlas permanently showing its first mark only. It now settles unconditionally via `setTimeout` regardless of whether rAF ever runs.

Repo validators: `validate:line-endings` OK, `validate:banned-invocations` OK (4196 files), `check-content-style --added` 0 blocking errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8