### PR TITLE
fix(i18n): make contentKey's two branches agree on what an id is (#519)

### DIFF
--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -107,9 +107,20 @@ export function contentKey(relPath) {
   return null;
 }
 
-/** Names that live inside a content tree without being content. */
+/**
+ * Names that live inside a content tree without being content.
+ *
+ * Takes a RAW path segment and strips a `.md` suffix itself, so the two branches above can
+ * hand it the same kind of thing. They could not before: the flat branch stripped the
+ * extension before testing while the nested branch passed a bare directory segment, which
+ * made `contentKey('skills/README.md/SKILL.md')` return `skills/README.md` instead of null
+ * while `contentKey('skills/README.md')` correctly returned null. Unreachable today only
+ * because every caller happens to `statSync(...).isFile()` afterwards — which is the
+ * "unreachable because of ambient state" framing #519 exists to reject.
+ */
 function isExcludedId(id) {
-  return id.startsWith('_') || id === 'README';
+  const stem = id.endsWith('.md') ? id.slice(0, -3) : id;
+  return stem.startsWith('_') || stem === 'README';
 }
 
 /**

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -83,15 +83,33 @@ export const TREES = ['skills', 'agents', 'teams', 'guides'];
 export function contentKey(relPath) {
   const parts = relPath.split('/');
   if (parts.length < 2 || !TREES.includes(parts[0])) return null;
+  // Both branches below must agree on what an id is, and on which ids are not content.
+  // They did not: the exclusion lived only in the flat branch, so
+  // `contentKey('skills/_template/SKILL.md')` returned `skills/_template` — a key the
+  // English history index then carried, which would have made a translated `_template`
+  // a rewrite target (#519). skills/ holds most of the corpus, so the general claim that
+  // deriving both the path and the key from this function removes the need for a second
+  // exclusion list was false exactly where it mattered most.
   if (parts[parts.length - 1] === 'SKILL.md') {
-    return parts.length >= 3 ? `${parts[0]}/${parts[parts.length - 2]}` : null;
+    if (parts.length < 3) return null;
+    // Second-to-last, never parts[1]: pre-flatten paths are
+    // `skills/<domain>/<id>/SKILL.md`, and keying off parts[1] would silently key a whole
+    // domain — ~42% of the blobs in history — to the wrong id.
+    const id = parts[parts.length - 2];
+    if (isExcludedId(id)) return null;
+    return `${parts[0]}/${id}`;
   }
   if (parts.length === 2 && parts[1].endsWith('.md')) {
     const id = parts[1].slice(0, -3);
-    if (id.startsWith('_') || id === 'README') return null;
+    if (isExcludedId(id)) return null;
     return `${parts[0]}/${id}`;
   }
   return null;
+}
+
+/** Names that live inside a content tree without being content. */
+function isExcludedId(id) {
+  return id.startsWith('_') || id === 'README';
 }
 
 /**

--- a/scripts/test/fences.test.js
+++ b/scripts/test/fences.test.js
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for `contentKey()` in `scripts/lib/fences.js`.
+ *
+ * There was no test file for this module at all, and that is how #519 survived: every
+ * skills path any fixture in `scripts/test/` constructs is the 3-segment
+ * `skills/<id>/SKILL.md`, where `parts[1]` and `parts[parts.length - 2]` are the SAME
+ * value. So the whole suite stayed green against `const id = parts[1]`, which would re-key
+ * every pre-flatten `skills/<domain>/<id>/SKILL.md` blob to its *domain* — silently
+ * emptying the historical basis for those skills and manufacturing violations across the
+ * corpus.
+ *
+ * The pre-flatten case is therefore asserted here directly, because prose in the function
+ * saying "second-to-last, never parts[1]" is an assertion nobody ran.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { contentKey } from '../lib/fences.js';
+
+test('a pre-flatten skills path keys to the same id as the flattened one', () => {
+  // The whole reason the nested branch uses parts[parts.length - 2]. ~42% of the blobs in
+  // this repo's history sit at the pre-flatten path.
+  assert.equal(contentKey('skills/r-packages/create-r-package/SKILL.md'), 'skills/create-r-package');
+  assert.equal(contentKey('skills/create-r-package/SKILL.md'), 'skills/create-r-package');
+  // Deeper nesting still keys off the directory holding SKILL.md.
+  assert.equal(contentKey('skills/a/b/c/demo/SKILL.md'), 'skills/demo');
+});
+
+test('flat trees key off the filename stem', () => {
+  assert.equal(contentKey('guides/agent-best-practices.md'), 'guides/agent-best-practices');
+  assert.equal(contentKey('agents/r-developer.md'), 'agents/r-developer');
+  assert.equal(contentKey('teams/visual-pr-review.md'), 'teams/visual-pr-review');
+});
+
+test('templates and READMEs are not content, in EITHER branch', () => {
+  // The #519 defect: the exclusion lived only in the flat branch.
+  assert.equal(contentKey('skills/_template/SKILL.md'), null);
+  assert.equal(contentKey('skills/_scratch/SKILL.md'), null);
+  assert.equal(contentKey('agents/_template.md'), null);
+  assert.equal(contentKey('guides/_template.md'), null);
+  assert.equal(contentKey('skills/README.md'), null);
+  assert.equal(contentKey('guides/README.md'), null);
+  // And the residual asymmetry: a raw segment vs a stripped stem. `isExcludedId` now
+  // strips `.md` itself so both branches can hand it the same kind of thing.
+  assert.equal(contentKey('skills/README.md/SKILL.md'), null);
+  assert.equal(contentKey('skills/_template.md/SKILL.md'), null);
+});
+
+test('non-content paths return null rather than a bogus key', () => {
+  assert.equal(contentKey('i18n/de/skills/demo/SKILL.md'), null, 'mirror paths must not key');
+  assert.equal(contentKey('scripts/lib/fences.js'), null);
+  assert.equal(contentKey('README.md'), null);
+  assert.equal(contentKey('skills'), null);
+  assert.equal(contentKey('skills/'), null);
+  assert.equal(contentKey('skills/SKILL.md'), null, 'a tree-level SKILL.md has no id');
+  assert.equal(contentKey('guides/nested/dir/page.md'), null, 'flat trees are flat');
+});

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -607,3 +607,42 @@ test('a template or README inside a tree is not a target', async (t) => {
   assert.doesNotMatch(r.stdout, /_template\.md/, 'a template reached the skipped list');
   assert.doesNotMatch(r.stdout, /README\.md/, 'a README reached the skipped list');
 });
+
+test('a template in the skills tree is not a target either', async (t) => {
+  // The arm above proves the property for the FLAT trees only, while its comment claims
+  // it generally. It did not hold for `skills/`, which is the tree holding most of the
+  // corpus: `contentKey` applied the `_`-prefix exclusion in the flat branch alone, so
+  // `skills/_template/SKILL.md` keyed to `skills/_template` and the English history index
+  // carried it. Unreachable in the real corpus only because no locale happens to carry a
+  // translated template — which is ambient state, not a guarantee (#519).
+  const { dir } = makeFixture(t);
+
+  const english = [
+    '---', 'name: skill-name', 'description: Template.', '---', '',
+    '# Template', '', '## Procedure', '',
+    '```bash', 'echo english', '```', '',
+  ].join('\n');
+  mkdirSync(join(dir, 'skills', '_template'), { recursive: true });
+  writeFileSync(join(dir, 'skills', '_template', 'SKILL.md'), english, 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'add a template to the skills tree']);
+
+  const translated = join(dir, 'i18n', 'de', 'skills', '_template', 'SKILL.md');
+  mkdirSync(dirname(translated), { recursive: true });
+  writeFileSync(
+    translated,
+    ['---', 'name: skill-name', 'locale: de', '---', '', '# Vorlage', '',
+      '```bash', 'echo uebersetzt', '```', ''].join('\n'),
+    'utf8',
+  );
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'add a translated template']);
+
+  const r = run(dir, ['--tree', 'skills', '--write']);
+
+  assert.equal(r.status, 0, r.stderr);
+  const after = readFileSync(translated, 'utf8');
+  assert.ok(after.includes('echo uebersetzt'), 'the skills template was treated as content');
+  // Not a target, not merely unwritten — same distinction the flat arm asserts.
+  assert.doesNotMatch(r.stdout, /_template/, 'the skills template reached the skipped list');
+});

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -641,6 +641,9 @@ test('a template in the skills tree is not a target either', async (t) => {
   const r = run(dir, ['--tree', 'skills', '--write']);
 
   assert.equal(r.status, 0, r.stderr);
+  // Positive control, as the flat arm has: without it both assertions below pass vacuously
+  // if `--write` stopped writing at all. `demo-skill` is divergent and must still be repaired.
+  assert.match(r.stdout, /files changed: 1/);
   const after = readFileSync(translated, 'utf8');
   assert.ok(after.includes('echo uebersetzt'), 'the skills template was treated as content');
   // Not a target, not merely unwritten — same distinction the flat arm asserts.


### PR DESCRIPTION
Closes #519.

## The asymmetry

`contentKey` applied its `_`-prefix and `README` exclusion **only** in the flat `<tree>/<id>.md` branch. So:

```js
contentKey('skills/_template/SKILL.md')  // -> 'skills/_template', not null
```

That path exists on disk and in git history (first at `496be0a2a`), so `buildEnglishFenceHistory` indexed the key — meaning a translated `i18n/<locale>/skills/_template/SKILL.md` would have been treated as content and rewritten by the normalizer.

## Why it matters even though it is unreachable

#518's commit message argues that deriving both the English path and the history key from `contentKey` is what stops `_template.md`, `README.md` and `_registry.yml`

> needing a second exclusion list here that could drift from the checker's

That is true for the flat mirror trees and **false for `skills/`** — the tree holding most of the corpus. A reader relying on the general claim would be wrong about the tree that matters most. It is a docstring guarantee with nothing behind it.

Unreachable today only because no locale happens to carry a translated `_template`, verified across all ten. That is ambient state, not a guarantee.

## The fix

Both branches now route through one `isExcludedId`, so they cannot disagree again, and the function carries a comment saying why.

The id is taken from `parts[parts.length - 2]` and deliberately **not** `parts[1]`. Pre-flatten paths are `skills/<domain>/<id>/SKILL.md`, so keying off `parts[1]` would silently key a whole domain — ~42% of the blobs in history — to the wrong id, and the English history index would report clean while missing it.

## Preconditions the issue attaches — all checked

| precondition | result |
|---|---|
| no locale carries a translated `_template` / `README` | confirmed across all ten |
| no test asserts the key for one | confirmed |
| `check-yaml-fences.js` guarded independently | yes — skips `_`-prefixed entries at `:129` *before* calling `contentKey` |

Those redundant guards are left in place rather than removed here.

## Verification

Adds a skills-tree arm to the normalizer suite. The existing arm runs `--tree guides` **only** while its comment claims the property holds generally — so the suite asserted the flat case and *documented* the general one. Like its sibling, the new arm asserts the template is not a **target** rather than merely unwritten, because the null-guard mutant leaves the bytes untouched either way and only the report distinguishes them.

Proven to catch the real defect rather than a proxy:

```console
$ git checkout main -- scripts/lib/fences.js     # the pre-fix function
$ node --test --test-name-pattern "skills tree is not a target" ...
✖ AssertionError: the skills template was treated as content

$ git checkout HEAD -- scripts/lib/fences.js     # the fix
✔ pass 1
```

`npm run mutation-check` on the shared predicate: **MUTANT KILLED by 2 failing tests** — the flat arm and the new skills arm.

Corpus fence backlog unchanged at **78 violations across 31 files** (see the baseline-correction comment below — this branch was cut when the number was 86/32, and #541 has since removed 8), which is the expected no-op: this closes a path with no instances today. 123/123 scripts tests pass; `validate:yaml-fences` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8