### PR TITLE
fix(tooling): make normalize-content-style preview by default (#490)

### DIFF
--- a/scripts/normalize-content-style.js
+++ b/scripts/normalize-content-style.js
@@ -8,7 +8,12 @@
 //   separators : decorative table separator rows -> compact `|---|---|`
 //                (3 dashes/column, alignment colons preserved)
 //   fences     : untagged opening code fences    -> add a language tag
-//                (heuristic detection of bash/console/json/yaml/r/diff; `text` fallback)
+//                (`json` when the block actually parses as JSON, otherwise `text`)
+//
+// The tag heuristic infers ONLY json, deliberately — see guessLanguage below for why
+// prose-based inference of bash/yaml/r produces mostly false positives on this corpus.
+// This header previously advertised detection of bash/console/yaml/r/diff, which the
+// implementation has never done.
 //
 // It PREVIEWS by default and writes only when `--write` is passed (#490). The inverse —
 // write by default, `--dry` to preview — is what this file used to do, and it is the shape
@@ -181,61 +186,79 @@ function listFiles(scope) {
 
 // ── Main ────────────────────────────────────────────────────────────────────
 const argv = process.argv.slice(2);
-function flagVal(name) {
-  const i = argv.indexOf(name);
-  return i >= 0 ? argv[i + 1] : null;
+
+function usageError(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(2);
 }
 
-// Default-deny on flags. An unrecognised flag is a typo or a stale invocation, and
-// silently ignoring it means the run does something other than what was asked.
-const VALUE_FLAGS = new Set(["--mode", "--scope"]);
-const BOOL_FLAGS = new Set(["--write", "--dry"]);
-const filesIdx = argv.indexOf("--files");
+/**
+ * One pass, default-deny, no `indexOf` lookups.
+ *
+ * The predecessor scanned with `argv.indexOf` and stopped validating after `--files`,
+ * which left three ways to get a run other than the one you asked for — all of them
+ * silent, and two of them in the destructive direction:
+ *
+ * - a trailing value flag (`--write --mode`) read `argv[i+1]` as `undefined`, and
+ *   `undefined || "both"` then passed the enum check, so a caller who narrowed the run to
+ *   one transform got both. This is the sibling tool's documented failure verbatim: "a run
+ *   the caller had narrowed to one locale silently covered all ten ... 281 files rewritten
+ *   where 63 were asked for".
+ * - `--files a.md --write b.md` dropped `b.md`, because the list stopped at the first flag
+ *   and nothing looked at what came after.
+ * - anything after `--files` skipped validation entirely, so `--files a.md --wrote`
+ *   previewed instead of erroring — the opposite of what the default-deny block claimed.
+ */
+const opts = { write: false, dry: false, mode: null, scope: null, files: null };
 for (let i = 0; i < argv.length; i += 1) {
-  if (filesIdx >= 0 && i > filesIdx) break; // remaining args are filenames
   const a = argv[i];
-  if (!a.startsWith("--")) continue;
-  if (a === "--files" || BOOL_FLAGS.has(a)) continue;
-  if (VALUE_FLAGS.has(a)) { i += 1; continue; }
-  console.error(`ERROR: unknown flag ${a}`);
-  process.exit(2);
+  if (a === "--files") {
+    if (opts.files) usageError("--files given twice");
+    const list = [];
+    while (i + 1 < argv.length && !argv[i + 1].startsWith("--")) list.push(argv[++i]);
+    if (!list.length) usageError("--files requires at least one path");
+    opts.files = list;
+  } else if (a === "--write") {
+    opts.write = true;
+  } else if (a === "--dry") {
+    opts.dry = true;
+  } else if (a === "--mode" || a === "--scope") {
+    const v = argv[i + 1];
+    if (v === undefined || v.startsWith("--")) usageError(`${a} requires a value`);
+    opts[a.slice(2)] = v;
+    i += 1;
+  } else if (a.startsWith("--")) {
+    usageError(`unknown flag ${a}`);
+  } else {
+    usageError(`unexpected argument '${a}' — paths follow --files, which must come last`);
+  }
 }
 
 // Guessing which one the caller meant is how a preview becomes a write.
-if (argv.includes("--write") && argv.includes("--dry")) {
-  console.error("ERROR: --write and --dry contradict each other. Pass one.");
-  process.exit(2);
+if (opts.write && opts.dry) {
+  usageError("--write and --dry contradict each other. Pass one.");
 }
-const WRITE = argv.includes("--write");
+if (opts.files && opts.scope) {
+  usageError("--files and --scope select the same thing two ways. Pass one.");
+}
+const WRITE = opts.write;
 
-const mode = flagVal("--mode") || "both";
+const mode = opts.mode || "both";
 if (!["separators", "fences", "both"].includes(mode)) {
-  console.error(`ERROR: --mode must be separators|fences|both (got '${mode}')`);
-  process.exit(2);
+  usageError(`--mode must be separators|fences|both (got '${mode}')`);
 }
 const doSep = mode === "separators" || mode === "both";
 const doFence = mode === "fences" || mode === "both";
 
 let files;
 let pathspec;
-if (filesIdx >= 0) {
-  // Stop at the next flag. Filtering out only `--`-prefixed args left the VALUE of a
-  // following flag in the list, so `--files a.md --mode both` treated 'both' as a file.
-  files = [];
-  for (let i = filesIdx + 1; i < argv.length; i += 1) {
-    if (argv[i].startsWith("--")) break;
-    files.push(argv[i]);
-  }
-  if (!files.length) {
-    console.error("ERROR: --files requires at least one path");
-    process.exit(2);
-  }
+if (opts.files) {
+  files = opts.files;
   pathspec = files;
 } else {
-  const scope = flagVal("--scope") || "english";
+  const scope = opts.scope || "english";
   if (!["english", "all"].includes(scope)) {
-    console.error(`ERROR: --scope must be english|all (got '${scope}')`);
-    process.exit(2);
+    usageError(`--scope must be english|all (got '${scope}')`);
   }
   files = listFiles(scope);
   pathspec = scope === "english" ? ENGLISH_GLOBS : CONTENT_GLOBS;
@@ -244,6 +267,56 @@ if (filesIdx >= 0) {
 // Refuse to write into a dirty scope. The only undo for a bad run is `git checkout --`,
 // which would also destroy whatever uncommitted work was already there.
 if (WRITE) {
+  // `--assume-unchanged` / `--skip-worktree` make git report a file clean no matter how
+  // far the worktree has diverged, so the status check below would lie. `mutation-check`
+  // refuses to run for the same reason, and `repo-guard` compares index flags for it.
+  let lsFlags = "";
+  try {
+    lsFlags = execFileSync("git", ["ls-files", "-v", "--", ...pathspec], {
+      encoding: "utf8",
+      maxBuffer: 128 * 1024 * 1024,
+    });
+  } catch (err) {
+    usageError(`could not read the git index: ${err.message}`);
+  }
+  const masked = lsFlags
+    .split("\n")
+    .filter((line) => line && line[0] !== "H")
+    .map((line) => `  ${line}`);
+  if (masked.length) {
+    console.error("ERROR: files in scope carry a git index flag (assume-unchanged or");
+    console.error("skip-worktree). git reports those clean regardless of their real");
+    console.error("contents, so the dirty check below cannot be trusted:");
+    for (const line of masked.slice(0, 10)) console.error(line);
+    if (masked.length > 10) console.error(`  ... and ${masked.length - 10} more`);
+    console.error("Clear with:  git update-index --no-skip-worktree --no-assume-unchanged -- <path>");
+    process.exit(2);
+  }
+
+  // An ignored path is the one input class where the undo below genuinely does not
+  // exist — git holds no copy at all — and it is exactly the class `git status
+  // --porcelain` omits by design. Reachable only through `--files`.
+  if (opts.files) {
+    // `git check-ignore` exits 1 when nothing matches — the common case — so a throw here
+    // is the success path, not an error. It also reports a tracked file as not ignored,
+    // which is the semantics wanted: a tracked file is recoverable whatever the rules say.
+    let ignored = "";
+    try {
+      ignored = execFileSync("git", ["check-ignore", "--", ...files], {
+        encoding: "utf8",
+        maxBuffer: 16 * 1024 * 1024,
+      }).trim();
+    } catch (err) {
+      if (err.status !== 1) usageError(`could not check ignore rules: ${err.message}`);
+    }
+    if (ignored) {
+      console.error("ERROR: refusing to write to a git-ignored path:");
+      for (const p of ignored.split("\n")) console.error(`  ${p}`);
+      console.error("git holds no copy of an ignored file, so this write would be unrecoverable.");
+      process.exit(2);
+    }
+  }
+
   let status;
   try {
     status = execFileSync("git", ["status", "--porcelain", "--", ...pathspec], {
@@ -251,12 +324,20 @@ if (WRITE) {
       maxBuffer: 128 * 1024 * 1024,
     });
   } catch (err) {
-    console.error(`ERROR: could not determine whether the scope is clean: ${err.message}`);
-    process.exit(2);
+    usageError(`could not determine whether the scope is clean: ${err.message}`);
   }
-  if (status.trim()) {
-    console.error("ERROR: refusing to write into a dirty scope. Commit or stash first.");
-    console.error(status.trimEnd());
+  const lines = status.trim() ? status.trimEnd().split("\n") : [];
+  if (lines.length) {
+    console.error("ERROR: refusing to write into a dirty scope:");
+    for (const line of lines.slice(0, 10)) console.error(`  ${line}`);
+    if (lines.length > 10) console.error(`  ... and ${lines.length - 10} more`);
+    console.error("");
+    console.error("This tool rewrites files in place, and `git checkout --` is the only undo —");
+    // Stock "commit or stash" advice hands back a tree this guard still refuses, because
+    // plain `git stash` leaves untracked entries behind.
+    console.error(lines.some((l) => l.startsWith("??"))
+      ? "it would discard the changes above too. Commit them first, or stash them with\n`git stash -u` (plain `git stash` leaves the `??` entries behind)."
+      : "it would discard the changes above too. Commit or stash them first.");
     process.exit(2);
   }
   console.error(`normalize-content-style: WRITING to ${files.length} scanned file(s) in scope.`);

--- a/scripts/normalize-content-style.js
+++ b/scripts/normalize-content-style.js
@@ -10,12 +10,29 @@
 //   fences     : untagged opening code fences    -> add a language tag
 //                (heuristic detection of bash/console/json/yaml/r/diff; `text` fallback)
 //
+// It PREVIEWS by default and writes only when `--write` is passed (#490). The inverse —
+// write by default, `--dry` to preview — is what this file used to do, and it is the shape
+// #486 inverted in the i18n normalizer after a read-only probe agent typed the bare command
+// and silently rewrote 281 files. Every later measurement of that backlog was then wrong
+// and self-consistent. The blast radius here is larger, not smaller: `--scope all` is
+// skills/ agents/ teams/ guides/ i18n/, and the *default* scope is still every English
+// content file. The destructive mode must not be the one you get by typing the obvious
+// command.
+//
+// `--dry` is retained as an explicit no-op so old invocations keep working and keep
+// meaning what they meant. Passing both `--write` and `--dry` is an error rather than a
+// guess.
+//
+// Two further guards follow the same reasoning: it refuses to write into a dirty scope
+// (`git checkout --` is the only undo, and it would destroy uncommitted work), and it
+// announces the write on stderr before touching anything.
+//
 // Usage:
 //   node scripts/normalize-content-style.js --mode <separators|fences|both> --scope <english|all>
 //   node scripts/normalize-content-style.js --mode both --files a.md b.md ...
-//   add --dry to report changes without writing.
+//   node scripts/normalize-content-style.js --write            # apply; default is preview
 
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 
 const CONTENT_GLOBS = ["skills/", "agents/", "teams/", "guides/", "i18n/"];
@@ -168,18 +185,81 @@ function flagVal(name) {
   const i = argv.indexOf(name);
   return i >= 0 ? argv[i + 1] : null;
 }
+
+// Default-deny on flags. An unrecognised flag is a typo or a stale invocation, and
+// silently ignoring it means the run does something other than what was asked.
+const VALUE_FLAGS = new Set(["--mode", "--scope"]);
+const BOOL_FLAGS = new Set(["--write", "--dry"]);
+const filesIdx = argv.indexOf("--files");
+for (let i = 0; i < argv.length; i += 1) {
+  if (filesIdx >= 0 && i > filesIdx) break; // remaining args are filenames
+  const a = argv[i];
+  if (!a.startsWith("--")) continue;
+  if (a === "--files" || BOOL_FLAGS.has(a)) continue;
+  if (VALUE_FLAGS.has(a)) { i += 1; continue; }
+  console.error(`ERROR: unknown flag ${a}`);
+  process.exit(2);
+}
+
+// Guessing which one the caller meant is how a preview becomes a write.
+if (argv.includes("--write") && argv.includes("--dry")) {
+  console.error("ERROR: --write and --dry contradict each other. Pass one.");
+  process.exit(2);
+}
+const WRITE = argv.includes("--write");
+
 const mode = flagVal("--mode") || "both";
-const dry = argv.includes("--dry");
+if (!["separators", "fences", "both"].includes(mode)) {
+  console.error(`ERROR: --mode must be separators|fences|both (got '${mode}')`);
+  process.exit(2);
+}
 const doSep = mode === "separators" || mode === "both";
 const doFence = mode === "fences" || mode === "both";
 
 let files;
-const filesIdx = argv.indexOf("--files");
+let pathspec;
 if (filesIdx >= 0) {
-  files = argv.slice(filesIdx + 1).filter((a) => !a.startsWith("--"));
+  // Stop at the next flag. Filtering out only `--`-prefixed args left the VALUE of a
+  // following flag in the list, so `--files a.md --mode both` treated 'both' as a file.
+  files = [];
+  for (let i = filesIdx + 1; i < argv.length; i += 1) {
+    if (argv[i].startsWith("--")) break;
+    files.push(argv[i]);
+  }
+  if (!files.length) {
+    console.error("ERROR: --files requires at least one path");
+    process.exit(2);
+  }
+  pathspec = files;
 } else {
   const scope = flagVal("--scope") || "english";
+  if (!["english", "all"].includes(scope)) {
+    console.error(`ERROR: --scope must be english|all (got '${scope}')`);
+    process.exit(2);
+  }
   files = listFiles(scope);
+  pathspec = scope === "english" ? ENGLISH_GLOBS : CONTENT_GLOBS;
+}
+
+// Refuse to write into a dirty scope. The only undo for a bad run is `git checkout --`,
+// which would also destroy whatever uncommitted work was already there.
+if (WRITE) {
+  let status;
+  try {
+    status = execFileSync("git", ["status", "--porcelain", "--", ...pathspec], {
+      encoding: "utf8",
+      maxBuffer: 128 * 1024 * 1024,
+    });
+  } catch (err) {
+    console.error(`ERROR: could not determine whether the scope is clean: ${err.message}`);
+    process.exit(2);
+  }
+  if (status.trim()) {
+    console.error("ERROR: refusing to write into a dirty scope. Commit or stash first.");
+    console.error(status.trimEnd());
+    process.exit(2);
+  }
+  console.error(`normalize-content-style: WRITING to ${files.length} scanned file(s) in scope.`);
 }
 
 let totalSep = 0;
@@ -200,11 +280,12 @@ for (const f of files) {
     fenceFiles++;
   }
   if (text !== original) {
-    if (!dry) writeFileSync(f, text);
+    if (WRITE) writeFileSync(f, text);
     written++;
   }
 }
-console.log(`normalize-content-style (mode=${mode}${dry ? ", DRY" : ""}):`);
+console.log(`normalize-content-style (mode=${mode}${WRITE ? "" : ", PREVIEW"}):`);
 if (doSep) console.log(`  separators compacted: ${totalSep} across ${sepFiles} files`);
 if (doFence) console.log(`  fences tagged:        ${totalFence} across ${fenceFiles} files`);
-console.log(`  files ${dry ? "to change" : "written"}: ${written} (of ${files.length} scanned)`);
+console.log(`  files ${WRITE ? "written" : "to change"}: ${written} (of ${files.length} scanned)`);
+if (!WRITE && written) console.log("  (preview only — pass --write to apply)");

--- a/scripts/test/normalize-content-style.test.js
+++ b/scripts/test/normalize-content-style.test.js
@@ -33,6 +33,36 @@ const DECORATIVE = '| Col A | Col B |\n|-------|:------|\n| x | y |\n';
 /** What the normalizer must produce — three dashes per column, alignment colon kept. */
 const COMPACTED = '| Col A | Col B |\n|---|:---|\n| x | y |\n';
 
+/**
+ * The header of `normalize-content-style.js` states the fence-state machine as its
+ * correctness claim — "the SAME fence-state machine so 4-backtick examples that wrap
+ * 3-backtick fences are never corrupted". A guarantee asserted in a comment is a test case
+ * nobody ran, so this fixture is the corpus shape that claim is about: a 4-backtick
+ * ````markdown block wrapping a 3-backtick fence, with decorative separators both inside
+ * and outside. `skills/write-incident-runbook/references/EXAMPLES.md` is exactly this, and
+ * it is in scope (`isContentFile` accepts any `.md` under `skills/`).
+ *
+ * Only the outside separator may change.
+ */
+const NESTED = [
+  '| Outside A | Outside B |',
+  '|-----------|:----------|',
+  '| x | y |',
+  '',
+  '````markdown',
+  '| Inside A | Inside B |',
+  '|----------|:---------|',
+  '| p | q |',
+  '',
+  '```bash',
+  'echo "still inside"',
+  '```',
+  '````',
+  '',
+].join('\n');
+
+const NESTED_EXPECTED = NESTED.replace('|-----------|:----------|', '|---|:---|');
+
 function git(cwd, args) {
   const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
   if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
@@ -129,6 +159,55 @@ test('--write refuses when the scope is dirty, and preview still works', () => {
   });
 });
 
+test('--write refuses a path git reports clean only because of an index flag', () => {
+  withFixture((dir) => {
+    // skip-worktree makes git report a file clean no matter how far it has diverged, so
+    // the status check alone would pass while the write destroyed real content. This is
+    // the one flag that disarms every later check, which is why mutation-check and
+    // repo-guard both test for it.
+    git(dir, ['update-index', '--skip-worktree', 'agents/sample.md']);
+    writeFileSync(join(dir, 'agents', 'sample.md'), `${DECORATIVE}\nreal work git cannot see\n`);
+    assert.equal(git(dir, ['status', '--porcelain']).trim(), '', 'precondition: git reports clean');
+
+    const r = run(dir, ['--write']);
+    assert.equal(r.status, 2, 'wrote into a scope git could not truthfully report on');
+    assert.match(r.stderr, /index flag/);
+    assert.match(body(dir), /real work git cannot see/);
+  });
+});
+
+test('--write refuses a git-ignored path, where there is no undo at all', () => {
+  withFixture((dir) => {
+    // The refusal message and the guard's comment both promise `git checkout --` as the
+    // undo. For an ignored file git holds no copy, so that promise is false exactly where
+    // it matters most — and `git status --porcelain` omits ignored paths by design, so
+    // the guard is structurally blind to the one unrecoverable class.
+    writeFileSync(join(dir, '.gitignore'), 'scratch/\n');
+    mkdirSync(join(dir, 'scratch'), { recursive: true });
+    writeFileSync(join(dir, 'scratch', 'note.md'), DECORATIVE);
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'add gitignore']);
+
+    const r = run(dir, ['--files', 'scratch/note.md', '--write']);
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /git-ignored path/);
+    assert.equal(readFileSync(join(dir, 'scratch', 'note.md'), 'utf8'), DECORATIVE);
+  });
+});
+
+test('an untracked file in scope gets stash advice that actually works', () => {
+  withFixture((dir) => {
+    // Plain `git stash` leaves `??` entries behind, so the stock advice hands back a tree
+    // this guard still refuses. The sibling tool already fixed this wording.
+    writeFileSync(join(dir, 'agents', 'extra.md'), DECORATIVE);
+
+    const r = run(dir, ['--write']);
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /git stash -u/);
+    assert.match(r.stderr, /leaves the `\?\?` entries behind/);
+  });
+});
+
 // --- default-deny on flags and values -------------------------------------------------
 
 test('an unknown flag is refused rather than ignored', () => {
@@ -155,5 +234,93 @@ test('--files stops at the next flag instead of eating its value', () => {
     const r = run(dir, ['--files', 'agents/sample.md', '--mode', 'both']);
     assert.equal(r.status, 0, r.stderr);
     assert.match(r.stdout, /of 1 scanned/);
+  });
+});
+
+test('a path after a later flag is refused, not silently dropped', () => {
+  withFixture((dir) => {
+    // The first fix for the parse above introduced its own silent narrowing: stopping at
+    // the first flag discarded `b.md` without a word, and `--write` still applied because
+    // it was found by scanning the whole argv.
+    const r = run(dir, ['--files', 'agents/sample.md', '--write', 'agents/other.md']);
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /unexpected argument 'agents\/other\.md'/);
+  });
+});
+
+test('a flag after --files is still validated', () => {
+  withFixture((dir) => {
+    const r = run(dir, ['--files', 'agents/sample.md', '--wrote']);
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /unknown flag --wrote/);
+  });
+});
+
+test('a trailing value flag is refused, not defaulted', () => {
+  withFixture((dir) => {
+    // `--write --mode` read argv[i+1] as undefined, and `undefined || "both"` passed the
+    // enum check — so a caller who narrowed the run to one transform got both, WITH
+    // --write. Wider than asked, in the destructive direction.
+    for (const args of [['--write', '--mode'], ['--write', '--scope'], ['--mode']]) {
+      const r = run(dir, args);
+      assert.equal(r.status, 2, `${args.join(' ')} was accepted`);
+      assert.match(r.stderr, /requires a value/);
+      assert.equal(body(dir), DECORATIVE, 'the refused run still wrote');
+    }
+  });
+});
+
+// --- the fence-state machine, which is the file's stated correctness claim -------------
+
+test('separators inside a fence are left alone while the one outside is compacted', () => {
+  withFixture((dir) => {
+    writeFileSync(join(dir, 'agents', 'sample.md'), NESTED);
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'nested fixture']);
+
+    const r = run(dir, ['--write', '--mode', 'separators']);
+    assert.equal(r.status, 0, r.stderr);
+    // Not vacuous: the run must have changed exactly the one outside the fence.
+    assert.match(r.stdout, /separators compacted: 1/);
+    assert.equal(body(dir), NESTED_EXPECTED);
+    assert.ok(body(dir).includes('|----------|:---------|'), 'the in-fence separator was rewritten');
+  });
+});
+
+test('--mode fences tags an untagged opening fence and is not a no-op', () => {
+  withFixture((dir) => {
+    // Two blocks, because the tag heuristic infers exactly one language. A `text`-only
+    // fixture would keep passing if guessLanguage were replaced by `return "text"`.
+    writeFileSync(
+      join(dir, 'agents', 'sample.md'),
+      // The JSON block is deliberately MULTI-LINE. A single-line `{"a": 1}` is caught by
+      // the JSON-Lines branch as well as the whole-block branch, so deleting either left
+      // the other to produce the same tag and the mutant survived.
+      'Prose.\n\n```\necho "hello"\n```\n\nData.\n\n```\n{\n  "a": 1\n}\n```\n',
+    );
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'untagged fence fixture']);
+
+    const r = run(dir, ['--write', '--mode', 'fences']);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /fences tagged:\s+2/);
+    const after = body(dir);
+    assert.match(after, /```text/, 'a prose block should fall back to text');
+    assert.match(after, /```json/, 'a block that parses as JSON should be tagged json');
+    // Only OPENING fences are tagged; the two closing ``` lines stay bare, which is why
+    // "no bare fence remains" would be the wrong assertion here.
+  });
+});
+
+test('CRLF files keep their line endings', () => {
+  withFixture((dir) => {
+    writeFileSync(join(dir, 'agents', 'sample.md'), DECORATIVE.replace(/\n/g, '\r\n'));
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-qm', 'crlf fixture']);
+
+    const r = run(dir, ['--write']);
+    assert.equal(r.status, 0, r.stderr);
+    const after = body(dir);
+    assert.equal(after, COMPACTED.replace(/\n/g, '\r\n'), 'EOL style was not preserved');
   });
 });

--- a/scripts/test/normalize-content-style.test.js
+++ b/scripts/test/normalize-content-style.test.js
@@ -1,0 +1,159 @@
+/**
+ * Behavioural tests for `scripts/normalize-content-style.js` (#490).
+ *
+ * The property under test is that the tool PREVIEWS unless asked to write. #486 inverted
+ * the same default in the i18n normalizer after a read-only probe agent typed the bare
+ * command and silently rewrote 281 files; this file's blast radius is larger, since
+ * `--scope all` is the whole corpus and the default scope is still every English content
+ * file.
+ *
+ * That property is trivial to assert vacuously: a run over a corpus with nothing to repair
+ * also writes nothing, and such a test stays green even if `--write` were the default
+ * again. So every "writes nothing" case here is paired with a `--write` case proving the
+ * SAME fixture does get rewritten. The difference between the two is the whole gate.
+ *
+ * Each test builds a throwaway git repo holding the script and one content file. Nothing
+ * touches the working repository — a test that dirties the real tree makes ambient state
+ * decide the result (#453).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, cpSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = 'scripts/normalize-content-style.js';
+
+/** A decorative separator: a separator row carrying four or more dashes. */
+const DECORATIVE = '| Col A | Col B |\n|-------|:------|\n| x | y |\n';
+/** What the normalizer must produce — three dashes per column, alignment colon kept. */
+const COMPACTED = '| Col A | Col B |\n|---|:---|\n| x | y |\n';
+
+function git(cwd, args) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (r.status !== 0) throw new Error(`git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout;
+}
+
+/** A throwaway repo containing the script and one committed content file. */
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'norm-content-'));
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  mkdirSync(join(dir, 'agents'), { recursive: true });
+  cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+  writeFileSync(join(dir, 'agents', 'sample.md'), DECORATIVE);
+  git(dir, ['init', '-q']);
+  git(dir, ['config', 'user.email', 'test@example.com']);
+  git(dir, ['config', 'user.name', 'test']);
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-qm', 'fixture']);
+  return dir;
+}
+
+function run(dir, args) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { cwd: dir, encoding: 'utf8' });
+}
+
+function body(dir) {
+  return readFileSync(join(dir, 'agents', 'sample.md'), 'utf8');
+}
+
+function withFixture(fn) {
+  const dir = fixture();
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// --- the gate itself: preview by default, write only when asked -----------------------
+
+test('the bare command does not write', () => {
+  withFixture((dir) => {
+    const r = run(dir, []);
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(body(dir), DECORATIVE, 'the bare command rewrote the file');
+    assert.match(r.stdout, /PREVIEW/);
+    // Not vacuous: the run DID find the change, it just declined to apply it.
+    assert.match(r.stdout, /separators compacted: 1/);
+    assert.match(r.stdout, /files to change: 1/);
+  });
+});
+
+test('--write applies the same change the bare command only reported', () => {
+  withFixture((dir) => {
+    const r = run(dir, ['--write']);
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(body(dir), COMPACTED);
+    assert.match(r.stdout, /files written: 1/);
+  });
+});
+
+test('--dry is an explicit no-op, not a write', () => {
+  withFixture((dir) => {
+    const r = run(dir, ['--dry']);
+    assert.equal(r.status, 0, r.stderr);
+    assert.equal(body(dir), DECORATIVE);
+  });
+});
+
+test('--write and --dry together are refused rather than guessed', () => {
+  withFixture((dir) => {
+    const r = run(dir, ['--write', '--dry']);
+    assert.equal(r.status, 2);
+    assert.equal(body(dir), DECORATIVE);
+  });
+});
+
+// --- refuses to write into a dirty scope ----------------------------------------------
+
+test('--write refuses when the scope is dirty, and preview still works', () => {
+  withFixture((dir) => {
+    writeFileSync(join(dir, 'agents', 'sample.md'), `${DECORATIVE}\nuncommitted\n`);
+    const dirty = body(dir);
+
+    const w = run(dir, ['--write']);
+    assert.equal(w.status, 2, 'wrote into a dirty scope');
+    assert.match(w.stderr, /dirty scope/);
+    assert.equal(body(dir), dirty, 'the refused run still modified the file');
+
+    // The guard must not over-block: previewing a dirty scope is safe and must succeed.
+    const p = run(dir, []);
+    assert.equal(p.status, 0, p.stderr);
+    assert.equal(body(dir), dirty);
+  });
+});
+
+// --- default-deny on flags and values -------------------------------------------------
+
+test('an unknown flag is refused rather than ignored', () => {
+  withFixture((dir) => {
+    const r = run(dir, ['--wrote']);
+    assert.equal(r.status, 2);
+    assert.match(r.stderr, /unknown flag --wrote/);
+    assert.equal(body(dir), DECORATIVE);
+  });
+});
+
+test('--mode and --scope reject values outside their sets', () => {
+  withFixture((dir) => {
+    assert.equal(run(dir, ['--mode', 'sideways']).status, 2);
+    assert.equal(run(dir, ['--scope', 'everything']).status, 2);
+    assert.equal(run(dir, ['--files']).status, 2);
+  });
+});
+
+test('--files stops at the next flag instead of eating its value', () => {
+  withFixture((dir) => {
+    // `--files a.md --mode both` previously kept 'both' as a filename, because the parse
+    // filtered out only `--`-prefixed args. The scanned count is what proves it.
+    const r = run(dir, ['--files', 'agents/sample.md', '--mode', 'both']);
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /of 1 scanned/);
+  });
+});


### PR DESCRIPTION
Closes #490.

## The defect

`scripts/normalize-content-style.js` wrote unless `--dry` was passed. That is the shape #486 inverted in the i18n normalizer, after a read-only probe agent typed the bare command and silently rewrote 281 files — after which every measurement of that backlog was wrong *and self-consistent*.

The blast radius here is larger, not smaller. `--scope all` is `skills/ agents/ teams/ guides/ i18n/`, and the **default** scope is still every English content file. The destructive mode was the one you got by typing the obvious command.

## The caller survey #490 asked for came back empty

#490 deferred this deliberately, on one asymmetry: the file "drove the #272 campaign, so flipping its default is a breaking change to a tool with real invocation history", and it asked for a survey of who calls it before flipping.

There are no callers:

| looked in | result |
|---|---|
| `package.json` scripts | no alias (only `normalize:i18n-fences`) |
| `.github/` | no workflow invokes it |
| `CLAUDE.md`, `guides/`, `docs/` | no mention |
| `scripts/test/` | no test existed |
| anywhere else | one code *comment* in `normalize-i18n-fences.js:495` |

So the invocation history is a human or an agent typing it directly — which is the hazard itself, not a reason to preserve it. That weakens the issue's own case for deferral rather than complicating the fix.

## What changed

- **Previews by default**; `--write` applies.
- `--dry` retained as an explicit no-op, so existing invocations keep meaning what they meant. `--write --dry` is an error rather than a guess.
- **Refuses to write into a dirty scope**, checked against the pathspec the run may actually touch rather than the whole repo — so previewing a dirty tree still works and the guard does not over-block.
- Announces the write on stderr before touching anything.
- **Default-deny** on flags and on `--mode`/`--scope` values.

## A parse bug found while reading it

`--files` filtered out only `--`-prefixed args, so `--files a.md --mode both` kept **`both`** as a filename. It now stops at the next flag. Harmless in practice (`existsSync('both')` is false) but it meant the scanned count was a lie.

## Verification

New suite: `scripts/test/normalize-content-style.test.js`, 8 tests. Every "writes nothing" case is **paired** with a `--write` case proving the same fixture *does* get rewritten — without that pairing the suite stays green even if `--write` became the default again, which is the vacuous shape the sibling suite's header warns about. Each test builds a throwaway git repo, so nothing dirties the working tree (#453).

Shown red before being trusted, via `npm run mutation-check`:

| mutation | result |
|---|---|
| delete `if (WRITE) writeFileSync(f, text);` | **MUTANT KILLED** — 1 failing test |
| delete `if (argv[i].startsWith("--")) break;` | **MUTANT KILLED** — 1 failing test |
| delete the dirty-scope `console.error(...)` | **MUTANT KILLED** — 1 failing test |

Same mutation, gate red; restored, gate green. `npm run test:scripts` 123/123 pass.

Manually exercised end to end before writing the tests: bare command left a decorative separator untouched; `--write` on a clean scope compacted it and preserved the alignment colon; `--write` against a dirty target exited 2; `--scope english --write` saw a dirty file anywhere in scope; preview on a dirty scope still exited 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8