### PR TITLE
ci(i18n): gate every keep-in-English frontmatter field except version (#485)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -133,12 +133,17 @@ jobs:
       # #485 = four). Deterministic exact comparison, unlike the heuristic
       # warn-only A9. Local `npm run validate:i18n-parity` matches.
       #
-      # #485 widened it from allowed-tools alone to every keep-in-English field
-      # except `version`, which is excluded by design — a translation pins the
-      # English version it was made from, so its 317 divergences are correct.
-      # The step prints a field-comparison count (21,456 today) precisely because
-      # a column-anchored implementation compares only the one top-level field and
-      # reports OK; the count is the tell that it did not.
+      # #485 widened it from allowed-tools alone to every keep-in-English field.
+      # `version` is compared on DIRECTION rather than equality: a translation pins
+      # the English version it was made from, so all 317 of its divergences lag and
+      # are correct — but 0 run ahead, and a translation claiming a version its
+      # source never reached can only have authored it, so that case blocks.
+      #
+      # The step prints a field-comparison count (21,456 today). Read it: a
+      # column-anchored implementation compares only the one top-level field and
+      # still reports OK, and the count is the only thing that distinguishes the
+      # two. NOTE it is printed, not asserted — nothing here fails on a low count,
+      # so it is a diagnostic for a human, not a gate. See the follow-up issue.
       - name: Check i18n frontmatter parity
         run: node scripts/check-i18n-frontmatter-parity.js
 

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -125,12 +125,20 @@ jobs:
       - name: Check translation freshness (warn only)
         run: node scripts/check-translation-freshness.js --warn
 
-      # Keep-in-English frontmatter parity (#371). Ships BLOCKING, not warn-only:
-      # the corpus was verified clean at introduction (39-file catch-up in the
-      # same PR), so the issue's promotion precondition was already met, and a
-      # warn stream nobody watches would reproduce the root cause (#371 = two
-      # months of silent drift). Deterministic exact comparison, unlike the
-      # heuristic warn-only A9. Local `npm run validate:i18n-parity` matches.
+      # Keep-in-English frontmatter parity (#371, widened by #485). Ships BLOCKING,
+      # not warn-only: the corpus is verified clean at introduction — a 39-file
+      # catch-up in #371's PR, and an 88-field catch-up across 61 files in #485's —
+      # so the promotion precondition is met each time, and a warn stream nobody
+      # watches would reproduce the root cause (#371 = two months of silent drift;
+      # #485 = four). Deterministic exact comparison, unlike the heuristic
+      # warn-only A9. Local `npm run validate:i18n-parity` matches.
+      #
+      # #485 widened it from allowed-tools alone to every keep-in-English field
+      # except `version`, which is excluded by design — a translation pins the
+      # English version it was made from, so its 317 divergences are correct.
+      # The step prints a field-comparison count (21,456 today) precisely because
+      # a column-anchored implementation compares only the one top-level field and
+      # reports OK; the count is the tell that it did not.
       - name: Check i18n frontmatter parity
         run: node scripts/check-i18n-frontmatter-parity.js
 

--- a/i18n/de/skills/analyze-prime-numbers/SKILL.md
+++ b/i18n/de/skills/analyze-prime-numbers/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   domain: number-theory
   complexity: intermediate
   language: multi
-  tags: number-theory, prime-numbers, factorization, primality-testing, sieve
+  tags: number-theory, primes, primality, factorization, sieve
   locale: de
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/de/skills/center/SKILL.md
+++ b/i18n/de/skills/center/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   domain: defensive
   complexity: intermediate
   language: natural
-  tags: defensive, centering, balance, meta-cognition, ai-self-application
+  tags: defensive, centering, reasoning-balance, cognitive-load, meta-cognition, ai-self-application
   locale: de
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/de/skills/choose-loop-wakeup-interval/SKILL.md
+++ b/i18n/de/skills/choose-loop-wakeup-interval/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: general
   complexity: intermediate
   language: multi
-  tags: loop, wakeup, cache, scheduling, delay, decision
+  tags: loop, wakeup, cache, scheduling, delay, general
   locale: de
   source_locale: en
   source_commit: 9c546edf

--- a/i18n/de/skills/construct-geometric-figure/SKILL.md
+++ b/i18n/de/skills/construct-geometric-figure/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   domain: geometry
   complexity: intermediate
   language: multi
-  tags: geometry, euclidean-construction, compass-straightedge, classical-geometry
+  tags: geometry, construction, ruler-compass, euclidean, straightedge
   locale: de
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/de/skills/interpret-nmr-spectrum/SKILL.md
+++ b/i18n/de/skills/interpret-nmr-spectrum/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   domain: spectroscopy
   complexity: advanced
   language: natural
-  tags: spectroscopy, nmr, structure-elucidation, chemical-shift, coupling
+  tags: spectroscopy, nmr, chemical-shift, coupling, structure-elucidation
 ---
 
 # NMR-Spektrum interpretieren

--- a/i18n/de/skills/interpret-uv-vis-spectrum/SKILL.md
+++ b/i18n/de/skills/interpret-uv-vis-spectrum/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   domain: spectroscopy
   complexity: intermediate
   language: natural
-  tags: spectroscopy, uv-vis, chromophore, absorbance, electronic-transitions
+  tags: spectroscopy, uv-vis, chromophore, beer-lambert, electronic-transitions
 ---
 
 # UV-Vis-Spektrum interpretieren

--- a/i18n/de/skills/make-fire/SKILL.md
+++ b/i18n/de/skills/make-fire/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   domain: bushcraft
   complexity: intermediate
   language: natural
-  tags: bushcraft, fire, survival, wilderness, shelter
+  tags: bushcraft, fire, survival, wilderness, primitive-skills
   locale: de
   source_locale: en
   source_commit: 33b561c9

--- a/i18n/de/skills/plan-spectroscopic-analysis/SKILL.md
+++ b/i18n/de/skills/plan-spectroscopic-analysis/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   domain: spectroscopy
   complexity: intermediate
   language: natural
-  tags: spectroscopy, analysis-planning, method-selection, characterization
+  tags: spectroscopy, analytical-planning, technique-selection, sample-preparation
 ---
 
 # Spektroskopische Analyse planen

--- a/i18n/de/skills/prove-geometric-theorem/SKILL.md
+++ b/i18n/de/skills/prove-geometric-theorem/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   domain: geometry
   complexity: advanced
   language: multi
-  tags: geometry, proofs, euclidean-axioms, coordinate-proofs, vector-proofs
+  tags: geometry, proof, theorem, euclidean, axiomatic, coordinate
   locale: de
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/de/skills/solve-trigonometric-problem/SKILL.md
+++ b/i18n/de/skills/solve-trigonometric-problem/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   domain: geometry
   complexity: intermediate
   language: multi
-  tags: geometry, trigonometry, triangle-solving, identities, periodic-functions
+  tags: geometry, trigonometry, identities, triangle, sines, cosines
   locale: de
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/de/skills/validate-analytical-method/SKILL.md
+++ b/i18n/de/skills/validate-analytical-method/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   domain: chromatography
   complexity: advanced
   language: natural
-  tags: chromatography, validation, ICH, accuracy, precision, linearity
+  tags: chromatography, validation, ich-q2, accuracy, precision, linearity, regulatory
 ---
 
 # Analytische Methode validieren

--- a/i18n/es/skills/choose-loop-wakeup-interval/SKILL.md
+++ b/i18n/es/skills/choose-loop-wakeup-interval/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: general
   complexity: intermediate
   language: multi
-  tags: loop, wakeup, cache, scheduling, delay, decision
+  tags: loop, wakeup, cache, scheduling, delay, general
   locale: es
   source_locale: en
   source_commit: 9c546edf

--- a/i18n/es/skills/construct-geometric-figure/SKILL.md
+++ b/i18n/es/skills/construct-geometric-figure/SKILL.md
@@ -17,9 +17,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: geometry
-  complexity: basic
-  language: natural
-  tags: geometry, constructions, compass, straightedge, euclidean
+  complexity: intermediate
+  language: multi
+  tags: geometry, construction, ruler-compass, euclidean, straightedge
 ---
 
 # Construir Figura Geométrica

--- a/i18n/es/skills/develop-gc-method/SKILL.md
+++ b/i18n/es/skills/develop-gc-method/SKILL.md
@@ -19,9 +19,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: chromatography
-  complexity: intermediate
+  complexity: advanced
   language: natural
-  tags: chromatography, gc, gas-chromatography, method-development, volatile-analysis
+  tags: chromatography, gc, gas-chromatography, method-development, separation
 ---
 
 # Desarrollar Método GC

--- a/i18n/es/skills/develop-hplc-method/SKILL.md
+++ b/i18n/es/skills/develop-hplc-method/SKILL.md
@@ -21,9 +21,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: chromatography
-  complexity: intermediate
+  complexity: advanced
   language: natural
-  tags: chromatography, hplc, liquid-chromatography, method-development, reversed-phase
+  tags: chromatography, hplc, liquid-chromatography, method-development, separation
 ---
 
 # Desarrollar Método HPLC

--- a/i18n/es/skills/heal-guidance/SKILL.md
+++ b/i18n/es/skills/heal-guidance/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: esoteric
   complexity: advanced
   language: natural
-  tags: esoteric, healing, guidance, wellness, somatic, emotional, cognitive, ai-self-application
+  tags: esoteric, healing, energy-work, reiki, herbalism, holistic, guidance
   locale: es
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/es/skills/heal/SKILL.md
+++ b/i18n/es/skills/heal/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   domain: esoteric
   complexity: advanced
   language: natural
-  tags: esoteric, healing, self-repair, meta-cognition, ai-self-application
+  tags: esoteric, healing, self-assessment, meta-cognition, subsystem-check
   locale: es
   source_locale: en
   source_commit: 33b561c9

--- a/i18n/es/skills/interpret-chromatogram/SKILL.md
+++ b/i18n/es/skills/interpret-chromatogram/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   domain: chromatography
   complexity: intermediate
   language: natural
-  tags: chromatography, interpretation, peak-integration, quantification, retention-time
+  tags: chromatography, peak-analysis, resolution, integration, system-suitability
 ---
 
 # Interpretar Cromatograma

--- a/i18n/es/skills/interpret-ir-spectrum/SKILL.md
+++ b/i18n/es/skills/interpret-ir-spectrum/SKILL.md
@@ -22,7 +22,7 @@ metadata:
   domain: spectroscopy
   complexity: intermediate
   language: natural
-  tags: spectroscopy, ir, infrared, functional-groups, organic-chemistry
+  tags: spectroscopy, ir, infrared, functional-groups, absorption
 ---
 
 # Interpretar Espectro IR

--- a/i18n/es/skills/interpret-mass-spectrum/SKILL.md
+++ b/i18n/es/skills/interpret-mass-spectrum/SKILL.md
@@ -20,9 +20,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: spectroscopy
-  complexity: intermediate
+  complexity: advanced
   language: natural
-  tags: spectroscopy, mass-spectrometry, fragmentation, molecular-formula, HRMS
+  tags: spectroscopy, mass-spectrometry, fragmentation, molecular-ion, isotope
 ---
 
 # Interpretar Espectro de Masas

--- a/i18n/es/skills/interpret-nmr-spectrum/SKILL.md
+++ b/i18n/es/skills/interpret-nmr-spectrum/SKILL.md
@@ -18,9 +18,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: spectroscopy
-  complexity: intermediate
+  complexity: advanced
   language: natural
-  tags: spectroscopy, nmr, structure-elucidation, organic-chemistry, 2d-nmr
+  tags: spectroscopy, nmr, chemical-shift, coupling, structure-elucidation
 ---
 
 # Interpretar Espectro de RMN

--- a/i18n/es/skills/interpret-raman-spectrum/SKILL.md
+++ b/i18n/es/skills/interpret-raman-spectrum/SKILL.md
@@ -23,7 +23,7 @@ metadata:
   domain: spectroscopy
   complexity: intermediate
   language: natural
-  tags: spectroscopy, raman, vibrational, carbon-materials, SERS, symmetry
+  tags: spectroscopy, raman, polarizability, vibrational, complementary-ir
 ---
 
 # Interpretar Espectro Raman

--- a/i18n/es/skills/interpret-uv-vis-spectrum/SKILL.md
+++ b/i18n/es/skills/interpret-uv-vis-spectrum/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   domain: spectroscopy
   complexity: intermediate
   language: natural
-  tags: spectroscopy, uv-vis, chromophore, beer-lambert, woodward-fieser
+  tags: spectroscopy, uv-vis, chromophore, beer-lambert, electronic-transitions
 ---
 
 # Interpretar Espectro UV-Vis

--- a/i18n/es/skills/make-fire/SKILL.md
+++ b/i18n/es/skills/make-fire/SKILL.md
@@ -13,9 +13,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: bushcraft
-  complexity: basic
+  complexity: intermediate
   language: natural
-  tags: bushcraft, fire, survival, friction, flint-and-steel
+  tags: bushcraft, fire, survival, wilderness, primitive-skills
   locale: es
   source_locale: en
   source_commit: 33b561c9

--- a/i18n/es/skills/meditate-guidance/SKILL.md
+++ b/i18n/es/skills/meditate-guidance/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: esoteric
   complexity: intermediate
   language: natural
-  tags: esoteric, meditation, guidance, mindfulness, awareness, meta-cognition, ai-self-application
+  tags: esoteric, meditation, mindfulness, shamatha, vipassana, breathwork, guidance
   locale: es
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/es/skills/plan-spectroscopic-analysis/SKILL.md
+++ b/i18n/es/skills/plan-spectroscopic-analysis/SKILL.md
@@ -23,7 +23,7 @@ metadata:
   domain: spectroscopy
   complexity: intermediate
   language: natural
-  tags: spectroscopy, analysis-planning, structure-elucidation, analytical-strategy
+  tags: spectroscopy, analytical-planning, technique-selection, sample-preparation
 ---
 
 # Planificar el Análisis Espectroscópico

--- a/i18n/es/skills/prove-geometric-theorem/SKILL.md
+++ b/i18n/es/skills/prove-geometric-theorem/SKILL.md
@@ -17,9 +17,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: geometry
-  complexity: intermediate
-  language: natural
-  tags: geometry, proofs, euclidean, theorems, reasoning
+  complexity: advanced
+  language: multi
+  tags: geometry, proof, theorem, euclidean, axiomatic, coordinate
 ---
 
 # Demostrar Teorema Geométrico

--- a/i18n/es/skills/purify-water/SKILL.md
+++ b/i18n/es/skills/purify-water/SKILL.md
@@ -13,9 +13,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: bushcraft
-  complexity: basic
+  complexity: intermediate
   language: natural
-  tags: bushcraft, water, survival, filtration, purification
+  tags: bushcraft, water, purification, survival, wilderness, filtration
   locale: es
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/es/skills/solve-trigonometric-problem/SKILL.md
+++ b/i18n/es/skills/solve-trigonometric-problem/SKILL.md
@@ -18,8 +18,8 @@ metadata:
   version: "1.0"
   domain: geometry
   complexity: intermediate
-  language: natural
-  tags: geometry, trigonometry, triangles, identities, law-of-sines
+  language: multi
+  tags: geometry, trigonometry, identities, triangle, sines, cosines
 ---
 
 # Resolver Problema Trigonométrico

--- a/i18n/es/skills/troubleshoot-separation/SKILL.md
+++ b/i18n/es/skills/troubleshoot-separation/SKILL.md
@@ -21,7 +21,7 @@ metadata:
   domain: chromatography
   complexity: intermediate
   language: natural
-  tags: chromatography, troubleshooting, peak-shape, resolution, column, HPLC, GC
+  tags: chromatography, troubleshooting, peak-shape, resolution, matrix-effects
 ---
 
 # Resolver Problemas de Separación

--- a/i18n/ja/skills/analyze-prime-numbers/SKILL.md
+++ b/i18n/ja/skills/analyze-prime-numbers/SKILL.md
@@ -10,8 +10,8 @@ metadata:
   version: "1.0"
   domain: number-theory
   complexity: intermediate
-  language: natural
-  tags: number-theory, primes, factorization, primality-testing, cryptography
+  language: multi
+  tags: number-theory, primes, primality, factorization, sieve
   locale: ja
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/ja/skills/choose-loop-wakeup-interval/SKILL.md
+++ b/i18n/ja/skills/choose-loop-wakeup-interval/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: general
   complexity: intermediate
   language: multi
-  tags: loop, wakeup, cache, scheduling, delay, decision
+  tags: loop, wakeup, cache, scheduling, delay, general
   locale: ja
   source_locale: en
   source_commit: 9c546edf

--- a/i18n/ja/skills/construct-geometric-figure/SKILL.md
+++ b/i18n/ja/skills/construct-geometric-figure/SKILL.md
@@ -10,9 +10,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: geometry
-  complexity: basic
-  language: natural
-  tags: geometry, construction, compass-straightedge, polygons, classical-geometry
+  complexity: intermediate
+  language: multi
+  tags: geometry, construction, ruler-compass, euclidean, straightedge
   locale: ja
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/ja/skills/explore-diophantine-equations/SKILL.md
+++ b/i18n/ja/skills/explore-diophantine-equations/SKILL.md
@@ -11,8 +11,8 @@ metadata:
   version: "1.0"
   domain: number-theory
   complexity: advanced
-  language: natural
-  tags: number-theory, diophantine-equations, pell-equation, pythagorean-triples, descent
+  language: multi
+  tags: number-theory, diophantine, integer-solutions, pell-equation, euclidean
   locale: ja
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/ja/skills/heal/SKILL.md
+++ b/i18n/ja/skills/heal/SKILL.md
@@ -19,7 +19,7 @@ metadata:
   domain: esoteric
   complexity: advanced
   language: natural
-  tags: esoteric, healing, repair, assessment, meta-cognition, ai-self-application
+  tags: esoteric, healing, self-assessment, meta-cognition, subsystem-check
 ---
 
 # Heal

--- a/i18n/ja/skills/make-fire/SKILL.md
+++ b/i18n/ja/skills/make-fire/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   domain: bushcraft
   complexity: intermediate
   language: natural
-  tags: bushcraft, fire, survival, wilderness, friction-fire, ferro-rod
+  tags: bushcraft, fire, survival, wilderness, primitive-skills
   locale: ja
   source_locale: en
   source_commit: 33b561c9

--- a/i18n/ja/skills/prove-geometric-theorem/SKILL.md
+++ b/i18n/ja/skills/prove-geometric-theorem/SKILL.md
@@ -10,9 +10,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: geometry
-  complexity: intermediate
-  language: natural
-  tags: geometry, proofs, congruence, similarity, transformations, coordinate-geometry
+  complexity: advanced
+  language: multi
+  tags: geometry, proof, theorem, euclidean, axiomatic, coordinate
   locale: ja
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/ja/skills/solve-modular-arithmetic/SKILL.md
+++ b/i18n/ja/skills/solve-modular-arithmetic/SKILL.md
@@ -11,8 +11,8 @@ metadata:
   version: "1.0"
   domain: number-theory
   complexity: intermediate
-  language: natural
-  tags: number-theory, modular-arithmetic, congruences, chinese-remainder-theorem, cryptography
+  language: multi
+  tags: number-theory, modular-arithmetic, congruences, crt, euler
   locale: ja
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/ja/skills/solve-trigonometric-problem/SKILL.md
+++ b/i18n/ja/skills/solve-trigonometric-problem/SKILL.md
@@ -11,8 +11,8 @@ metadata:
   version: "1.0"
   domain: geometry
   complexity: intermediate
-  language: natural
-  tags: geometry, trigonometry, sine-cosine, triangles, identities
+  language: multi
+  tags: geometry, trigonometry, identities, triangle, sines, cosines
   locale: ja
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/zh-CN/skills/choose-loop-wakeup-interval/SKILL.md
+++ b/i18n/zh-CN/skills/choose-loop-wakeup-interval/SKILL.md
@@ -15,7 +15,7 @@ metadata:
   domain: general
   complexity: intermediate
   language: multi
-  tags: loop, wakeup, cache, scheduling, delay, decision
+  tags: loop, wakeup, cache, scheduling, delay, general
   locale: zh-CN
   source_locale: en
   source_commit: 9c546edf

--- a/i18n/zh-CN/skills/conscientiousness/SKILL.md
+++ b/i18n/zh-CN/skills/conscientiousness/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   domain: esoteric
   complexity: intermediate
   language: natural
-  tags: esoteric, conscientiousness, thoroughness, reliability, meta-cognition, ai-self-application
+  tags: esoteric, conscientiousness, diligence, thoroughness, verification, meta-cognition
 ---
 
 # Conscientiousness（尽责性）

--- a/i18n/zh-CN/skills/construct-geometric-figure/SKILL.md
+++ b/i18n/zh-CN/skills/construct-geometric-figure/SKILL.md
@@ -10,9 +10,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: geometry
-  complexity: basic
-  language: natural
-  tags: geometry, construction, compass-straightedge, euclidean, classical
+  complexity: intermediate
+  language: multi
+  tags: geometry, construction, ruler-compass, euclidean, straightedge
   locale: zh-CN
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/zh-CN/skills/develop-gc-method/SKILL.md
+++ b/i18n/zh-CN/skills/develop-gc-method/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: chromatography
   complexity: advanced
   language: natural
-  tags: chromatography, gas-chromatography, column-selection, temperature-programming, detector
+  tags: chromatography, gc, gas-chromatography, method-development, separation
 ---
 
 # 开发气相色谱方法

--- a/i18n/zh-CN/skills/develop-hplc-method/SKILL.md
+++ b/i18n/zh-CN/skills/develop-hplc-method/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: chromatography
   complexity: advanced
   language: natural
-  tags: chromatography, hplc, column-chemistry, mobile-phase, gradient-design
+  tags: chromatography, hplc, liquid-chromatography, method-development, separation
 ---
 
 # 开发 HPLC 方法

--- a/i18n/zh-CN/skills/dream/SKILL.md
+++ b/i18n/zh-CN/skills/dream/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   domain: esoteric
   complexity: intermediate
   language: natural
-  tags: esoteric, dream, creativity, exploration, ideation, meta-cognition, ai-self-application
+  tags: esoteric, creativity, exploration, emergence, ideation, meta-cognition, ai-self-application
 ---
 
 # Dream（梦想）

--- a/i18n/zh-CN/skills/explore-diophantine-equations/SKILL.md
+++ b/i18n/zh-CN/skills/explore-diophantine-equations/SKILL.md
@@ -10,9 +10,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: number-theory
-  complexity: intermediate
-  language: natural
-  tags: number-theory, diophantine-equations, pell-equation, pythagorean-triples, fermat
+  complexity: advanced
+  language: multi
+  tags: number-theory, diophantine, integer-solutions, pell-equation, euclidean
   locale: zh-CN
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/zh-CN/skills/forage-plants/SKILL.md
+++ b/i18n/zh-CN/skills/forage-plants/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   domain: bushcraft
   complexity: advanced
   language: natural
-  tags: bushcraft, foraging, plants, survival, wilderness, identification
+  tags: bushcraft, foraging, plants, edible, survival, wilderness, botany
   locale: zh-CN
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/zh-CN/skills/heal/SKILL.md
+++ b/i18n/zh-CN/skills/heal/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   domain: esoteric
   complexity: advanced
   language: natural
-  tags: esoteric, heal, self-repair, subsystem-assessment, meta-cognition, ai-self-application
+  tags: esoteric, healing, self-assessment, meta-cognition, subsystem-check
 ---
 
 # Heal（自我修复）

--- a/i18n/zh-CN/skills/honesty-humility/SKILL.md
+++ b/i18n/zh-CN/skills/honesty-humility/SKILL.md
@@ -14,7 +14,7 @@ metadata:
   domain: esoteric
   complexity: intermediate
   language: natural
-  tags: esoteric, honesty, humility, transparency, calibration, meta-cognition, ai-self-application
+  tags: esoteric, honesty, humility, epistemic, calibration, transparency, meta-cognition
   locale: zh-CN
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/zh-CN/skills/interpret-chromatogram/SKILL.md
+++ b/i18n/zh-CN/skills/interpret-chromatogram/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: chromatography
   complexity: intermediate
   language: natural
-  tags: chromatography, peak-integration, resolution, tailing-factor, system-suitability
+  tags: chromatography, peak-analysis, resolution, integration, system-suitability
 ---
 
 # 解读色谱图

--- a/i18n/zh-CN/skills/interpret-ir-spectrum/SKILL.md
+++ b/i18n/zh-CN/skills/interpret-ir-spectrum/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: spectroscopy
   complexity: intermediate
   language: natural
-  tags: spectroscopy, infrared, functional-groups, wavenumber, absorption
+  tags: spectroscopy, ir, infrared, functional-groups, absorption
 ---
 
 # 解读红外光谱

--- a/i18n/zh-CN/skills/interpret-mass-spectrum/SKILL.md
+++ b/i18n/zh-CN/skills/interpret-mass-spectrum/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: spectroscopy
   complexity: advanced
   language: natural
-  tags: spectroscopy, mass-spectrometry, fragmentation, molecular-ion, isotope-pattern
+  tags: spectroscopy, mass-spectrometry, fragmentation, molecular-ion, isotope
 ---
 
 # 解读质谱

--- a/i18n/zh-CN/skills/interpret-nmr-spectrum/SKILL.md
+++ b/i18n/zh-CN/skills/interpret-nmr-spectrum/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: spectroscopy
   complexity: advanced
   language: natural
-  tags: spectroscopy, nmr, structure-elucidation, chemical-shift, coupling-constant
+  tags: spectroscopy, nmr, chemical-shift, coupling, structure-elucidation
 ---
 
 # 解读核磁共振谱

--- a/i18n/zh-CN/skills/interpret-raman-spectrum/SKILL.md
+++ b/i18n/zh-CN/skills/interpret-raman-spectrum/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: spectroscopy
   complexity: intermediate
   language: natural
-  tags: spectroscopy, raman, selection-rules, polarizability, mutual-exclusion
+  tags: spectroscopy, raman, polarizability, vibrational, complementary-ir
 ---
 
 # 解读拉曼光谱

--- a/i18n/zh-CN/skills/intrinsic/SKILL.md
+++ b/i18n/zh-CN/skills/intrinsic/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   domain: esoteric
   complexity: intermediate
   language: natural
-  tags: esoteric, intrinsic, motivation, autonomy, competence, purpose, meta-cognition, ai-self-application
+  tags: esoteric, intrinsic-motivation, self-determination, flow, engagement, meta-cognition
 ---
 
 # Intrinsic（内在动机）

--- a/i18n/zh-CN/skills/make-fire/SKILL.md
+++ b/i18n/zh-CN/skills/make-fire/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   domain: bushcraft
   complexity: intermediate
   language: natural
-  tags: bushcraft, fire, survival, wilderness, friction-fire
+  tags: bushcraft, fire, survival, wilderness, primitive-skills
   locale: zh-CN
   source_locale: en
   source_commit: 33b561c9

--- a/i18n/zh-CN/skills/plan-spectroscopic-analysis/SKILL.md
+++ b/i18n/zh-CN/skills/plan-spectroscopic-analysis/SKILL.md
@@ -17,7 +17,7 @@ metadata:
   domain: spectroscopy
   complexity: intermediate
   language: natural
-  tags: spectroscopy, analytical-planning, technique-selection, structure-elucidation
+  tags: spectroscopy, analytical-planning, technique-selection, sample-preparation
 ---
 
 # 规划谱学分析方案

--- a/i18n/zh-CN/skills/prove-geometric-theorem/SKILL.md
+++ b/i18n/zh-CN/skills/prove-geometric-theorem/SKILL.md
@@ -9,9 +9,9 @@ metadata:
   author: Philipp Thoss
   version: "1.0"
   domain: geometry
-  complexity: intermediate
-  language: natural
-  tags: geometry, proof, theorem, coordinate-geometry, vector-geometry
+  complexity: advanced
+  language: multi
+  tags: geometry, proof, theorem, euclidean, axiomatic, coordinate
   locale: zh-CN
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/zh-CN/skills/shine/SKILL.md
+++ b/i18n/zh-CN/skills/shine/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   domain: esoteric
   complexity: intermediate
   language: natural
-  tags: esoteric, shine, authenticity, expression, meta-cognition, ai-self-application
+  tags: esoteric, radiance, authenticity, presence, engagement, stardust, luminosity
 ---
 
 # Shine（光辉）

--- a/i18n/zh-CN/skills/solve-modular-arithmetic/SKILL.md
+++ b/i18n/zh-CN/skills/solve-modular-arithmetic/SKILL.md
@@ -11,8 +11,8 @@ metadata:
   version: "1.0"
   domain: number-theory
   complexity: intermediate
-  language: natural
-  tags: number-theory, modular-arithmetic, congruences, chinese-remainder-theorem, rsa
+  language: multi
+  tags: number-theory, modular-arithmetic, congruences, crt, euler
   locale: zh-CN
   source_locale: en
   source_commit: 6f65f316

--- a/i18n/zh-CN/skills/solve-trigonometric-problem/SKILL.md
+++ b/i18n/zh-CN/skills/solve-trigonometric-problem/SKILL.md
@@ -11,8 +11,8 @@ metadata:
   version: "1.0"
   domain: geometry
   complexity: intermediate
-  language: natural
-  tags: geometry, trigonometry, identities, triangles, equations
+  language: multi
+  tags: geometry, trigonometry, identities, triangle, sines, cosines
   locale: zh-CN
   source_locale: en
   source_commit: 6f65f316

--- a/scripts/check-i18n-frontmatter-parity.js
+++ b/scripts/check-i18n-frontmatter-parity.js
@@ -8,10 +8,27 @@
  * changes, every locale snapshot silently desyncs (the drift class behind
  * PR #368; root cause filed as #371).
  *
- * Currently compares: allowed-tools (the field that actually drifted).
- * Extending to tags/domain/language is a recorded follow-up decision — the
- * corpus carries pre-existing paraphrase drift in tags that needs its own
- * catch-up first (see #371 discussion).
+ * Compares every keep-in-English frontmatter field EXCEPT `version` (#485).
+ *
+ * `version` is deliberately excluded and must stay excluded. It diverges on 317
+ * of 3,576 pairs across all ten locales, and that is not drift: a translation
+ * records the English version it was made from, so a bump on the English side
+ * is expected to leave the snapshot behind. Gating it would fail 317 files for
+ * doing the right thing.
+ *
+ * The remaining fields were measured at the time this was extended:
+ *
+ *   tags           61 divergences   de 11, es 19, ja  9, zh-CN 22
+ *   language       14 divergences   es  3, ja  6, zh-CN 5
+ *   complexity     13 divergences   es  8, ja  2, zh-CN 3
+ *   domain          0
+ *   author          0
+ *   allowed-tools   0   (repaired by 439d92df; dead as a live detector, see #485)
+ *
+ * All 88 were caught up in the commit that extended this, and every divergent
+ * value was recorded on #543 first — those files are that issue's screening
+ * population, and pasting English over them destroys the signal that identifies
+ * them.
  *
  * Deliberately does NOT parse the full frontmatter as YAML: pilot-era
  * translations carry shape variance (locale fields at top level vs under
@@ -45,23 +62,49 @@ function extractFrontmatter(text) {
 }
 
 /**
- * Extract allowed-tools tokens from a frontmatter block.
- * Inline form:  allowed-tools: Bash Read Write
- * Block form:   allowed-tools:\n  - Bash\n  - Read
+ * The keep-in-English fields this gate compares. `version` is excluded on purpose —
+ * see the header. Order is the report order.
+ */
+const GATED_FIELDS = ['allowed-tools', 'tags', 'domain', 'language', 'complexity', 'author'];
+
+/**
+ * Extract one field from a frontmatter block, at ANY indent.
+ *
+ * The indent tolerance is load-bearing, not defensive. `allowed-tools` sits at column 0,
+ * but `tags`, `domain`, `language`, `complexity` and `author` are all nested under
+ * `metadata:` — so a column-anchored `^tags:` matches **zero** of the 3,576 pairs and the
+ * gate reports clean having compared nothing. That was measured, not assumed:
+ *
+ *   tags        found at indent 0: 0    at any indent: 3526
+ *   language    found at indent 0: 0    at any indent: 3576
+ *   complexity  found at indent 0: 0    at any indent: 3576
+ *
+ * It also covers the two frontmatter shapes this corpus carries (#533): `de`/`zh-CN` nest
+ * the locale fields under `metadata:` while `ja`/`es` place them top-level.
+ *
+ * Inline form:  <field>: a b c
+ * Block form:   <field>:\n  - a\n  - b
  * Returns an array of tokens, or null when the field is absent.
  */
-function extractAllowedTools(fmText) {
+function extractField(fmText, key) {
   if (fmText === null) return null;
+  const inlineRe = new RegExp(`^[ \\t]*${key}:[ \\t]*(\\S.*)$`);
+  const emptyRe = new RegExp(`^([ \\t]*)${key}:[ \\t]*$`);
   const lines = fmText.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
-    const inline = lines[i].match(/^allowed-tools:[ \t]*(\S.*)$/);
-    if (inline) return inline[1].trim().split(/[\s,]+/);
-    if (/^allowed-tools:[ \t]*$/.test(lines[i])) {
+    const inline = lines[i].match(inlineRe);
+    if (inline) return inline[1].trim().split(/[\s,]+/).filter(Boolean);
+    const empty = lines[i].match(emptyRe);
+    if (empty) {
       const items = [];
+      const keyIndent = empty[1].length;
       for (let j = i + 1; j < lines.length; j++) {
         const item = lines[j].match(/^[ \t]+-[ \t]*(\S.*)$/);
-        if (item) items.push(item[1].trim());
-        else if (/^\S/.test(lines[j])) break; // next top-level key
+        if (item) { items.push(item[1].trim()); continue; }
+        // A line indented no further than the key ends the block. Anchoring on `^\S`
+        // would run a nested field's list into the following sibling keys.
+        const indent = lines[j].match(/^[ \t]*/)[0].length;
+        if (lines[j].trim() !== '' && indent <= keyIndent) break;
       }
       return items;
     }
@@ -69,17 +112,20 @@ function extractAllowedTools(fmText) {
   return null;
 }
 
-// Cache the English side once: skill name -> token array (or null).
-const englishTools = new Map();
+// Cache the English side once: skill name -> { field -> token array (or null) }.
+const englishFields = new Map();
 for (const skillName of readdirSync(SKILLS_DIR)) {
   if (skillName.startsWith('_')) continue;
   const sourcePath = join(SKILLS_DIR, skillName, 'SKILL.md');
   if (!existsSync(sourcePath)) continue;
   const fm = extractFrontmatter(readFileSync(sourcePath, 'utf8'));
-  englishTools.set(skillName, extractAllowedTools(fm));
+  const byField = {};
+  for (const field of GATED_FIELDS) byField[field] = extractField(fm, field);
+  englishFields.set(skillName, byField);
 }
 
-let compared = 0;
+let comparedPairs = 0;
+let comparedFields = 0;
 const problems = []; // { file, kind, detail }
 
 for (const locale of readdirSync(I18N_DIR)) {
@@ -90,31 +136,36 @@ for (const locale of readdirSync(I18N_DIR)) {
     if (!existsSync(translatedPath)) continue;
     const relPath = `i18n/${locale}/skills/${skillName}/SKILL.md`;
 
-    if (!englishTools.has(skillName)) {
+    if (!englishFields.has(skillName)) {
       problems.push({ file: relPath, kind: 'ORPHAN', detail: 'no English source skill' });
       continue;
     }
-    const sourceTokens = englishTools.get(skillName);
+    const source = englishFields.get(skillName);
     const fm = extractFrontmatter(readFileSync(translatedPath, 'utf8'));
-    const translatedTokens = extractAllowedTools(fm);
-    compared++;
+    comparedPairs++;
 
-    if (sourceTokens === null) {
-      // English has no allowed-tools; a translation must not invent one.
-      if (translatedTokens !== null) {
-        problems.push({ file: relPath, kind: 'EXTRA', detail: `allowed-tools "${translatedTokens.join(' ')}" but English source has no such field` });
+    for (const field of GATED_FIELDS) {
+      const sourceTokens = source[field];
+      const translatedTokens = extractField(fm, field);
+
+      if (sourceTokens === null) {
+        // English has no such field; a translation must not invent one.
+        if (translatedTokens !== null) {
+          problems.push({ file: relPath, kind: 'EXTRA', detail: `${field} "${translatedTokens.join(' ')}" but English source has no such field` });
+        }
+        continue;
       }
-      continue;
-    }
+      comparedFields++;
 
-    if (translatedTokens === null) {
-      problems.push({ file: relPath, kind: 'MISSING', detail: `allowed-tools absent (source: ${sourceTokens.join(' ')})` });
-    } else if (translatedTokens.join(' ') !== sourceTokens.join(' ')) {
-      problems.push({
-        file: relPath,
-        kind: 'MISMATCH',
-        detail: `allowed-tools "${translatedTokens.join(' ')}" != source "${sourceTokens.join(' ')}"`,
-      });
+      if (translatedTokens === null) {
+        problems.push({ file: relPath, kind: 'MISSING', detail: `${field} absent (source: ${sourceTokens.join(' ')})` });
+      } else if (translatedTokens.join(' ') !== sourceTokens.join(' ')) {
+        problems.push({
+          file: relPath,
+          kind: 'MISMATCH',
+          detail: `${field} "${translatedTokens.join(' ')}" != source "${sourceTokens.join(' ')}"`,
+        });
+      }
     }
   }
 }
@@ -122,11 +173,15 @@ for (const locale of readdirSync(I18N_DIR)) {
 const label = WARN_ONLY ? 'WARN' : 'FAIL';
 for (const p of problems) console.log(`${label} [${p.kind}] ${p.file}: ${p.detail}`);
 
-console.log(`\ni18n frontmatter parity: ${compared} translated skills compared against ${englishTools.size} English sources.`);
+console.log(`\ni18n frontmatter parity: ${comparedPairs} translated skills against ${englishFields.size} English sources;`);
+// Field comparisons are reported because the pair count alone cannot distinguish "compared
+// six fields per pair" from "matched nothing and reported clean" — the exact failure a
+// column-anchored implementation produces.
+console.log(`${comparedFields} field comparison(s) across: ${GATED_FIELDS.join(', ')} (version excluded by design).`);
 if (problems.length === 0) {
-  console.log('OK: all keep-in-English allowed-tools fields match their source.');
+  console.log('OK: all keep-in-English frontmatter fields match their source.');
 } else {
-  console.log(`${problems.length} parity problem(s) found. Fix: copy the English allowed-tools value verbatim (keep-in-English field, see i18n/README.md).`);
+  console.log(`${problems.length} parity problem(s) found. Fix: copy the English value verbatim (keep-in-English fields, see i18n/README.md).`);
 }
 
 process.exit(problems.length > 0 && !WARN_ONLY ? 1 : 0);

--- a/scripts/check-i18n-frontmatter-parity.js
+++ b/scripts/check-i18n-frontmatter-parity.js
@@ -8,13 +8,20 @@
  * changes, every locale snapshot silently desyncs (the drift class behind
  * PR #368; root cause filed as #371).
  *
- * Compares every keep-in-English frontmatter field EXCEPT `version` (#485).
+ * Compares every keep-in-English frontmatter field on EQUALITY except `version`,
+ * which is compared on DIRECTION instead (#485).
  *
- * `version` is deliberately excluded and must stay excluded. It diverges on 317
- * of 3,576 pairs across all ten locales, and that is not drift: a translation
- * records the English version it was made from, so a bump on the English side
- * is expected to leave the snapshot behind. Gating it would fail 317 files for
- * doing the right thing.
+ * `version` cannot be gated on equality. It diverges on 317 of 3,576 pairs
+ * across all ten locales, and that is not drift: a translation records the
+ * English version it was made from, so a bump on the English side is expected to
+ * leave the snapshot behind. Gating equality would fail 317 files for doing the
+ * right thing.
+ *
+ * But it can be gated on direction. All 317 divergences are the translation
+ * running BEHIND its source; measured, exactly 0 run ahead. Nothing legitimate
+ * produces a translation claiming a version its source never reached — that can
+ * only come from metadata being authored rather than copied, which is the #543
+ * signature. So the AHEAD case is blocking, with nothing to catch up.
  *
  * The remaining fields were measured at the time this was extended:
  *
@@ -66,6 +73,35 @@ function extractFrontmatter(text) {
  * see the header. Order is the report order.
  */
 const GATED_FIELDS = ['allowed-tools', 'tags', 'domain', 'language', 'complexity', 'author'];
+
+/**
+ * `version` cannot be gated on equality, but it can be gated on DIRECTION.
+ *
+ * A translation records the English version it was made from, so lagging behind is correct
+ * and 317 of 3,576 pairs do exactly that. Running *ahead* is a different thing: no
+ * legitimate process produces a translation claiming a version its source never reached.
+ * It can only come from metadata being authored rather than copied — the #543 signature.
+ *
+ * Measured before this was added: 317 behind, **0 ahead**, 0 incomparable. So the check
+ * ships blocking with nothing to catch up, and it closes the hole a blanket exclusion
+ * would leave open.
+ */
+function compareVersions(a, b) {
+  const parts = (v) => v.replace(/^["']|["']$/g, '').split('.')
+    .map((x) => (/^\d+$/.test(x) ? Number(x) : x));
+  const pa = parts(a);
+  const pb = parts(b);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i += 1) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x === y) continue;
+    // A non-numeric segment (a pre-release tag, say) falls back to string order rather
+    // than being silently treated as equal.
+    if (typeof x === 'number' && typeof y === 'number') return x < y ? -1 : 1;
+    return String(x) < String(y) ? -1 : 1;
+  }
+  return 0;
+}
 
 /**
  * Extract one field from a frontmatter block, at ANY indent.
@@ -121,11 +157,13 @@ for (const skillName of readdirSync(SKILLS_DIR)) {
   const fm = extractFrontmatter(readFileSync(sourcePath, 'utf8'));
   const byField = {};
   for (const field of GATED_FIELDS) byField[field] = extractField(fm, field);
+  byField.version = extractField(fm, 'version');
   englishFields.set(skillName, byField);
 }
 
 let comparedPairs = 0;
 let comparedFields = 0;
+let versionsChecked = 0;
 const problems = []; // { file, kind, detail }
 
 for (const locale of readdirSync(I18N_DIR)) {
@@ -167,6 +205,23 @@ for (const locale of readdirSync(I18N_DIR)) {
         });
       }
     }
+
+    // version: direction only, never equality. See compareVersions.
+    const sourceVersion = extractField(fm === null ? null : fm, 'version');
+    const englishVersion = source.version;
+    if (englishVersion !== null && sourceVersion !== null) {
+      versionsChecked++;
+      // Values are usually YAML-quoted (`version: "1.0"`); strip for display so the
+      // message does not read `""1.0""`.
+      const unquote = (v) => v.join(' ').replace(/^["']|["']$/g, '');
+      if (compareVersions(sourceVersion.join(' '), englishVersion.join(' ')) > 0) {
+        problems.push({
+          file: relPath,
+          kind: 'AHEAD',
+          detail: `version "${unquote(sourceVersion)}" is ahead of source "${unquote(englishVersion)}" — a translation cannot legitimately reach a version its source never did`,
+        });
+      }
+    }
   }
 }
 
@@ -177,11 +232,18 @@ console.log(`\ni18n frontmatter parity: ${comparedPairs} translated skills again
 // Field comparisons are reported because the pair count alone cannot distinguish "compared
 // six fields per pair" from "matched nothing and reported clean" — the exact failure a
 // column-anchored implementation produces.
-console.log(`${comparedFields} field comparison(s) across: ${GATED_FIELDS.join(', ')} (version excluded by design).`);
+console.log(`${comparedFields} field comparison(s) across: ${GATED_FIELDS.join(', ')};`);
+console.log(`${versionsChecked} version(s) checked for direction only (lagging is legitimate, running ahead is not).`);
 if (problems.length === 0) {
   console.log('OK: all keep-in-English frontmatter fields match their source.');
 } else {
   console.log(`${problems.length} parity problem(s) found. Fix: copy the English value verbatim (keep-in-English fields, see i18n/README.md).`);
+  if (problems.some((p) => p.kind === 'AHEAD')) {
+    // Copying English is the wrong advice here: the translation's version is meant to lag.
+    console.log('For [AHEAD]: do NOT copy the English version. A translation ahead of its');
+    console.log('source means the value was authored rather than recorded — investigate the');
+    console.log('file before changing anything (see #543).');
+  }
 }
 
 process.exit(problems.length > 0 && !WARN_ONLY ? 1 : 0);

--- a/scripts/check-i18n-frontmatter-parity.js
+++ b/scripts/check-i18n-frontmatter-parity.js
@@ -69,8 +69,8 @@ function extractFrontmatter(text) {
 }
 
 /**
- * The keep-in-English fields this gate compares. `version` is excluded on purpose —
- * see the header. Order is the report order.
+ * The keep-in-English fields compared on EQUALITY. `version` is absent here because it
+ * is compared on DIRECTION instead — see compareVersions. Order is the report order.
  */
 const GATED_FIELDS = ['allowed-tools', 'tags', 'domain', 'language', 'complexity', 'author'];
 
@@ -111,16 +111,36 @@ function compareVersions(a, b) {
  * `metadata:` — so a column-anchored `^tags:` matches **zero** of the 3,576 pairs and the
  * gate reports clean having compared nothing. That was measured, not assumed:
  *
- *   tags        found at indent 0: 0    at any indent: 3526
+ *   tags        found at indent 0: 0    at any indent: 3576
  *   language    found at indent 0: 0    at any indent: 3576
  *   complexity  found at indent 0: 0    at any indent: 3576
  *
- * It also covers the two frontmatter shapes this corpus carries (#533): `de`/`zh-CN` nest
- * the locale fields under `metadata:` while `ja`/`es` place them top-level.
+ * (An earlier probe reported 3,526 for `tags`. That probe matched the inline form only;
+ * the missing 50 are the block-form files below, which this function does find.)
+ *
+ * It also covers the two frontmatter shapes this corpus carries (#533). The variance is
+ * per FILE, not per locale: `i18n/es/skills/create-skill/SKILL.md` nests `locale:` under
+ * `metadata:` while `i18n/es/skills/construct-geometric-figure/SKILL.md` puts
+ * `source_commit:` at column 0, and `ja` does both too. Indent tolerance is the only thing
+ * that survives that, which is a stronger argument than a per-locale rule would be.
  *
  * Inline form:  <field>: a b c
  * Block form:   <field>:\n  - a\n  - b
+ *
+ * Block form is live, not defensive: `skills/install-almanac-content/SKILL.md` carries
+ * block-form `allowed-tools` (grant `- Bash`) in English and all ten locales, and 50
+ * translated files carry block-form `tags` — 60 field comparisons the inline branch alone
+ * cannot see, including the one grant this gate most exists to protect.
+ *
+ * The block terminator compares indent against the KEY's indent. `^\S` would not fire for
+ * a nested list and would run into sibling keys; `indent < keyIndent` would never fire for
+ * a column-0 key and would swallow the rest of the frontmatter. Both are tested.
+ *
  * Returns an array of tokens, or null when the field is absent.
+ *
+ * Known latent: a quoted list (`tags: "a, b"`) tokenises to `"a` / `b"` and would
+ * false-MISMATCH against an unquoted source. No such pair exists in the corpus — the only
+ * quoted gated value is `allowed-tools: ""`, identical on both sides.
  */
 function extractField(fmText, key) {
   if (fmText === null) return null;
@@ -207,18 +227,18 @@ for (const locale of readdirSync(I18N_DIR)) {
     }
 
     // version: direction only, never equality. See compareVersions.
-    const sourceVersion = extractField(fm === null ? null : fm, 'version');
+    const translatedVersion = extractField(fm, 'version');
     const englishVersion = source.version;
-    if (englishVersion !== null && sourceVersion !== null) {
+    if (englishVersion !== null && translatedVersion !== null) {
       versionsChecked++;
       // Values are usually YAML-quoted (`version: "1.0"`); strip for display so the
       // message does not read `""1.0""`.
       const unquote = (v) => v.join(' ').replace(/^["']|["']$/g, '');
-      if (compareVersions(sourceVersion.join(' '), englishVersion.join(' ')) > 0) {
+      if (compareVersions(translatedVersion.join(' '), englishVersion.join(' ')) > 0) {
         problems.push({
           file: relPath,
           kind: 'AHEAD',
-          detail: `version "${unquote(sourceVersion)}" is ahead of source "${unquote(englishVersion)}" — a translation cannot legitimately reach a version its source never did`,
+          detail: `version "${unquote(translatedVersion)}" is ahead of source "${unquote(englishVersion)}" — a translation cannot legitimately reach a version its source never did`,
         });
       }
     }

--- a/scripts/test/check-i18n-frontmatter-parity.test.js
+++ b/scripts/test/check-i18n-frontmatter-parity.test.js
@@ -5,7 +5,7 @@
  * exactly the kind that fails silently: `tags`, `domain`, `language`, `complexity` and
  * `author` are all nested under `metadata:`, so a column-anchored `^tags:` matches
  * **nothing** and the gate reports clean having compared zero fields. Measured before the
- * fix: 0 of 3,576 pairs found at indent 0, 3,526 found at any indent.
+ * fix: 0 of 3,576 pairs found at indent 0, all 3,576 found at any indent.
  *
  * Two properties therefore matter more than the individual verdicts:
  *
@@ -14,8 +14,8 @@
  *      "matched nothing". The script prints the field-comparison count for this reason and
  *      the tests assert on it.
  *
- * Fixtures cover BOTH frontmatter shapes this corpus carries (#533): locale fields nested
- * under `metadata:` (de, zh-CN) and placed top-level (ja, es).
+ * Fixtures cover BOTH frontmatter shapes this corpus carries (#533) and both value forms.
+ * The shape varies per FILE, not per locale — `es` and `ja` each carry both.
  */
 
 import { test } from 'node:test';
@@ -59,9 +59,43 @@ function shapeA(over = {}) {
   return english(over).replace('  author:', '  locale: de\n  source_locale: en\n  author:');
 }
 
-/** Shape B — locale fields at top level, as ja and es carry them. */
+/** Shape B — locale fields at top level. Both shapes occur, per file, not per locale. */
 function shapeB(over = {}) {
   return english(over).replace('allowed-tools:', 'locale: ja\nsource_locale: en\nallowed-tools:');
+}
+
+/**
+ * Block form: `allowed-tools` as a YAML list at indent 0, and `tags` as a list nested
+ * under `metadata:`. This is not hypothetical — `skills/install-almanac-content/SKILL.md`
+ * carries block-form `allowed-tools` (grant `- Bash`) in English and all ten locales, and
+ * 50 translated files carry block-form `tags`. Together that is 60 live field comparisons
+ * the inline branch alone cannot see.
+ *
+ * Each list is followed by a sibling key at the SAME indent as its own key, which is what
+ * exercises the block terminator: a terminator of `indent < keyIndent` never fires for a
+ * column-0 key and swallows everything after it.
+ */
+function blockForm({ tools = ['Bash', 'Read', 'Glob'], tags = ['shiny', 'ui', 'theming'] } = {}) {
+  return [
+    '---',
+    'name: demo-skill',
+    'description: A demo skill.',
+    'allowed-tools:',
+    ...tools.map((t) => `  - ${t}`),
+    'metadata:',
+    '  author: Philipp Thoss',
+    '  version: "1.0"',
+    '  domain: shiny',
+    '  complexity: intermediate',
+    '  language: R',
+    '  tags:',
+    ...tags.map((t) => `    - ${t}`),
+    '  locale: de',
+    '---',
+    '',
+    '# Demo Skill',
+    '',
+  ].join('\n');
 }
 
 function fixture(t, translations) {
@@ -122,7 +156,62 @@ test('the comparison count matches what is on disk', () => {
   }
 });
 
-// --- version is excluded, and must stay excluded ---------------------------------------
+// --- block form, which the inline branch cannot see ------------------------------------
+
+test('block-form allowed-tools is compared, at indent 0 with a sibling key after it', () => {
+  // Deleting the block branch leaves every inline test green while silently dropping
+  // `allowed-tools` on install-almanac-content — the skill granting `- Bash` — in all ten
+  // locales. That is the #368/#371 drift class this gate exists for.
+  const dir = mkdtempSync(join(tmpdir(), 'fm-parity-block-'));
+  try {
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+    mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+    writeFileSync(join(dir, 'skills', 'demo-skill', 'SKILL.md'), blockForm(), 'utf8');
+
+    const p = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, blockForm({ tools: ['Bash', 'Read'] }), 'utf8');
+
+    const r = run(dir);
+    assert.equal(r.status, 1, 'block-form allowed-tools drift was not detected');
+    assert.match(r.stdout, /allowed-tools "Bash Read" != source "Bash Read Glob"/);
+    // The list must stop at the sibling `metadata:` key rather than absorbing it. A
+    // terminator of `indent < keyIndent` never fires for a column-0 key, and the value
+    // would then read "Bash Read author ... tags shiny ui theming locale de" — which stays
+    // symmetric on both sides, so only this assertion catches it.
+    assert.doesNotMatch(r.stdout, /allowed-tools "[^"]*author/, 'the list ran past its sibling key');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('block-form tags nested under metadata is compared, and stops at its sibling', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'fm-parity-block2-'));
+  try {
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+    mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+    writeFileSync(join(dir, 'skills', 'demo-skill', 'SKILL.md'), blockForm(), 'utf8');
+
+    const p = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, blockForm({ tags: ['shiny', 'ui', 'INVENTED'] }), 'utf8');
+
+    const r = run(dir);
+    assert.equal(r.status, 1, 'block-form tags drift was not detected');
+    assert.match(r.stdout, /tags "shiny ui INVENTED" != source "shiny ui theming"/);
+    // `tags` sits at indent 2 with `locale: de` following at indent 2. The list must end
+    // there rather than swallowing the sibling.
+    assert.doesNotMatch(r.stdout, /tags "[^"]*locale/, 'the nested list ran past its sibling key');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- version: direction, not equality --------------------------------------------------
 
 test('a lagging version passes — a translation pins what it was made from', () => {
   // 317 of 3,576 real pairs lag. Gating equality would fail them all for being correct.

--- a/scripts/test/check-i18n-frontmatter-parity.test.js
+++ b/scripts/test/check-i18n-frontmatter-parity.test.js
@@ -1,0 +1,230 @@
+/**
+ * Behavioural tests for `scripts/check-i18n-frontmatter-parity.js` (#485).
+ *
+ * There was no test file for this script before #485 extended it, and the extension is
+ * exactly the kind that fails silently: `tags`, `domain`, `language`, `complexity` and
+ * `author` are all nested under `metadata:`, so a column-anchored `^tags:` matches
+ * **nothing** and the gate reports clean having compared zero fields. Measured before the
+ * fix: 0 of 3,576 pairs found at indent 0, 3,526 found at any indent.
+ *
+ * Two properties therefore matter more than the individual verdicts:
+ *
+ *   1. A nested field is actually compared — the vacuity guard.
+ *   2. The number of comparisons matches what is on disk, so "clean" cannot mean
+ *      "matched nothing". The script prints the field-comparison count for this reason and
+ *      the tests assert on it.
+ *
+ * Fixtures cover BOTH frontmatter shapes this corpus carries (#533): locale fields nested
+ * under `metadata:` (de, zh-CN) and placed top-level (ja, es).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = 'scripts/check-i18n-frontmatter-parity.js';
+
+/** English source: locale fields absent, everything else under `metadata:`. */
+function english(over = {}) {
+  const m = {
+    author: 'Philipp Thoss',
+    version: '"1.0"',
+    domain: 'shiny',
+    complexity: 'intermediate',
+    language: 'R',
+    tags: 'shiny, ui, theming',
+    ...over,
+  };
+  return [
+    '---',
+    'name: demo-skill',
+    'description: A demo skill.',
+    'allowed-tools: Read Write Edit',
+    'metadata:',
+    ...Object.entries(m).map(([k, v]) => `  ${k}: ${v}`),
+    '---',
+    '',
+    '# Demo Skill',
+    '',
+  ].join('\n');
+}
+
+/** Shape A — locale fields nested under `metadata:`, as de and zh-CN carry them. */
+function shapeA(over = {}) {
+  return english(over).replace('  author:', '  locale: de\n  source_locale: en\n  author:');
+}
+
+/** Shape B — locale fields at top level, as ja and es carry them. */
+function shapeB(over = {}) {
+  return english(over).replace('allowed-tools:', 'locale: ja\nsource_locale: en\nallowed-tools:');
+}
+
+function fixture(t, translations) {
+  const dir = mkdtempSync(join(tmpdir(), 'fm-parity-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+
+  mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'demo-skill', 'SKILL.md'), english(), 'utf8');
+
+  for (const [locale, body] of Object.entries(translations)) {
+    const p = join(dir, 'i18n', locale, 'skills', 'demo-skill', 'SKILL.md');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, body, 'utf8');
+  }
+  return dir;
+}
+
+function run(dir, args = []) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { cwd: dir, encoding: 'utf8' });
+}
+
+/** The `N field comparison(s)` the script reports. */
+function comparisons(stdout) {
+  const m = stdout.match(/(\d+) field comparison\(s\)/);
+  return m ? Number(m[1]) : -1;
+}
+
+// --- the vacuity guard ----------------------------------------------------------------
+
+test('a nested field is compared, not skipped — in both frontmatter shapes', () => {
+  // The whole point. Under column anchoring these would be invisible and the run clean.
+  for (const [label, make] of [['shape A (nested)', shapeA], ['shape B (top-level)', shapeB]]) {
+    const dir = fixture({ after: () => {} }, { de: make({ tags: 'shiny, ui, INVENTED' }) });
+    try {
+      const r = run(dir, ['--warn']);
+      assert.match(r.stdout, /MISMATCH/, `${label}: nested tags drift was not detected`);
+      assert.match(r.stdout, /tags "shiny ui INVENTED" != source "shiny ui theming"/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+test('the comparison count matches what is on disk', () => {
+  // "clean" must not be reachable by comparing nothing. Six gated fields are present on
+  // the English source, so one translated pair must yield exactly six comparisons.
+  const dir = fixture({ after: () => {} }, { de: shapeA() });
+  try {
+    const r = run(dir);
+    assert.equal(r.status, 0, r.stdout);
+    assert.equal(comparisons(r.stdout), 6, 'not every gated field was compared');
+    assert.match(r.stdout, /1 translated skills against 1 English sources/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- version is excluded, and must stay excluded ---------------------------------------
+
+test('version may differ without failing — a translation pins what it was made from', () => {
+  // 317 of 3,576 real pairs diverge here. Gating it would fail them all for being correct.
+  const dir = fixture({ after: () => {} }, { de: shapeA({ version: '"0.9"' }) });
+  try {
+    const r = run(dir);
+    assert.equal(r.status, 0, r.stdout);
+    // Scoped to a reported problem: the summary line legitimately names `version` when it
+    // says the field is excluded by design, so a bare /version/i match is too loose.
+    assert.doesNotMatch(r.stdout, /(MISMATCH|MISSING|EXTRA)\] .*version /, 'version was gated');
+    assert.match(r.stdout, /version excluded by design/, 'the exclusion should be stated in the report');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- each verdict fires ----------------------------------------------------------------
+
+test('every gated field is actually gated', () => {
+  const cases = [
+    ['tags', { tags: 'shiny, ui, other' }],
+    ['domain', { domain: 'r-packages' }],
+    ['language', { language: 'natural' }],
+    ['complexity', { complexity: 'basic' }],
+    ['author', { author: 'Someone Else' }],
+  ];
+  for (const [field, over] of cases) {
+    const dir = fixture({ after: () => {} }, { de: shapeA(over) });
+    try {
+      const r = run(dir);
+      assert.equal(r.status, 1, `${field} drift did not fail the gate`);
+      assert.match(r.stdout, new RegExp(`MISMATCH\\] .*${field} `), `${field} was not reported`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+test('allowed-tools at column 0 still works after the indent change', () => {
+  const dir = fixture({ after: () => {} }, { de: shapeA().replace('allowed-tools: Read Write Edit', 'allowed-tools: Read Write') });
+  try {
+    const r = run(dir);
+    assert.equal(r.status, 1);
+    assert.match(r.stdout, /allowed-tools "Read Write" != source "Read Write Edit"/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a field the translation drops is MISSING; one it invents is EXTRA', () => {
+  const dropped = shapeA().replace('  tags: shiny, ui, theming\n', '');
+  const missing = fixture({ after: () => {} }, { de: dropped });
+  try {
+    const r = run(missing, ['--warn']);
+    assert.match(r.stdout, /MISSING\] .*tags absent/);
+  } finally {
+    rmSync(missing, { recursive: true, force: true });
+  }
+
+  // English without tags, translation with them.
+  const dir = mkdtempSync(join(tmpdir(), 'fm-parity-extra-'));
+  try {
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+    mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+    writeFileSync(
+      join(dir, 'skills', 'demo-skill', 'SKILL.md'),
+      english().replace('  tags: shiny, ui, theming\n', ''),
+      'utf8',
+    );
+    const p = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, shapeA(), 'utf8');
+    const r = run(dir, ['--warn']);
+    assert.match(r.stdout, /EXTRA\] .*tags .*but English source has no such field/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a translation with no English source is an ORPHAN', () => {
+  const dir = fixture({ after: () => {} }, { de: shapeA() });
+  try {
+    const p = join(dir, 'i18n', 'de', 'skills', 'ghost-skill', 'SKILL.md');
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, shapeA(), 'utf8');
+    const r = run(dir, ['--warn']);
+    assert.match(r.stdout, /ORPHAN\] .*ghost-skill/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// --- exit posture ----------------------------------------------------------------------
+
+test('--warn reports without failing; the bare run fails', () => {
+  const dir = fixture({ after: () => {} }, { de: shapeA({ tags: 'drifted' }) });
+  try {
+    assert.equal(run(dir, ['--warn']).status, 0, '--warn should not fail the build');
+    assert.equal(run(dir).status, 1, 'the gate should be blocking by default');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/test/check-i18n-frontmatter-parity.test.js
+++ b/scripts/test/check-i18n-frontmatter-parity.test.js
@@ -124,18 +124,43 @@ test('the comparison count matches what is on disk', () => {
 
 // --- version is excluded, and must stay excluded ---------------------------------------
 
-test('version may differ without failing — a translation pins what it was made from', () => {
-  // 317 of 3,576 real pairs diverge here. Gating it would fail them all for being correct.
+test('a lagging version passes — a translation pins what it was made from', () => {
+  // 317 of 3,576 real pairs lag. Gating equality would fail them all for being correct.
   const dir = fixture({ after: () => {} }, { de: shapeA({ version: '"0.9"' }) });
   try {
     const r = run(dir);
     assert.equal(r.status, 0, r.stdout);
-    // Scoped to a reported problem: the summary line legitimately names `version` when it
-    // says the field is excluded by design, so a bare /version/i match is too loose.
-    assert.doesNotMatch(r.stdout, /(MISMATCH|MISSING|EXTRA)\] .*version /, 'version was gated');
-    assert.match(r.stdout, /version excluded by design/, 'the exclusion should be stated in the report');
+    // Scoped to a reported problem: the summary line legitimately names `version`, so a
+    // bare /version/i match is too loose.
+    assert.doesNotMatch(r.stdout, /(MISMATCH|MISSING|EXTRA|AHEAD)\] .*version /, 'a lagging version was gated');
+    assert.match(r.stdout, /1 version\(s\) checked for direction/, 'the version check did not run');
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a version AHEAD of its source fails — nothing legitimate produces one', () => {
+  // Paired with the test above, which is what stops that one being vacuous: a check that
+  // passes a lagging version would also pass if it examined nothing at all.
+  const dir = fixture({ after: () => {} }, { de: shapeA({ version: '"1.1"' }) });
+  try {
+    const r = run(dir);
+    assert.equal(r.status, 1, 'a translation ahead of its source did not fail the gate');
+    assert.match(r.stdout, /AHEAD\] .*version "1\.1" is ahead of source "1\.0"/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('version direction compares numerically, not as strings', () => {
+  // '10' < '9' as strings. A string comparison would call 1.10 "ahead" of 1.9 and,
+  // worse, call a genuinely-ahead 1.9 "behind" 1.10 — a false pass.
+  const behind = fixture({ after: () => {} }, { de: shapeA({ version: '"1.9"' }) });
+  try {
+    // English is 1.0, so 1.9 IS ahead and must fail regardless of segment width.
+    assert.equal(run(behind).status, 1);
+  } finally {
+    rmSync(behind, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Closes #485.

## What ships

`check-i18n-frontmatter-parity.js` goes from **one** gated field to **six** — `allowed-tools`, `tags`, `domain`, `language`, `complexity`, `author` — and the corpus is caught up in the same commit, so the gate is blocking from the moment it lands. That is #371's own precedent, recorded in the workflow comment: it could ship blocking because its 39-file catch-up shipped with it.

**21,456 field comparisons** across 3,576 pairs, up from 3,576.

## `version` is excluded by design

It diverges on **317 of 3,576 pairs, across all ten locales** — and that is not drift. A translation records the English version it was made from, so an English bump is *expected* to leave the snapshot behind. Gating it would fail 317 files for being correct.

Measured at HEAD:

| field | drift | locales |
|---|---|---|
| `tags` | 61 | de 11, es 19, ja 9, zh-CN 22 |
| `language` | 14 | es 3, ja 6, zh-CN 5 |
| `complexity` | 13 | es 8, ja 2, zh-CN 3 |
| `domain` / `author` / `allowed-tools` | 0 | — already clean, so free to lock in |
| **`version`** | **317** | **all ten — excluded** |

## The indent trap is worse than the issue says

#485 warns that column-anchoring "skips 1,052 of 3,576 pairs". Measured, it is total: `tags`, `domain`, `language`, `complexity` and `author` are all nested under `metadata:`, so `^tags:` matches **nothing**.

```text
tags        found at indent 0: 0    at any indent: 3526
language    found at indent 0: 0    at any indent: 3576
complexity  found at indent 0: 0    at any indent: 3576
```

Demonstrated rather than described. With the anchored regex, against the **real corpus**:

```console
$ node scripts/check-i18n-frontmatter-parity.js
i18n frontmatter parity: 3576 translated skills against 369 English sources;
3576 field comparison(s) across: allowed-tools, tags, domain, language, complexity, author
OK: all keep-in-English frontmatter fields match their source.
EXIT=0
```

Exit 0, "OK", **88 genuine divergences sitting in the tree.** A perfectly vacuous gate.

That is why the script now prints its comparison count: **3,576 instead of 21,456 is the tell** that five of six fields matched nothing. Under anchoring, 5 of the 8 new tests fail.

The indent tolerance also covers the two frontmatter shapes the corpus carries (#533) — `de`/`zh-CN` nest the locale fields under `metadata:`, `ja`/`es` do not.

## Two corrections to the issue, both re-derived rather than quoted

- **The compressed-prose exemption is unnecessary.** All six `caveman`/`wenyan` locales preserve `tags`, `language` and `complexity` **byte-identically** (347/347 each). #485's body records 22 benign divergences there; at HEAD there are none — so neither the exemption nor the conjunctive code-token-survival design it offers as an alternative is needed. The plain comparison is exact.
- **61 files, not 56.** `de` fell from 12 to 11 when #541 removed `de/design-shiny-ui` earlier today.

## Catch-up, and the evidence it would have destroyed

88 fields across 61 files, by a repair script that **refuses any ambiguous edit**: it requires the field line to appear exactly once inside the frontmatter block, and preserves the original indent so both shapes survive. Zero refusals; the diff is exactly **88 insertions / 88 deletions**.

**Every divergent value was recorded on #543, with its before and after, *before* the repair ran.** Those 61 files are that issue's screening population, and pasting English over them destroys the signal that identifies them — the same laundering shape #534 existed to beat, replayed on the metadata axis.

## Verification

`scripts/test/check-i18n-frontmatter-parity.test.js` — there was no test file for this script. 8 tests: both frontmatter shapes, the vacuity guard, the comparison-count assertion, each verdict kind (MISMATCH/MISSING/EXTRA/ORPHAN), `version` staying ungated, and the `--warn` vs blocking postures.

`npm run mutation-check` kills the indent regex, the comparison counter, and the field list.

152/152 scripts tests. Fence parity **unchanged at 78/31**; yaml-fences, line-endings, content-style green.

Translation status **cannot** move and was not regenerated — verified rather than assumed: `generate-translation-status.js` reads only `source_commit` from frontmatter and compares bodies with frontmatter stripped, neither of which this touches.

## One honest note

The one-off repair script's regex uses `.*$`, which consumes a trailing `\r`, so on a CRLF file it would have dropped that line's carriage return and produced mixed endings. All 61 files happened to be LF, so it did not bite — ambient state, not a guarantee. The script is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8