### PR TITLE
fix(skills): scope the runbook template heading to what it introduces (#517)

### DIFF
--- a/skills/write-incident-runbook/references/EXAMPLES.md
+++ b/skills/write-incident-runbook/references/EXAMPLES.md
@@ -679,11 +679,12 @@ Escalate **proactively** if:
 #### CDN Provider (e.g., Cloudflare)
 - **Critical**: +1-888-XXX-XXXX
 - **Account**: CF-67890
+- **Support Portal**: https://support.cloudflare.com
 ````
 
 ## Step 5: Complete Communication Templates
 
-### Internal Communication Templates (All Variants)
+### Communication Templates (All Variants)
 
 ````markdown
 ## Communication Templates

--- a/skills/write-incident-runbook/references/EXAMPLES.md
+++ b/skills/write-incident-runbook/references/EXAMPLES.md
@@ -684,7 +684,7 @@ Escalate **proactively** if:
 
 ## Step 5: Complete Communication Templates
 
-### Communication Templates (All Variants)
+### Communication Templates (Internal and External)
 
 ````markdown
 ## Communication Templates


### PR DESCRIPTION
Closes #517.

## The defect

`skills/write-incident-runbook/references/EXAMPLES.md` introduced a fenced template block with:

    ### Internal Communication Templates (All Variants)

The block runs internal-only for its first half — Initial Incident Declaration, Progress Update, Mitigation Announcement, Incident Resolution, False Alarm — and then continues with `### External Status Page Updates` and `### Customer Support Email Template`. A reader arrived under a heading promising *internal* and was shown customer-facing copy.

`SKILL.md:229` already describes the same target as "all internal and external templates", so the sub-heading was the narrower of the two, and the one that was wrong. Retitled to match its own parent, `## Step 5: Complete Communication Templates`.

## Also fixed

The Cloudflare vendor entry carried `**Critical**` and `**Account**` but not `**Support Portal**`, while both siblings above it (AWS, MongoDB) carry all three. #517 flagged this as worth doing if the file were touched again — it is being touched.

## Verified before treating it as an authoring slip

The issue notes this shape is also what #511's runaway-fence damage produces — a swallowed `### External Communication Templates` sibling would look identical. It is not that. The 4-backtick fence runs **688–867**, so the sub-heading sits *outside* it as a real document heading, and the two external headings sit *inside* the template content. That is the shape the issue describes, not a loss.

## Scope

**No i18n fan-out.** No locale mirror carries `references/EXAMPLES.md` at all — that is #469, still open — so this is genuinely a single-file change rather than an eleven-file one.

No other file references the old heading as an anchor (`SKILL.md`'s link targets the parent `#step-5-complete-communication-templates`, which is unchanged). `check-content-style --added` 0 blocking errors; `validate:line-endings` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8