### PR TITLE
fix(i18n): decide a scaffold by absence of translation, not equality with English (#473, #532)

### DIFF
--- a/i18n/caveman-lite/translation_status.yml
+++ b/i18n/caveman-lite/translation_status.yml
@@ -2,11 +2,11 @@ locale: caveman-lite
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 350
+    translated: 346
     total: 369
-    pct: 94.9
-    stale: 311
-    stubs: 2
+    pct: 93.8
+    stale: 307
+    stubs: 6
   agents:
     translated: 0
     total: 75
@@ -26,8 +26,8 @@ coverage:
     stale: 0
     stubs: 0
   total:
-    translated: 350
+    translated: 346
     total: 500
-    pct: 70
-    stale: 311
-    stubs: 2
+    pct: 69.2
+    stale: 307
+    stubs: 6

--- a/i18n/caveman-ultra/translation_status.yml
+++ b/i18n/caveman-ultra/translation_status.yml
@@ -2,11 +2,11 @@ locale: caveman-ultra
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 350
+    translated: 346
     total: 369
-    pct: 94.9
-    stale: 311
-    stubs: 2
+    pct: 93.8
+    stale: 307
+    stubs: 6
   agents:
     translated: 0
     total: 75
@@ -26,8 +26,8 @@ coverage:
     stale: 0
     stubs: 0
   total:
-    translated: 350
+    translated: 346
     total: 500
-    pct: 70
-    stale: 311
-    stubs: 2
+    pct: 69.2
+    stale: 307
+    stubs: 6

--- a/i18n/caveman/translation_status.yml
+++ b/i18n/caveman/translation_status.yml
@@ -2,11 +2,11 @@ locale: caveman
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 350
+    translated: 346
     total: 369
-    pct: 94.9
-    stale: 311
-    stubs: 2
+    pct: 93.8
+    stale: 307
+    stubs: 6
   agents:
     translated: 0
     total: 75
@@ -26,8 +26,8 @@ coverage:
     stale: 0
     stubs: 0
   total:
-    translated: 350
+    translated: 346
     total: 500
-    pct: 70
-    stale: 311
-    stubs: 2
+    pct: 69.2
+    stale: 307
+    stubs: 6

--- a/i18n/de/translation_status.yml
+++ b/i18n/de/translation_status.yml
@@ -2,11 +2,11 @@ locale: de
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 344
+    translated: 340
     total: 369
-    pct: 93.2
-    stale: 170
-    stubs: 22
+    pct: 92.1
+    stale: 166
+    stubs: 26
   agents:
     translated: 3
     total: 75
@@ -20,14 +20,14 @@ coverage:
     stale: 1
     stubs: 5
   guides:
-    translated: 4
+    translated: 3
     total: 34
-    pct: 11.8
-    stale: 3
-    stubs: 1
+    pct: 8.8
+    stale: 2
+    stubs: 2
   total:
-    translated: 352
+    translated: 347
     total: 500
-    pct: 70.4
-    stale: 177
-    stubs: 31
+    pct: 69.4
+    stale: 172
+    stubs: 36

--- a/i18n/es/translation_status.yml
+++ b/i18n/es/translation_status.yml
@@ -2,11 +2,11 @@ locale: es
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 339
+    translated: 335
     total: 369
-    pct: 91.9
-    stale: 167
-    stubs: 27
+    pct: 90.8
+    stale: 163
+    stubs: 31
   agents:
     translated: 3
     total: 75
@@ -20,14 +20,14 @@ coverage:
     stale: 1
     stubs: 5
   guides:
-    translated: 4
+    translated: 3
     total: 34
-    pct: 11.8
-    stale: 3
-    stubs: 1
+    pct: 8.8
+    stale: 2
+    stubs: 2
   total:
-    translated: 347
+    translated: 342
     total: 500
-    pct: 69.4
-    stale: 174
-    stubs: 36
+    pct: 68.4
+    stale: 169
+    stubs: 41

--- a/i18n/ja/translation_status.yml
+++ b/i18n/ja/translation_status.yml
@@ -2,11 +2,11 @@ locale: ja
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 353
+    translated: 349
     total: 369
-    pct: 95.7
-    stale: 165
-    stubs: 13
+    pct: 94.6
+    stale: 161
+    stubs: 17
   agents:
     translated: 3
     total: 75
@@ -20,14 +20,14 @@ coverage:
     stale: 1
     stubs: 5
   guides:
-    translated: 4
+    translated: 2
     total: 34
-    pct: 11.8
-    stale: 3
-    stubs: 1
+    pct: 5.9
+    stale: 1
+    stubs: 3
   total:
-    translated: 361
+    translated: 355
     total: 500
-    pct: 72.2
-    stale: 172
-    stubs: 22
+    pct: 71
+    stale: 166
+    stubs: 28

--- a/i18n/wenyan-lite/translation_status.yml
+++ b/i18n/wenyan-lite/translation_status.yml
@@ -2,11 +2,11 @@ locale: wenyan-lite
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 350
+    translated: 346
     total: 369
-    pct: 94.9
-    stale: 311
-    stubs: 2
+    pct: 93.8
+    stale: 307
+    stubs: 6
   agents:
     translated: 0
     total: 75
@@ -26,8 +26,8 @@ coverage:
     stale: 0
     stubs: 0
   total:
-    translated: 350
+    translated: 346
     total: 500
-    pct: 70
-    stale: 311
-    stubs: 2
+    pct: 69.2
+    stale: 307
+    stubs: 6

--- a/i18n/wenyan-ultra/translation_status.yml
+++ b/i18n/wenyan-ultra/translation_status.yml
@@ -2,11 +2,11 @@ locale: wenyan-ultra
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 350
+    translated: 346
     total: 369
-    pct: 94.9
-    stale: 308
-    stubs: 2
+    pct: 93.8
+    stale: 304
+    stubs: 6
   agents:
     translated: 0
     total: 75
@@ -26,8 +26,8 @@ coverage:
     stale: 0
     stubs: 0
   total:
-    translated: 350
+    translated: 346
     total: 500
-    pct: 70
-    stale: 308
-    stubs: 2
+    pct: 69.2
+    stale: 304
+    stubs: 6

--- a/i18n/wenyan/translation_status.yml
+++ b/i18n/wenyan/translation_status.yml
@@ -2,11 +2,11 @@ locale: wenyan
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 350
+    translated: 346
     total: 369
-    pct: 94.9
-    stale: 311
-    stubs: 2
+    pct: 93.8
+    stale: 307
+    stubs: 6
   agents:
     translated: 0
     total: 75
@@ -26,8 +26,8 @@ coverage:
     stale: 0
     stubs: 0
   total:
-    translated: 350
+    translated: 346
     total: 500
-    pct: 70
-    stale: 311
-    stubs: 2
+    pct: 69.2
+    stale: 307
+    stubs: 6

--- a/i18n/zh-CN/translation_status.yml
+++ b/i18n/zh-CN/translation_status.yml
@@ -2,11 +2,11 @@ locale: zh-CN
 last_updated: '2026-08-11'
 coverage:
   skills:
-    translated: 353
+    translated: 349
     total: 369
-    pct: 95.7
-    stale: 172
-    stubs: 13
+    pct: 94.6
+    stale: 168
+    stubs: 17
   agents:
     translated: 3
     total: 75
@@ -20,14 +20,14 @@ coverage:
     stale: 1
     stubs: 5
   guides:
-    translated: 4
+    translated: 2
     total: 34
-    pct: 11.8
-    stale: 3
-    stubs: 1
+    pct: 5.9
+    stale: 1
+    stubs: 3
   total:
-    translated: 361
+    translated: 355
     total: 500
-    pct: 72.2
-    stale: 179
-    stubs: 22
+    pct: 71
+    stale: 173
+    stubs: 28

--- a/scripts/audit-skill-sections.js
+++ b/scripts/audit-skill-sections.js
@@ -122,11 +122,15 @@ export function countPitfalls(body) {
   return tableRows > 2 ? tableRows - 2 : 0;
 }
 
-export function auditSkill(skillId) {
-  const path = resolve(SKILLS_DIR, skillId, 'SKILL.md');
-  if (!existsSync(path)) return { skill: skillId, error: 'SKILL.md not found' };
-
-  const raw = readFileSync(path, 'utf8');
+/**
+ * Audit already-read SKILL.md text. Separate from `auditSkill` so the verdict can be tested
+ * against a fixture: `auditSkill` is bound to this repo's `skills/` directory, and the only
+ * way to exercise it otherwise is to write a fixture into the corpus.
+ *
+ * @param {string} raw     full file text, LF or CRLF
+ * @param {string} skillId id to report back
+ */
+export function auditSkillText(raw, skillId) {
   // Normalised, not `split('\n')`: heading detection compares whole trimmed lines, so a
   // working-tree CRLF copy would leave `## Common Pitfalls\r` matching nothing and report
   // every required section missing (#532's audit of the other splitting sites).
@@ -142,6 +146,12 @@ export function auditSkill(skillId) {
     version: versionMatch ? versionMatch[1] : null,
     missing,
   };
+}
+
+export function auditSkill(skillId) {
+  const path = resolve(SKILLS_DIR, skillId, 'SKILL.md');
+  if (!existsSync(path)) return { skill: skillId, error: 'SKILL.md not found' };
+  return auditSkillText(readFileSync(path, 'utf8'), skillId);
 }
 
 function listSkillIds() {

--- a/scripts/audit-skill-sections.js
+++ b/scripts/audit-skill-sections.js
@@ -21,6 +21,7 @@
 import { readFileSync, existsSync, readdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
+import { toLines } from './lib/fences.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -126,7 +127,10 @@ export function auditSkill(skillId) {
   if (!existsSync(path)) return { skill: skillId, error: 'SKILL.md not found' };
 
   const raw = readFileSync(path, 'utf8');
-  const lines = raw.split('\n');
+  // Normalised, not `split('\n')`: heading detection compares whole trimmed lines, so a
+  // working-tree CRLF copy would leave `## Common Pitfalls\r` matching nothing and report
+  // every required section missing (#532's audit of the other splitting sites).
+  const lines = toLines(raw);
   const missing = REQUIRED_SECTIONS.filter((heading) => sectionBody(lines, heading) === null);
   const pitfalls = countPitfalls(sectionBody(lines, 'Common Pitfalls'));
   const versionMatch = raw.match(/^\s+version:\s*"([^"]+)"/m);

--- a/scripts/audit-skill-sections.js
+++ b/scripts/audit-skill-sections.js
@@ -131,12 +131,14 @@ export function countPitfalls(body) {
  * @param {string} skillId id to report back
  */
 export function auditSkillText(raw, skillId) {
-  // Normalising is defence in depth, not a repaired defect, and the difference matters.
-  // #532's audit first recorded this site as broken — "a CRLF copy would report every
-  // required section missing". That was wrong: heading detection compares `line.trim()`,
-  // which eats the trailing '\r', and every other test here is start-anchored. Mutating
-  // this back to `raw.split('\n')` leaves the suite green, correctly. It stays normalised
-  // so the next end-anchored or equality comparison added below is safe by default.
+  // Normalised, and the reason is `fenceMask`, not the heading match. Heading detection is
+  // safe on its own — it compares `line.trim()`, and `\r` is a LineTerminator that `trim()`
+  // strips. What breaks is the fence opener at :77, `/^ {0,3}(`{3,}|~{3,})(.*)$/`: the shape
+  // `lib/fences.js` documents as CRLF-fragile, since `.` does not match `\r` and an
+  // unanchored `$` asserts end of input. On a CRLF copy no fence is ever detected, the mask
+  // stays uniformly true, and the audit locks onto the ```markdown-fenced
+  // "## Common Pitfalls" template that `create-skill` and `evolve-skill` embed — the exact
+  // failure `fenceMask`'s own docstring exists to prevent (#532).
   const lines = toLines(raw);
   const missing = REQUIRED_SECTIONS.filter((heading) => sectionBody(lines, heading) === null);
   const pitfalls = countPitfalls(sectionBody(lines, 'Common Pitfalls'));

--- a/scripts/audit-skill-sections.js
+++ b/scripts/audit-skill-sections.js
@@ -131,9 +131,12 @@ export function countPitfalls(body) {
  * @param {string} skillId id to report back
  */
 export function auditSkillText(raw, skillId) {
-  // Normalised, not `split('\n')`: heading detection compares whole trimmed lines, so a
-  // working-tree CRLF copy would leave `## Common Pitfalls\r` matching nothing and report
-  // every required section missing (#532's audit of the other splitting sites).
+  // Normalising is defence in depth, not a repaired defect, and the difference matters.
+  // #532's audit first recorded this site as broken — "a CRLF copy would report every
+  // required section missing". That was wrong: heading detection compares `line.trim()`,
+  // which eats the trailing '\r', and every other test here is start-anchored. Mutating
+  // this back to `raw.split('\n')` leaves the suite green, correctly. It stays normalised
+  // so the next end-anchored or equality comparison added below is safe by default.
   const lines = toLines(raw);
   const missing = REQUIRED_SECTIONS.filter((heading) => sectionBody(lines, heading) === null);
   const pitfalls = countPitfalls(sectionBody(lines, 'Common Pitfalls'));

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -16,8 +16,7 @@ import { resolve, dirname, join, basename } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { assertNotShallow, createFreshnessChecker } from './lib/git-freshness.js';
-import { buildEnglishProseHistory, classifyTranslation } from './lib/translation-status.js';
-import { contentKey } from './lib/fences.js';
+import { buildEnglishProseHistory, classifyTranslation, translationKey } from './lib/translation-status.js';
 
 // A stub verdict is acted on by deleting and re-scaffolding the file (#478), so a wrong one
 // destroys work. The aggregate counts cannot be reviewed; this prints the per-file list that
@@ -125,14 +124,12 @@ function countTranslations(locale, contentType) {
       itemId = basename(entry, '.md');
     }
 
-    // Keyed through `contentKey` rather than by re-deriving `<tree>/<id>` here, so this
-    // cannot drift from the pool's own idea of what an id is — the exact drift #519 was.
-    // It also skips `_`-prefixed and README entries, which would otherwise key to nothing,
-    // report `no-source`, and be counted as translated.
-    const relSourcePath = contentType === 'skills'
-      ? `${contentType}/${itemId}/SKILL.md`
-      : `${contentType}/${itemId}.md`;
-    const key = contentKey(relSourcePath);
+    // Keyed through `translationKey`, which defers to `contentKey`, so this cannot drift
+    // from the pool's own idea of what an id is. The null branch below is NOT covered by a
+    // test: it fires only for a `_`-prefixed or README mirror, and no such file exists in
+    // `i18n/` — adding one to the corpus purely as a fixture would be worse than the gap.
+    // The derivation itself is covered in `translation-status.test.js`.
+    const key = translationKey(contentType, itemId);
     if (key === null) continue;
 
     const verdict = classifyTranslation({

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -7,6 +7,8 @@
  *
  * Usage:
  *   node scripts/generate-translation-status.js
+ *   node scripts/generate-translation-status.js --verdicts   # also list every stub, with
+ *                                                            # the reason and line counts
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
@@ -15,6 +17,12 @@ import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { assertNotShallow, createFreshnessChecker } from './lib/git-freshness.js';
 import { buildEnglishProseHistory, classifyTranslation } from './lib/translation-status.js';
+import { contentKey } from './lib/fences.js';
+
+// A stub verdict is acted on by deleting and re-scaffolding the file (#478), so a wrong one
+// destroys work. The aggregate counts cannot be reviewed; this prints the per-file list that
+// can. Use it before any bulk remediation.
+const SHOW_VERDICTS = process.argv.includes('--verdicts');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -117,20 +125,33 @@ function countTranslations(locale, contentType) {
       itemId = basename(entry, '.md');
     }
 
-    const sourcePath = resolveSourcePath(contentType, translatedFile);
+    // Keyed through `contentKey` rather than by re-deriving `<tree>/<id>` here, so this
+    // cannot drift from the pool's own idea of what an id is — the exact drift #519 was.
+    // It also skips `_`-prefixed and README entries, which would otherwise key to nothing,
+    // report `no-source`, and be counted as translated.
+    const relSourcePath = contentType === 'skills'
+      ? `${contentType}/${itemId}/SKILL.md`
+      : `${contentType}/${itemId}.md`;
+    const key = contentKey(relSourcePath);
+    if (key === null) continue;
 
     const verdict = classifyTranslation({
       translatedText: readFileSync(translatedFile, 'utf8'),
       locale,
-      englishLines: englishProse.get(`${contentType}/${itemId}`),
+      englishLines: englishProse.get(key),
     });
     if (verdict.stub) {
       stubs++;
+      if (SHOW_VERDICTS) {
+        console.log(`  STUB ${locale}/${key}  (${verdict.reason}, ${verdict.foreign}/${verdict.total} foreign)`);
+      }
       continue;
     }
 
     translated++;
 
+    // Computed here rather than above the verdict: the stub path discards it.
+    const sourcePath = resolveSourcePath(contentType, translatedFile);
     const sourceCommit = extractSourceCommit(translatedFile);
     if (existsSync(sourcePath) && sourceCommit) {
       if (freshness.isStale(sourceCommit, toRelPath(sourcePath))) {

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -14,6 +14,7 @@ import { resolve, dirname, join, basename } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { assertNotShallow, createFreshnessChecker } from './lib/git-freshness.js';
+import { buildEnglishProseHistory, classifyTranslation } from './lib/translation-status.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -60,40 +61,13 @@ function extractSourceCommit(filePath) {
   return match ? match[1] : null;
 }
 
-/**
- * Strip YAML frontmatter, return body only.
- * Frontmatter is delimited by two '---' lines at the start of the file.
- */
-function stripFrontmatter(content) {
-  const lines = content.split('\n');
-  let fmCount = 0;
-  let bodyStart = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim() === '---') {
-      fmCount++;
-      if (fmCount === 2) {
-        bodyStart = i + 1;
-        break;
-      }
-    }
-  }
-  return bodyStart >= 0 ? lines.slice(bodyStart).join('\n') : content;
-}
-
-/**
- * Detect untranslated stub: scaffold copies English source byte-for-byte
- * and only injects frontmatter fields. If body equals source body, it's a stub.
- * Source bodies are cached — every locale compares against the same sources.
- */
-const sourceBodyCache = new Map();
-function isUntranslatedStub(translatedFile, sourcePath) {
-  if (!existsSync(sourcePath)) return false;
-  const tBody = stripFrontmatter(readFileSync(translatedFile, 'utf8')).trim();
-  if (!sourceBodyCache.has(sourcePath)) {
-    sourceBodyCache.set(sourcePath, stripFrontmatter(readFileSync(sourcePath, 'utf8')).trim());
-  }
-  return tBody === sourceBodyCache.get(sourcePath);
-}
+// Stub detection lives in ./lib/translation-status.js. It used to be body equality against
+// the English source on disk, which stopped being true the moment English was next edited
+// (#473) and was defeated outright by an interior `\r` (#532). See that module's header for
+// why comparing against the `source_commit` blob does not fix it either.
+//
+// Built once and reused across all ten locales: two git processes for the whole corpus.
+const englishProse = buildEnglishProseHistory(ROOT);
 
 // Batched staleness (#305): one `git log <source_commit>..HEAD` per DISTINCT
 // source_commit instead of per-file `git log -1` + `merge-base` spawns.
@@ -131,18 +105,26 @@ function countTranslations(locale, contentType) {
     const entryPath = resolve(typeDir, entry);
 
     let translatedFile;
+    let itemId;
     if (contentType === 'skills') {
       if (!statSync(entryPath).isDirectory()) continue;
       translatedFile = resolve(entryPath, 'SKILL.md');
       if (!existsSync(translatedFile)) continue;
+      itemId = entry;
     } else {
       if (!entry.endsWith('.md')) continue;
       translatedFile = entryPath;
+      itemId = basename(entry, '.md');
     }
 
     const sourcePath = resolveSourcePath(contentType, translatedFile);
 
-    if (isUntranslatedStub(translatedFile, sourcePath)) {
+    const verdict = classifyTranslation({
+      translatedText: readFileSync(translatedFile, 'utf8'),
+      locale,
+      englishLines: englishProse.get(`${contentType}/${itemId}`),
+    });
+    if (verdict.stub) {
       stubs++;
       continue;
     }

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -55,9 +55,14 @@ const GIT_BUFFER = 512 * 1024 * 1024;
 
 /**
  * Shortest line worth comparing. Below this, markdown structure dominates — `---`, `1.`,
- * `**Note:**`, a bare heading — and matches English in every locale whether or not anything
- * was translated. The value is a floor on noise, not a tuned parameter: the verdict is
- * "zero foreign lines", so a lower floor only adds lines that agree by construction.
+ * `**Note:**` — and matches English in every locale whether or not anything was translated.
+ *
+ * The floor errs **strict**, not neutral: a short translated line such as `## Nutzung` is
+ * genuine evidence of translation that this discards, and discarding evidence can only flip
+ * a verdict toward `stub`. Measured, the margin holds anyway — the genuine translation
+ * closest to the scaffold verdict corpus-wide is a `caveman-lite` file with 2 foreign lines,
+ * and among the natural-language locales the closest carries 5. Re-measure before lowering
+ * it; do not reason about it.
  */
 export const MIN_LINE_LENGTH = 12;
 

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * translation-status.js — deciding whether a translated file is an untranslated scaffold.
+ *
+ * Extracted from `generate-translation-status.js` so the verdict can be unit-tested without
+ * a git repository or a ten-minute corpus scan (#305).
+ *
+ * ## Why this is not a body comparison
+ *
+ * The original detector asked "is the translated body byte-equal to the English body?".
+ * That is the right *question* — file existence lies, so `translation_status.yml` once
+ * counted scaffolds as translations — but byte equality is the wrong instrument, and it
+ * failed in three separate ways:
+ *
+ *   1. Equality against **current** English closes the moment English is next edited, after
+ *      which an untranslated scaffold is silently recounted as a translation (#473).
+ *   2. Equality is byte equality, so a translated copy that acquires CRLF while its source
+ *      stays LF stops matching and is recounted the same way (#532).
+ *   3. Equality against the `source_commit` blob — the fix suggested on both issues — does
+ *      not work either. Mirrors in this repo are routinely patched *surgically*: an English
+ *      fix is spliced into `i18n/**` without recopying the file. The result equals no single
+ *      English revision, past or present. Measured on the four
+ *      `harden-github-repo-security` scaffolds: they match neither current English nor the
+ *      blob at their own recorded `source_commit` nor any of the four revisions the path
+ *      has ever had.
+ *
+ * All three failures point the same way — `stubs` decays upward into `translated` — and all
+ * three come from asking a question about *one* English text.
+ *
+ * ## What is asked instead
+ *
+ * A file is an untranslated scaffold when it carries **no evidence of translation**:
+ *
+ *   - every substantive prose line in it appeared verbatim in English at some point, or
+ *   - the locale is written in a script the file contains none of.
+ *
+ * Both are decisive rather than threshold-based, which matters because the compressed
+ * locales are *specified* to stay close to English — `caveman-lite` keeps grammar, articles
+ * and full sentences, and measures ~90% verbatim English lines by design. Any similarity
+ * threshold that catches a scaffold also condemns that tier for meeting its own spec. The
+ * zero-evidence rule does not: measured across the corpus, `caveman-lite`'s genuine
+ * translations all carry at least one line English never had, and its scaffolds carry none.
+ *
+ * Frozen fences are excluded from both sides. A fence whose tag is not `text`/`markdown`/`md`
+ * is keep-in-English by design in every locale, so counting it as agreement would push every
+ * genuine translation toward the scaffold verdict.
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import { toLines, extractFences, isGated, contentKey, TREES } from './fences.js';
+
+const GIT_BUFFER = 512 * 1024 * 1024;
+
+/**
+ * Shortest line worth comparing. Below this, markdown structure dominates — `---`, `1.`,
+ * `**Note:**`, a bare heading — and matches English in every locale whether or not anything
+ * was translated. The value is a floor on noise, not a tuned parameter: the verdict is
+ * "zero foreign lines", so a lower floor only adds lines that agree by construction.
+ */
+export const MIN_LINE_LENGTH = 12;
+
+/**
+ * Fewest substantive lines a file must have before the zero-evidence rule may fire. A file
+ * with two comparable lines does not carry enough text to distinguish "untranslated" from
+ * "short". Files below this are reported `insufficient` and counted as translated, which is
+ * the lenient direction — stated so a reader knows which way the residue leans.
+ */
+export const MIN_SUBSTANTIVE_LINES = 5;
+
+/**
+ * Locales written in a script English does not use. A file in one of these containing none
+ * of that script is untranslated no matter what its prose compares to — decisive, with no
+ * false positives available to it.
+ *
+ * Listed explicitly rather than derived from the locale code: adding a locale here is a
+ * claim about its writing system and should be made deliberately. A locale absent from this
+ * map is simply judged by prose alone.
+ */
+export const REQUIRED_SCRIPT = new Map([
+  ['ja', /[぀-ヿ㐀-䶿一-鿿豈-﫿]/u],
+  ['zh-CN', /[㐀-䶿一-鿿豈-﫿]/u],
+  ['wenyan', /[㐀-䶿一-鿿豈-﫿]/u],
+  ['wenyan-lite', /[㐀-䶿一-鿿豈-﫿]/u],
+  ['wenyan-ultra', /[㐀-䶿一-鿿豈-﫿]/u],
+]);
+
+/**
+ * Strip YAML frontmatter, returning the body.
+ *
+ * Splits through `toLines()`, which normalises CRLF and lone CR (#532). The previous
+ * implementation split on `\n` and trimmed only the ends, so an interior `\r` survived into
+ * every comparison — the same blindness `toLines()` carries a comment about having already
+ * caused once, unfixed at this call site.
+ *
+ * @param {string} content full file text
+ * @returns {string} body with LF line endings, or the whole text when no frontmatter closes
+ */
+export function stripFrontmatter(content) {
+  const lines = toLines(content);
+  let delimiters = 0;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].trim() === '---') {
+      delimiters += 1;
+      if (delimiters === 2) return lines.slice(i + 1).join('\n');
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Lines of `text` that are outside frozen fences: fence delimiters dropped, frozen fence
+ * bodies dropped, localisable (`text`/`markdown`/`md`) fence bodies kept because those are
+ * translatable and a scaffold's English in them is evidence.
+ *
+ * @param {string} text
+ * @returns {string[]}
+ */
+export function openLines(text) {
+  const lines = toLines(text);
+  const dropped = new Array(lines.length).fill(false);
+  for (const fence of extractFences(text)) {
+    dropped[fence.line - 1] = true;
+    if (fence.bodyEnd < lines.length) dropped[fence.bodyEnd] = true;
+    if (isGated(fence)) {
+      for (let i = fence.bodyStart; i < fence.bodyEnd; i += 1) dropped[i] = true;
+    }
+  }
+  return lines.filter((_, i) => !dropped[i]);
+}
+
+/**
+ * The lines of `text` long enough to carry prose, trimmed.
+ * @param {string} text
+ * @returns {string[]}
+ */
+export function substantiveLines(text) {
+  return openLines(text)
+    .map((line) => line.trim())
+    .filter((line) => line.length >= MIN_LINE_LENGTH && /\p{L}/u.test(line));
+}
+
+/**
+ * Decide whether one translated file is an untranslated scaffold.
+ *
+ * @param {object} input
+ * @param {string} input.translatedText   full text of the translated file
+ * @param {string} input.locale           locale code, e.g. `de`
+ * @param {Set<string>} input.englishLines every substantive prose line the English source
+ *                                        has ever had (see `buildEnglishProseHistory`)
+ * @returns {{stub: boolean, reason: string, foreign: number, total: number}}
+ *   `reason` is one of `no-script`, `no-foreign-lines`, `has-foreign-lines`,
+ *   `insufficient`, `no-source`.
+ */
+export function classifyTranslation({ translatedText, locale, englishLines }) {
+  const body = stripFrontmatter(translatedText);
+  const lines = substantiveLines(body);
+
+  const script = REQUIRED_SCRIPT.get(locale);
+  if (script && !script.test(body)) {
+    return { stub: true, reason: 'no-script', foreign: 0, total: lines.length };
+  }
+
+  if (!englishLines) {
+    return { stub: false, reason: 'no-source', foreign: 0, total: lines.length };
+  }
+  if (lines.length < MIN_SUBSTANTIVE_LINES) {
+    return { stub: false, reason: 'insufficient', foreign: 0, total: lines.length };
+  }
+
+  let foreign = 0;
+  for (const line of lines) if (!englishLines.has(line)) foreign += 1;
+
+  return foreign === 0
+    ? { stub: true, reason: 'no-foreign-lines', foreign, total: lines.length }
+    : { stub: false, reason: 'has-foreign-lines', foreign, total: lines.length };
+}
+
+/**
+ * Every substantive English prose line each source has ever carried, keyed by `contentKey`
+ * (`skills/create-r-package`, `agents/r-developer`, …).
+ *
+ * Pooling across history is what makes the verdict survive surgical mirror propagation: a
+ * paragraph spliced into `i18n/**` from a later English revision, sitting in a body copied
+ * from an earlier one, is English in both halves and foreign in neither.
+ *
+ * Costs two git processes for the whole corpus — one `git log --name-only`, one
+ * `git cat-file --batch` — rather than one per file (#305). The working tree is added last
+ * so an uncommitted English edit counts as English too.
+ *
+ * @param {string} root repository root
+ * @returns {Map<string, Set<string>>}
+ */
+export function buildEnglishProseHistory(root) {
+  const log = execFileSync(
+    'git', ['log', '--format=%x00%H', '--name-only', '--', ...TREES],
+    { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER },
+  );
+
+  const specs = [];
+  const seen = new Set();
+  let commit = null;
+  for (const line of log.split('\n')) {
+    if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
+    if (!line || !commit || contentKey(line) === null) continue;
+    const spec = `${commit}:${line}`;
+    if (seen.has(spec)) continue;
+    seen.add(spec);
+    specs.push(spec);
+  }
+
+  const history = new Map();
+  const add = (key, text) => {
+    if (key === null) return;
+    if (!history.has(key)) history.set(key, new Set());
+    const set = history.get(key);
+    for (const line of substantiveLines(stripFrontmatter(text))) set.add(line);
+  };
+
+  if (specs.length) {
+    const batch = spawnSync('git', ['cat-file', '--batch'], {
+      cwd: root,
+      input: Buffer.from(`${specs.join('\n')}\n`, 'utf8'),
+      maxBuffer: GIT_BUFFER,
+    });
+    if (batch.status !== 0) {
+      throw new Error(`git cat-file --batch failed: ${batch.stderr?.toString().slice(0, 500)}`);
+    }
+    const buf = batch.stdout;
+    let offset = 0;
+    let index = 0;
+    while (offset < buf.length && index < specs.length) {
+      const newline = buf.indexOf(0x0a, offset);
+      if (newline < 0) break;
+      const header = buf.slice(offset, newline).toString('utf8');
+      offset = newline + 1;
+      if (/ (missing|ambiguous)$/.test(header)) { index += 1; continue; }
+      const size = Number.parseInt(header.split(' ')[2], 10);
+      if (!Number.isFinite(size)) break;
+      const path = specs[index].slice(specs[index].indexOf(':') + 1);
+      add(contentKey(path), buf.slice(offset, offset + size).toString('utf8'));
+      offset += size + 1;
+      index += 1;
+    }
+  }
+
+  for (const tree of TREES) {
+    const base = join(root, tree);
+    if (!existsSync(base)) continue;
+    for (const entry of readdirSync(base)) {
+      if (entry.startsWith('_')) continue;
+      const path = tree === 'skills' ? join(base, entry, 'SKILL.md') : join(base, entry);
+      if (!existsSync(path) || !statSync(path).isFile()) continue;
+      const rel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
+      add(contentKey(rel), readFileSync(path, 'utf8'));
+    }
+  }
+
+  return history;
+}

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -38,12 +38,26 @@
  * locales are *specified* to stay close to English — `caveman-lite` keeps grammar, articles
  * and full sentences, and measures ~90% verbatim English lines by design. Any similarity
  * threshold that catches a scaffold also condemns that tier for meeting its own spec. The
- * zero-evidence rule does not: measured across the corpus, `caveman-lite`'s genuine
- * translations all carry at least one line English never had, and its scaffolds carry none.
+ * zero-evidence rule does not: measured on the corpus of 2026-08-11, every genuine
+ * `caveman-lite` translation carries at least one line English never had — the closest
+ * carrying exactly one — and its scaffolds carry none. That is a measurement, not an
+ * invariant. Nothing in the spec forbids a short, heavily fenced skill from compressing to
+ * zero novel lines.
  *
  * Frozen fences are excluded from both sides. A fence whose tag is not `text`/`markdown`/`md`
  * is keep-in-English by design in every locale, so counting it as agreement would push every
  * genuine translation toward the scaffold verdict.
+ *
+ * ## Which way the errors point, and why it changed
+ *
+ * The old detector's failures were all **lenient**: a scaffold read as a translation, and
+ * the cost was an inflated percentage. This one can fail **strict** — a genuine translation
+ * read as a scaffold — and that cost is different in kind, because the established
+ * remediation for a scaffold in this repo is #478's delete-and-re-scaffold. A false stub
+ * therefore destroys real work.
+ *
+ * So: before acting on a verdict in bulk, read the per-file list rather than the aggregate
+ * count. `generate-translation-status.js --verdicts` prints it. A number cannot be reviewed.
  */
 
 import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
@@ -51,6 +65,9 @@ import { join } from 'path';
 import { execFileSync, spawnSync } from 'child_process';
 import { toLines, extractFences, isGated, contentKey, TREES } from './fences.js';
 
+// Deliberately smaller than `lib/fences.js`'s 2 GiB: this pool holds trimmed prose lines,
+// not whole fence bodies. On overflow `execFileSync` throws ENOBUFS, so the difference fails
+// loud rather than producing a short pool. Raise both together if either is ever hit.
 const GIT_BUFFER = 512 * 1024 * 1024;
 
 /**
@@ -81,7 +98,12 @@ export const MIN_SUBSTANTIVE_LINES = 5;
  *
  * Listed explicitly rather than derived from the locale code: adding a locale here is a
  * claim about its writing system and should be made deliberately. A locale absent from this
- * map is simply judged by prose alone.
+ * map is simply judged by prose alone, which is the primary rule anyway — a new locale is
+ * less redundantly guarded, not unguarded.
+ *
+ * The test runs against the whole body, frozen fences included, so a CJK literal inside a
+ * keep-in-English code fence satisfies it. Deliberate: that errs lenient, the prose rule
+ * still catches such a file, and per the header the strict direction is the expensive one.
  */
 export const REQUIRED_SCRIPT = new Map([
   ['ja', /[぀-ヿ㐀-䶿一-鿿豈-﫿]/u],
@@ -193,6 +215,17 @@ export function classifyTranslation({ translatedText, locale, englishLines }) {
  * Costs two git processes for the whole corpus — one `git log --name-only`, one
  * `git cat-file --batch` — rather than one per file (#305). The working tree is added last
  * so an uncommitted English edit counts as English too.
+ *
+ * Two known gaps in the walk, shared with `buildEnglishFenceHistory` and pointing opposite
+ * ways in the two consumers, which is why neither should be "fixed" without checking both:
+ * `git log` lists no paths for a merge commit and applies default history simplification, so
+ * a body existing only as conflict-resolution output never enters the pool; and `--name-only`
+ * without `--follow` loses pre-rename paths (harmless for the skills flatten, which
+ * `contentKey` normalises, but not for an id rename). **Here** both shrink the pool, so a
+ * scaffold shows foreign lines and reads as translated — lenient. In `fences.js`, where the
+ * same pool is a *violation* basis, a missing revision manufactures a false violation —
+ * strict. Measured on this repo: adding `--diff-merges=separate` changes the pool by 0 lines
+ * and the verdict set by 0 files.
  *
  * @param {string} root repository root
  * @returns {Map<string, Set<string>>}

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -169,6 +169,24 @@ export function substantiveLines(text) {
 }
 
 /**
+ * The pool key for a translated item, or `null` when the id is not content.
+ *
+ * Exists so the caller does not re-derive `<tree>/<id>` next to `contentKey`'s own rule for
+ * what an id is. Two copies of that rule is exactly the drift #519 was, and here the
+ * consequence is quiet: a mirror of `_template` or `README` keys to nothing, reports
+ * `no-source`, and is counted as *translated*.
+ *
+ * @param {string} contentType `skills` | `agents` | `teams` | `guides`
+ * @param {string} itemId      directory name (skills) or filename stem (everything else)
+ * @returns {string|null}
+ */
+export function translationKey(contentType, itemId) {
+  return contentKey(contentType === 'skills'
+    ? `${contentType}/${itemId}/SKILL.md`
+    : `${contentType}/${itemId}.md`);
+}
+
+/**
  * Decide whether one translated file is an untranslated scaffold.
  *
  * @param {object} input

--- a/scripts/mutation-check.js
+++ b/scripts/mutation-check.js
@@ -301,19 +301,13 @@ console.log('      green.\n');
 
 const original = readFileSync(absFile, 'utf8');
 
-// A CRLF file would be rejoined with LF, so every untouched line changes too. The
-// "did the mutation land" test is a string comparison, and it would pass on a no-op
-// mutation purely from the line-ending rewrite — the vacuous pass this tool exists to
-// refuse. Fail closed rather than mutate line endings behind the caller's back (#532).
-if (original.includes('\r')) {
-  fail(
-    `${opts.file} contains carriage returns.\n` +
-    'Mutants are built by splitting and rejoining on LF, so every line would change and\n' +
-    '"the mutation landed" could not be told apart from a line-ending rewrite.\n' +
-    'Repair with `git add --renormalize` and re-run.'
-  );
-}
-
+// CRLF is safe here, and that was checked rather than assumed (#532's audit). Splitting on
+// '\n' leaves the '\r' attached to the END of each line, so rejoining on '\n' reproduces
+// every untouched line byte-for-byte — `"a\r\nX\r\nb\r\n"` deletes to `"a\r\nb\r\n"`. And
+// the --replace branch never splits lines at all. An earlier revision of this file added a
+// guard refusing carriage returns on the theory that rejoining rewrote line endings; the
+// theory was wrong and the guard only refused valid input.
+//
 // Build the mutant in memory. Comparing strings is how "did it land" is decided:
 // asking git would be blind to exactly the cases guarded against above.
 let mutated;

--- a/scripts/mutation-check.js
+++ b/scripts/mutation-check.js
@@ -301,6 +301,19 @@ console.log('      green.\n');
 
 const original = readFileSync(absFile, 'utf8');
 
+// A CRLF file would be rejoined with LF, so every untouched line changes too. The
+// "did the mutation land" test is a string comparison, and it would pass on a no-op
+// mutation purely from the line-ending rewrite — the vacuous pass this tool exists to
+// refuse. Fail closed rather than mutate line endings behind the caller's back (#532).
+if (original.includes('\r')) {
+  fail(
+    `${opts.file} contains carriage returns.\n` +
+    'Mutants are built by splitting and rejoining on LF, so every line would change and\n' +
+    '"the mutation landed" could not be told apart from a line-ending rewrite.\n' +
+    'Repair with `git add --renormalize` and re-run.'
+  );
+}
+
 // Build the mutant in memory. Comparing strings is how "did it land" is decided:
 // asking git would be blind to exactly the cases guarded against above.
 let mutated;

--- a/scripts/test/audit-skill-sections.test.js
+++ b/scripts/test/audit-skill-sections.test.js
@@ -1,15 +1,25 @@
 /**
  * Tests for `auditSkillText()` in `scripts/audit-skill-sections.js`.
  *
- * Written to test a code comment claiming a carriage return "would report every required
- * section missing" — and the claim turned out to be **false**. `sectionBody` compares
- * `line.trim()`, which eats the trailing '\r', and every other test in the module is
- * start-anchored, so `raw.split('\n')` and `toLines(raw)` behave identically. The mutant
- * reverting the normalisation SURVIVES, and that is the correct result, recorded here so
- * nobody re-derives the wrong conclusion from the surviving mutant.
+ * Two wrong claims were made about this module before the right one, and the sequence is
+ * worth keeping because it is entirely about which fixture was used.
  *
- * The tests are kept because the module had none at all, and because the CRLF case is now
- * a characterisation test: if a future end-anchored comparison is added below, it breaks.
+ *   1. "A CRLF copy would report every required section missing." **False.** `sectionBody`
+ *      compares `line.trim()`, and `\r` is a LineTerminator that `trim()` strips.
+ *   2. "So the site was safe all along, and the surviving mutant is correct." **Also false**,
+ *      and only looked true because the first fixture here contained no fenced block.
+ *
+ * The real defect is one function down. `fenceMask` matches an opener with
+ * `/^ {0,3}(`{3,}|~{3,})(.*)$/` — the exact shape `lib/fences.js` documents as CRLF-fragile:
+ * `.` does not match `\r` and an unanchored `$` asserts end of input, so ```` ```markdown\r ````
+ * matches nothing, no fence is ever detected, and the mask stays uniformly `true`. Skills
+ * such as `create-skill` embed a ```` ```markdown ```` fence containing a literal
+ * `## Common Pitfalls` template, so with a blind mask the audit locks onto the template
+ * instead of the real section and counts the wrong bullets — the precise failure
+ * `fenceMask`'s own docstring exists to prevent.
+ *
+ * `FENCED_TEMPLATE_SKILL` below is that fixture. It is what makes the mutant reverting
+ * `toLines(raw)` to `raw.split('\n')` die instead of survive.
  */
 
 import { test } from 'node:test';
@@ -56,6 +66,33 @@ const SKILL = [
   '',
 ].join('\n');
 
+/**
+ * A skill that documents skill-authoring, so it carries a fenced template containing a
+ * literal `## Common Pitfalls` with a different number of bullets than the real section.
+ * `create-skill` and `evolve-skill` are both shaped like this.
+ */
+const FENCED_TEMPLATE_SKILL = SKILL.replace(
+  '## Common Pitfalls\n',
+  [
+    '## Procedure Template',
+    '',
+    'Copy this into the new skill:',
+    '',
+    '```markdown',
+    '## Common Pitfalls',
+    '',
+    '- **Template pitfall A**: replace this',
+    '- **Template pitfall B**: and this',
+    '- **Template pitfall C**: and this',
+    '- **Template pitfall D**: and this',
+    '- **Template pitfall E**: and this',
+    '```',
+    '',
+    '## Common Pitfalls',
+    '',
+  ].join('\n'),
+);
+
 test('a well-formed skill reports no missing sections', () => {
   const result = auditSkillText(SKILL, 'demo-skill');
   assert.deepEqual(result.missing, []);
@@ -64,12 +101,28 @@ test('a well-formed skill reports no missing sections', () => {
 });
 
 test('a CRLF copy audits identically (#532)', () => {
-  // True of BOTH implementations — see the header. This pins the behaviour rather than the
-  // mechanism, so it stays meaningful if the parsing changes.
+  // True of both implementations on a fence-free file — see the header. Kept because it pins
+  // behaviour rather than mechanism, and because it is the half that reads as obvious.
   const crlf = SKILL.replace(/\n/g, '\r\n');
   const result = auditSkillText(crlf, 'demo-skill');
   assert.deepEqual(result.missing, [], 'a carriage return must not empty the section list');
   assert.deepEqual(result, auditSkillText(SKILL, 'demo-skill'));
+});
+
+test('a fenced Common Pitfalls template is not mistaken for the real section', () => {
+  // The pre-existing guarantee, restated as a test: fence-blind parsing locks onto the
+  // template. Three real bullets follow the real heading; the template has five.
+  assert.equal(auditSkillText(FENCED_TEMPLATE_SKILL, 'demo-skill').pitfalls, 3);
+});
+
+test('and it is still not mistaken for it under CRLF (#532 — the real defect)', () => {
+  // THE test. `fenceMask`'s opener regex is `/^ {0,3}(`{3,}|~{3,})(.*)$/`: `.` does not match
+  // `\r` and `$` asserts end of input, so "```markdown\r" matches nothing, no fence is
+  // detected, the mask stays all-true, and the audit counts the template's five bullets.
+  // Reverting `toLines(raw)` to `raw.split('\n')` fails exactly here.
+  const crlf = FENCED_TEMPLATE_SKILL.replace(/\n/g, '\r\n');
+  assert.equal(auditSkillText(crlf, 'demo-skill').pitfalls, 3);
+  assert.deepEqual(auditSkillText(crlf, 'demo-skill'), auditSkillText(FENCED_TEMPLATE_SKILL, 'demo-skill'));
 });
 
 test('a genuinely incomplete skill still reports what is missing', () => {

--- a/scripts/test/audit-skill-sections.test.js
+++ b/scripts/test/audit-skill-sections.test.js
@@ -1,0 +1,91 @@
+/**
+ * Tests for `auditSkillText()` in `scripts/audit-skill-sections.js`.
+ *
+ * The CRLF fix that #532's audit produced arrived as a code comment saying a carriage return
+ * "would report every required section missing." That is an assertion nobody ran — the class
+ * of claim this repo has been burned by before. It is asserted here instead.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { auditSkillText, countPitfalls, REQUIRED_SECTIONS } from '../audit-skill-sections.js';
+
+const SKILL = [
+  '---',
+  'name: demo-skill',
+  'description: A demo',
+  'metadata:',
+  '  version: "1.2.0"',
+  '---',
+  '',
+  '# Demo Skill',
+  '',
+  '## When to Use',
+  '',
+  'When demonstrating.',
+  '',
+  '## Inputs',
+  '',
+  '- **Required**: nothing',
+  '',
+  '## Procedure',
+  '',
+  '### Step 1: Do it',
+  '',
+  'Do the thing.',
+  '',
+  '## Validation',
+  '',
+  '- [ ] It worked',
+  '',
+  '## Common Pitfalls',
+  '',
+  '- **First**: one way it goes wrong',
+  '- **Second**: another way',
+  '- **Third**: a third way',
+  '',
+  '## Related Skills',
+  '',
+  '- `other-skill` — related',
+  '',
+].join('\n');
+
+test('a well-formed skill reports no missing sections', () => {
+  const result = auditSkillText(SKILL, 'demo-skill');
+  assert.deepEqual(result.missing, []);
+  assert.equal(result.pitfalls, 3);
+  assert.equal(result.version, '1.2.0');
+});
+
+test('a CRLF copy audits identically (#532)', () => {
+  // The defect the fix exists to prevent: with `split('\n')`, every heading line ends `\r`,
+  // so no whole-line comparison matches and all six required sections read as missing.
+  const crlf = SKILL.replace(/\n/g, '\r\n');
+  const result = auditSkillText(crlf, 'demo-skill');
+  assert.deepEqual(result.missing, [], 'a carriage return must not empty the section list');
+  assert.deepEqual(result, auditSkillText(SKILL, 'demo-skill'));
+});
+
+test('a genuinely incomplete skill still reports what is missing', () => {
+  // Guards the other direction: the CRLF fix must not make the audit report success for a
+  // file that really is missing sections.
+  const stripped = SKILL.replace('## Common Pitfalls', '## Something Else');
+  const result = auditSkillText(stripped, 'demo-skill');
+  assert.deepEqual(result.missing, ['Common Pitfalls']);
+  // `null`, not 0 — an absent section is distinguishable from a present but empty one.
+  assert.equal(result.pitfalls, null);
+  assert.ok(REQUIRED_SECTIONS.includes('Common Pitfalls'));
+});
+
+test('pitfalls are counted in both authored list formats, under either line ending', () => {
+  // The #382 tail measurement under-counted by 8 skills with a dash-only counter. Exercised
+  // through `auditSkillText` because the counter takes `sectionBody`'s structured output,
+  // and that is exactly what a stray `\r` would corrupt.
+  const numbered = SKILL.replace(
+    '- **First**: one way it goes wrong\n- **Second**: another way\n- **Third**: a third way',
+    '1. **First**: one way it goes wrong\n2. **Second**: another way',
+  );
+  assert.equal(auditSkillText(numbered, 'demo-skill').pitfalls, 2);
+  assert.equal(auditSkillText(numbered.replace(/\n/g, '\r\n'), 'demo-skill').pitfalls, 2);
+  assert.equal(typeof countPitfalls, 'function');
+});

--- a/scripts/test/audit-skill-sections.test.js
+++ b/scripts/test/audit-skill-sections.test.js
@@ -1,9 +1,15 @@
 /**
  * Tests for `auditSkillText()` in `scripts/audit-skill-sections.js`.
  *
- * The CRLF fix that #532's audit produced arrived as a code comment saying a carriage return
- * "would report every required section missing." That is an assertion nobody ran — the class
- * of claim this repo has been burned by before. It is asserted here instead.
+ * Written to test a code comment claiming a carriage return "would report every required
+ * section missing" — and the claim turned out to be **false**. `sectionBody` compares
+ * `line.trim()`, which eats the trailing '\r', and every other test in the module is
+ * start-anchored, so `raw.split('\n')` and `toLines(raw)` behave identically. The mutant
+ * reverting the normalisation SURVIVES, and that is the correct result, recorded here so
+ * nobody re-derives the wrong conclusion from the surviving mutant.
+ *
+ * The tests are kept because the module had none at all, and because the CRLF case is now
+ * a characterisation test: if a future end-anchored comparison is added below, it breaks.
  */
 
 import { test } from 'node:test';
@@ -58,8 +64,8 @@ test('a well-formed skill reports no missing sections', () => {
 });
 
 test('a CRLF copy audits identically (#532)', () => {
-  // The defect the fix exists to prevent: with `split('\n')`, every heading line ends `\r`,
-  // so no whole-line comparison matches and all six required sections read as missing.
+  // True of BOTH implementations — see the header. This pins the behaviour rather than the
+  // mechanism, so it stays meaningful if the parsing changes.
   const crlf = SKILL.replace(/\n/g, '\r\n');
   const result = auditSkillText(crlf, 'demo-skill');
   assert.deepEqual(result.missing, [], 'a carriage return must not empty the section list');

--- a/scripts/test/translation-status.test.js
+++ b/scripts/test/translation-status.test.js
@@ -27,6 +27,7 @@ import {
   substantiveLines,
   classifyTranslation,
   buildEnglishProseHistory,
+  translationKey,
   MIN_SUBSTANTIVE_LINES,
 } from '../lib/translation-status.js';
 
@@ -313,6 +314,20 @@ test('a translation whose English source is gone is reported no-source', () => {
   });
   assert.equal(verdict.stub, false);
   assert.equal(verdict.reason, 'no-source');
+});
+
+// ── the pool key ────────────────────────────────────────────────────────────
+
+test('translationKey agrees with contentKey, including on what is not content', () => {
+  assert.equal(translationKey('skills', 'create-r-package'), 'skills/create-r-package');
+  assert.equal(translationKey('guides', 'agent-best-practices'), 'guides/agent-best-practices');
+  assert.equal(translationKey('agents', 'r-developer'), 'agents/r-developer');
+  // The reason this helper exists rather than a second `${tree}/${id}` in the caller: a
+  // mirror of a template or a README keys to nothing, reports `no-source`, and is counted
+  // as translated. Both branches must exclude them, which is what #519 was about.
+  assert.equal(translationKey('skills', '_template'), null);
+  assert.equal(translationKey('guides', '_template'), null);
+  assert.equal(translationKey('teams', 'README'), null);
 });
 
 // ── the git path ────────────────────────────────────────────────────────────

--- a/scripts/test/translation-status.test.js
+++ b/scripts/test/translation-status.test.js
@@ -270,6 +270,41 @@ test('a file too short to judge is reported insufficient, not a scaffold', () =>
   assert.ok(verdict.total < MIN_SUBSTANTIVE_LINES);
 });
 
+// The boundary, pinned on BOTH sides with literal counts. Asserting
+// `total < MIN_SUBSTANTIVE_LINES` against the imported constant is self-referential and
+// cannot fix a value: mutating 5 to 2, 3 or 4 survives it. These two do not — the fixtures
+// are built to have exactly 5 and exactly 4 substantive lines by construction.
+const lineOfLength = (n, i) => `Fixture prose line ${i}`.padEnd(n, 'x');
+
+test('exactly MIN_SUBSTANTIVE_LINES substantive lines is enough to judge', () => {
+  const body = Array.from({ length: 5 }, (_, i) => lineOfLength(20, i)).join('\n\n');
+  const verdict = classifyTranslation({
+    translatedText: withFrontmatter(body), locale: 'de', englishLines: poolOf(body),
+  });
+  assert.equal(verdict.total, 5, 'fixture must sit exactly on the boundary');
+  assert.equal(verdict.reason, 'no-foreign-lines');
+  assert.equal(verdict.stub, true);
+});
+
+test('one line below the boundary is not judged', () => {
+  const body = Array.from({ length: 4 }, (_, i) => lineOfLength(20, i)).join('\n\n');
+  const verdict = classifyTranslation({
+    translatedText: withFrontmatter(body), locale: 'de', englishLines: poolOf(body),
+  });
+  assert.equal(verdict.total, 4);
+  assert.equal(verdict.reason, 'insufficient');
+  assert.equal(verdict.stub, false);
+});
+
+test('MIN_LINE_LENGTH is pinned at both ends too', () => {
+  // A 12-character line counts; an 11-character one does not. Without this, `>=` mutates to
+  // `>` and nothing notices.
+  const twelve = 'abcdefghijkl';
+  const eleven = 'abcdefghijk';
+  assert.equal(twelve.length, 12);
+  assert.deepEqual(substantiveLines(`${twelve}\n${eleven}\n`), [twelve]);
+});
+
 test('a translation whose English source is gone is reported no-source', () => {
   const verdict = classifyTranslation({
     translatedText: withFrontmatter(ENGLISH_BODY),
@@ -335,6 +370,42 @@ test('buildEnglishProseHistory includes uncommitted English edits', () => {
     assert.ok(lines.has('Uncommitted prose line in the working tree.'),
       'an uncommitted English edit is a legal basis, or every local scaffold reads as translated');
     assert.ok(lines.has('Committed prose line for the base.'));
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('a missing blob does not shift the batch parser onto the wrong key', () => {
+  // The batch loop walks `git cat-file --batch` output positionally: each `missing` header
+  // must advance the spec index WITHOUT consuming a payload. If that skip is wrong, every
+  // subsequent blob is attributed to the previous spec's key, and the pools are silently
+  // wrong rather than empty — the worst available failure. Two skills are used so a
+  // misalignment lands prose in the other one's basis, where it is visible.
+  const repo = mkdtempSync(join(tmpdir(), 'aa-tstatus-missing-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: repo, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.invalid');
+    git('config', 'user.name', 'Test');
+
+    for (const [id, line] of [['alpha-skill', 'Alpha prose line, unique to alpha.'], ['beta-skill', 'Beta prose line, unique to beta.']]) {
+      mkdirSync(join(repo, 'skills', id), { recursive: true });
+      writeFileSync(join(repo, 'skills', id, 'SKILL.md'), withFrontmatter(`# ${id}\n\n${line}\n`));
+    }
+    git('add', '-A');
+    git('commit', '-qm', 'two skills');
+
+    // Delete one and commit: its path now appears in history at a commit where the OTHER
+    // skill's blob is absent, so the walk emits specs that resolve to `missing`.
+    rmSync(join(repo, 'skills', 'alpha-skill'), { recursive: true, force: true });
+    git('add', '-A');
+    git('commit', '-qm', 'delete alpha');
+
+    const history = buildEnglishProseHistory(repo);
+    assert.ok(history.get('skills/alpha-skill')?.has('Alpha prose line, unique to alpha.'));
+    assert.ok(history.get('skills/beta-skill')?.has('Beta prose line, unique to beta.'));
+    assert.equal(history.get('skills/beta-skill')?.has('Alpha prose line, unique to alpha.'), false,
+      'a misaligned batch parse would cross-pollinate the two bases');
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/scripts/test/translation-status.test.js
+++ b/scripts/test/translation-status.test.js
@@ -1,0 +1,364 @@
+/**
+ * Unit tests for `scripts/lib/translation-status.js`.
+ *
+ * There was no test file for `generate-translation-status.js` at all, which is how #473 and
+ * #532 both survived in the same twelve lines. The script is also unrunnable as a test: it
+ * walks ten locales over an NTFS mount and takes ~10 minutes (#305). Extracting the verdict
+ * into a pure function is what makes these assertions possible at all.
+ *
+ * Each test below names the failure it exists to catch. The three that matter most:
+ *
+ *   - a CRLF copy of an English body is still a scaffold (#532),
+ *   - a scaffold stays a scaffold after English moves on (#473 — the window),
+ *   - a scaffold assembled from two different English revisions is still a scaffold
+ *     (surgical mirror propagation, which is why comparing against the `source_commit`
+ *     blob does not work — measured on the four `harden-github-repo-security` files).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync } from 'child_process';
+import {
+  stripFrontmatter,
+  openLines,
+  substantiveLines,
+  classifyTranslation,
+  buildEnglishProseHistory,
+  MIN_SUBSTANTIVE_LINES,
+} from '../lib/translation-status.js';
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+const ENGLISH_BODY = [
+  '# Create R Package',
+  '',
+  '## When to Use',
+  '',
+  'Use this skill when starting a new R package from scratch.',
+  'It covers the directory layout and the DESCRIPTION file.',
+  '',
+  '## Procedure',
+  '',
+  '1. Run the scaffolding command shown below.',
+  '',
+  '```bash',
+  'usethis::create_package("mypkg")',
+  '```',
+  '',
+  'Verify the package directory was created before continuing.',
+  'The DESCRIPTION file must name an author and a maintainer.',
+  '',
+].join('\n');
+
+const withFrontmatter = (body, extra = '') => [
+  '---',
+  'name: create-r-package',
+  'description: Scaffold an R package',
+  extra,
+  '---',
+  body,
+].filter((l) => l !== '').join('\n');
+
+/** Every substantive line of `body`, as the English pool would hold them. */
+const poolOf = (...bodies) => new Set(bodies.flatMap((b) => substantiveLines(b)));
+
+// ── stripFrontmatter ────────────────────────────────────────────────────────
+
+test('stripFrontmatter returns the body after the second delimiter', () => {
+  const body = stripFrontmatter(withFrontmatter(ENGLISH_BODY));
+  assert.ok(body.startsWith('# Create R Package'));
+  assert.ok(!body.includes('description: Scaffold'));
+});
+
+test('stripFrontmatter normalises CRLF and lone CR (#532)', () => {
+  // The defect: split on '\n' left an interior '\r' on every line, so byte comparison
+  // against an LF source failed and the scaffold was recounted as a translation.
+  const crlf = withFrontmatter(ENGLISH_BODY).replace(/\n/g, '\r\n');
+  assert.equal(stripFrontmatter(crlf), stripFrontmatter(withFrontmatter(ENGLISH_BODY)));
+  assert.ok(!stripFrontmatter(crlf).includes('\r'));
+
+  const cr = withFrontmatter(ENGLISH_BODY).replace(/\n/g, '\r');
+  assert.ok(!stripFrontmatter(cr).includes('\r'));
+});
+
+test('a file with no closing frontmatter delimiter keeps its whole text, normalised', () => {
+  const text = '---\r\nname: x\r\n# heading\r\nbody line that is long enough\r\n';
+  // Nothing is stripped — there is no second delimiter — but CRLF is still normalised, so
+  // the fallback path cannot smuggle carriage returns into the comparison either.
+  assert.equal(stripFrontmatter(text), '---\nname: x\n# heading\nbody line that is long enough\n');
+});
+
+// ── fence handling ──────────────────────────────────────────────────────────
+
+test('frozen fence bodies are excluded, localisable ones are kept', () => {
+  const text = [
+    'Prose above the fence.',
+    '```bash',
+    'echo "this is keep-in-English by design"',
+    '```',
+    '```text',
+    'This table is translatable prose.',
+    '```',
+  ].join('\n');
+  const lines = openLines(text);
+  // The frozen `bash` body and BOTH delimiter lines of each fence are gone.
+  assert.ok(!lines.some((l) => l.includes('keep-in-English')));
+  assert.ok(!lines.some((l) => l.startsWith('```')));
+  // The `text` fence body survives — it is translatable, so English in it is evidence.
+  assert.ok(lines.some((l) => l.includes('translatable prose')));
+});
+
+test('substantiveLines drops markdown scaffolding that matches in every locale', () => {
+  const lines = substantiveLines('# Hi\n\n---\n1.\n**Note:**\nA line long enough to compare.\n');
+  assert.deepEqual(lines, ['A line long enough to compare.']);
+});
+
+// ── the three failures this rewrite exists to fix ───────────────────────────
+
+test('a scaffold is a scaffold after English moves on (#473 — the window)', () => {
+  const scaffold = withFrontmatter(ENGLISH_BODY, '  source_commit: abc1234');
+  const englishNow = `${ENGLISH_BODY}\nA paragraph added to English after the scaffold was made.\n`;
+  // Pool spans history: the old body AND the current one.
+  const pool = poolOf(ENGLISH_BODY, englishNow);
+
+  const verdict = classifyTranslation({ translatedText: scaffold, locale: 'de', englishLines: pool });
+  assert.equal(verdict.stub, true);
+  assert.equal(verdict.reason, 'no-foreign-lines');
+
+  // And the point of the historical pool: comparing against current English ALONE would
+  // still call it a stub here only because the old lines survived the edit. Delete one and
+  // the single-revision comparison collapses, while the pooled one does not.
+  const englishRewritten = ENGLISH_BODY
+    .replace('Verify the package directory was created before continuing.', 'Confirm the directory exists.');
+  assert.equal(
+    classifyTranslation({ translatedText: scaffold, locale: 'de', englishLines: poolOf(englishRewritten) }).stub,
+    false,
+    'sanity: a single-revision pool loses the scaffold, which is exactly defect #473',
+  );
+  assert.equal(
+    classifyTranslation({ translatedText: scaffold, locale: 'de', englishLines: poolOf(ENGLISH_BODY, englishRewritten) }).stub,
+    true,
+    'the historical pool keeps it',
+  );
+});
+
+test('a CRLF scaffold is still a scaffold (#532)', () => {
+  const scaffold = withFrontmatter(ENGLISH_BODY).replace(/\n/g, '\r\n');
+  const verdict = classifyTranslation({ translatedText: scaffold, locale: 'de', englishLines: poolOf(ENGLISH_BODY) });
+  assert.equal(verdict.stub, true, 'CRLF must not launder a scaffold into the translated count');
+  assert.equal(verdict.foreign, 0);
+});
+
+test('a scaffold surgically patched from a later revision is still a scaffold', () => {
+  // The measured shape of the four `harden-github-repo-security` files: an old English body
+  // with one paragraph spliced in from a newer English revision. It equals NO single
+  // revision, which is why comparing against the `source_commit` blob fails.
+  const englishNew = ENGLISH_BODY
+    .replace('The DESCRIPTION file must name an author and a maintainer.',
+      'The DESCRIPTION file must name an author, a maintainer and a licence.');
+  const frankenstein = withFrontmatter(
+    ENGLISH_BODY.replace('The DESCRIPTION file must name an author and a maintainer.',
+      'The DESCRIPTION file must name an author, a maintainer and a licence.'),
+  );
+
+  // Neither single revision explains it...
+  assert.equal(classifyTranslation({ translatedText: frankenstein, locale: 'de', englishLines: poolOf(ENGLISH_BODY) }).stub, false);
+  // ...but the union of revisions does.
+  assert.equal(
+    classifyTranslation({ translatedText: frankenstein, locale: 'de', englishLines: poolOf(ENGLISH_BODY, englishNew) }).stub,
+    true,
+  );
+});
+
+// ── the other side: genuine translations must survive ───────────────────────
+
+test('a genuine translation is not a scaffold', () => {
+  const german = withFrontmatter([
+    '# R-Paket erstellen',
+    '',
+    '## Wann zu verwenden',
+    '',
+    'Verwende diese Faehigkeit, wenn du ein neues R-Paket beginnst.',
+    'Sie behandelt das Verzeichnislayout und die DESCRIPTION-Datei.',
+    '',
+    '```bash',
+    'usethis::create_package("mypkg")',
+    '```',
+    '',
+    'Pruefe, dass das Paketverzeichnis angelegt wurde, bevor du fortfaehrst.',
+    'Die DESCRIPTION-Datei muss Autor und Betreuer nennen.',
+  ].join('\n'));
+  const verdict = classifyTranslation({ translatedText: german, locale: 'de', englishLines: poolOf(ENGLISH_BODY) });
+  assert.equal(verdict.stub, false);
+  assert.equal(verdict.reason, 'has-foreign-lines');
+});
+
+test('a near-English compressed tier is not a scaffold on one differing line', () => {
+  // caveman-lite is SPECIFIED to keep grammar, articles and full sentences, and measures
+  // ~90% verbatim English lines corpus-wide. Any similarity threshold that catches a
+  // scaffold also condemns this tier for meeting its spec — hence a zero-evidence rule.
+  const caveman = withFrontmatter(
+    ENGLISH_BODY.replace('Use this skill when starting a new R package from scratch.',
+      'Use skill when start new R package from scratch.'),
+  );
+  const verdict = classifyTranslation({ translatedText: caveman, locale: 'caveman-lite', englishLines: poolOf(ENGLISH_BODY) });
+  assert.equal(verdict.stub, false);
+  assert.equal(verdict.foreign, 1);
+});
+
+test('an identical body under a locale with no script rule still needs prose evidence', () => {
+  const verdict = classifyTranslation({
+    translatedText: withFrontmatter(ENGLISH_BODY),
+    locale: 'caveman',
+    englishLines: poolOf(ENGLISH_BODY),
+  });
+  assert.equal(verdict.stub, true);
+});
+
+// ── the script rule ─────────────────────────────────────────────────────────
+
+test('a CJK-script locale with no CJK is a scaffold regardless of prose', () => {
+  // Decisive: a Japanese document containing zero kana and zero han is not Japanese. This
+  // fires even when the prose comparison cannot, e.g. against an empty pool.
+  const verdict = classifyTranslation({
+    translatedText: withFrontmatter(ENGLISH_BODY),
+    locale: 'ja',
+    englishLines: new Set(),
+  });
+  assert.equal(verdict.stub, true);
+  assert.equal(verdict.reason, 'no-script');
+});
+
+test('the script rule reads the body, not the frontmatter', () => {
+  // A scaffold whose frontmatter names the locale in its own script must not pass.
+  const scaffold = withFrontmatter(ENGLISH_BODY, '  name_native: 日本語');
+  assert.equal(classifyTranslation({ translatedText: scaffold, locale: 'ja', englishLines: new Set() }).stub, true);
+});
+
+test('a translated CJK file passes the script rule and then the prose rule', () => {
+  const japanese = withFrontmatter([
+    '# Rパッケージの作成',
+    '',
+    'このスキルは新しいRパッケージを最初から作成するときに使用します。',
+    'ディレクトリ構成とDESCRIPTIONファイルについて説明します。',
+    'パッケージディレクトリが作成されたことを確認してから続行してください。',
+    'DESCRIPTIONファイルには著者と管理者を記載する必要があります。',
+    'この手順は一度だけ実行してください。',
+  ].join('\n'));
+  const verdict = classifyTranslation({ translatedText: japanese, locale: 'ja', englishLines: poolOf(ENGLISH_BODY) });
+  assert.equal(verdict.stub, false);
+  assert.equal(verdict.reason, 'has-foreign-lines');
+});
+
+test('zh-CN does not accept kana as evidence of Chinese', () => {
+  // Kana only — no han. `行` would be a Han character and would defeat the point.
+  const kanaOnly = withFrontmatter(`${ENGLISH_BODY}\nこれはひらがなだけのぎょうです。\n`);
+  assert.equal(classifyTranslation({ translatedText: kanaOnly, locale: 'zh-CN', englishLines: poolOf(ENGLISH_BODY) }).reason, 'no-script');
+  assert.equal(classifyTranslation({ translatedText: kanaOnly, locale: 'ja', englishLines: poolOf(ENGLISH_BODY) }).reason, 'has-foreign-lines');
+});
+
+// ── the lenient residue, stated rather than hidden ──────────────────────────
+
+test('a file too short to judge is reported insufficient, not a scaffold', () => {
+  const tiny = withFrontmatter('# Title\n\nOne single line of prose here.\n');
+  const verdict = classifyTranslation({ translatedText: tiny, locale: 'de', englishLines: poolOf(ENGLISH_BODY) });
+  assert.equal(verdict.stub, false);
+  assert.equal(verdict.reason, 'insufficient');
+  assert.ok(verdict.total < MIN_SUBSTANTIVE_LINES);
+});
+
+test('a translation whose English source is gone is reported no-source', () => {
+  const verdict = classifyTranslation({
+    translatedText: withFrontmatter(ENGLISH_BODY),
+    locale: 'de',
+    englishLines: undefined,
+  });
+  assert.equal(verdict.stub, false);
+  assert.equal(verdict.reason, 'no-source');
+});
+
+// ── the git path ────────────────────────────────────────────────────────────
+
+test('buildEnglishProseHistory pools every revision a source has had', () => {
+  const repo = mkdtempSync(join(tmpdir(), 'aa-tstatus-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: repo, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.invalid');
+    git('config', 'user.name', 'Test');
+
+    const skillDir = join(repo, 'skills', 'demo-skill');
+    mkdirSync(skillDir, { recursive: true });
+    const path = join(skillDir, 'SKILL.md');
+
+    const first = withFrontmatter('# Demo\n\nThe first revision said something specific here.\n');
+    writeFileSync(path, first);
+    git('add', '-A');
+    git('commit', '-qm', 'first');
+
+    const second = withFrontmatter('# Demo\n\nThe second revision says something else entirely.\n');
+    writeFileSync(path, second);
+    git('add', '-A');
+    git('commit', '-qm', 'second');
+
+    const history = buildEnglishProseHistory(repo);
+    const lines = history.get('skills/demo-skill');
+    assert.ok(lines, 'the skill must be keyed by contentKey');
+    assert.ok(lines.has('The first revision said something specific here.'),
+      'a line deleted from English is still English — this is what makes the detector survive surgical propagation');
+    assert.ok(lines.has('The second revision says something else entirely.'));
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('buildEnglishProseHistory includes uncommitted English edits', () => {
+  const repo = mkdtempSync(join(tmpdir(), 'aa-tstatus-wt-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: repo, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.invalid');
+    git('config', 'user.name', 'Test');
+
+    const skillDir = join(repo, 'skills', 'demo-skill');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), withFrontmatter('# Demo\n\nCommitted prose line for the base.\n'));
+    git('add', '-A');
+    git('commit', '-qm', 'base');
+
+    writeFileSync(join(skillDir, 'SKILL.md'), withFrontmatter('# Demo\n\nUncommitted prose line in the working tree.\n'));
+
+    const lines = buildEnglishProseHistory(repo).get('skills/demo-skill');
+    assert.ok(lines.has('Uncommitted prose line in the working tree.'),
+      'an uncommitted English edit is a legal basis, or every local scaffold reads as translated');
+    assert.ok(lines.has('Committed prose line for the base.'));
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test('buildEnglishProseHistory excludes templates and READMEs', () => {
+  const repo = mkdtempSync(join(tmpdir(), 'aa-tstatus-tpl-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: repo, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.invalid');
+    git('config', 'user.name', 'Test');
+
+    mkdirSync(join(repo, 'skills', '_template'), { recursive: true });
+    writeFileSync(join(repo, 'skills', '_template', 'SKILL.md'), withFrontmatter('# T\n\nTemplate prose line here.\n'));
+    mkdirSync(join(repo, 'guides'), { recursive: true });
+    writeFileSync(join(repo, 'guides', 'README.md'), '# Guides\n\nGenerated index prose line.\n');
+    git('add', '-A');
+    git('commit', '-qm', 'templates');
+
+    const history = buildEnglishProseHistory(repo);
+    assert.equal(history.get('skills/_template'), undefined);
+    assert.equal(history.get('guides/README'), undefined);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #532. Addresses #473 acceptance criteria 1–4; AC5 is a content backlog, filed as #554.

## What was wrong

`isUntranslatedStub()` asked whether a translated body was byte-equal to the English body on disk. The *question* is right — file existence lies, which is why body equality replaced it — but byte equality against one English text fails three ways, all pushing `stubs` upward into `translated`:

1. **The window (#473).** Equality against *current* English closes the moment English is next edited. After that an untranslated scaffold is silently recounted as a translation.
2. **CRLF (#532).** `stripFrontmatter()` split on `\n` and trimmed only the ends, so an interior `\r` survived into every comparison. `toLines()` in `lib/fences.js` carries a comment about this exact blindness having already cost the repo once; the fix was never propagated to this call site.
3. **The blob (new).** Comparing against the `source_commit` blob — the fix suggested on both issues, in a comment I wrote — **does not work**, and this was measured rather than reasoned:

```
de     sc=84a3c915 vs-current=false vs-blob=false  len t=17417 blob=17445 cur=19146
es     sc=84a3c915 vs-current=false vs-blob=false  len t=17417 blob=17445 cur=19146
ja     sc=84a3c915 vs-current=false vs-blob=false  len t=17417 blob=17445 cur=19146
zh-CN  sc=84a3c915 vs-current=false vs-blob=false  len t=17417 blob=17445 cur=19146

revisions touching skills/harden-github-repo-security/SKILL.md: 4
distinct English bodies: 4
de/es/ja/zh-CN  matches-some-revision=NO
```

The four scaffolds match neither current English, nor the blob at their own recorded `source_commit`, nor **any** of the four revisions that path has ever had. The cause is structural: mirrors here are patched **surgically**. An English fix gets spliced into `i18n/**` without recopying the file — I did exactly this myself in #550, last week — so the result is an old body with a newer paragraph in it, equal to no single revision, past or present. Any equality-based detector is dead on arrival against that.

## What replaces it

A file is an untranslated scaffold when it shows **no evidence of translation**:

- every substantive prose line in it appeared verbatim in English at *some* point, **or**
- its locale is written in a script the file contains none of.

Frozen fences are excluded from both sides. A fence whose tag is not `text`/`markdown`/`md` is keep-in-English by design in every locale, so counting it as agreement would push every genuine translation toward the scaffold verdict.

Both rules are decisive rather than threshold-based, and that is load-bearing rather than stylistic. Measured corpus-wide, `caveman-lite` sits at a **median 0.895** verbatim-English-line ratio (336 of 352 files above 0.75) because its spec requires it to keep grammar, articles and full sentences — so any similarity threshold that catches a scaffold also condemns that entire tier for meeting its own spec (#473 AC4 warns about precisely this). The zero-evidence rule does not: `caveman-lite`'s genuine translations all carry at least one line English never had, the closest carrying 2.

Pooling across history is what makes the verdict survive surgical propagation, and it costs two git processes for the whole corpus — one `git log --name-only`, one `git cat-file --batch` — not one per file (#305). Pool build measures 8.6s / 2,488 blobs / 64,304 lines.

`git log --name-only` shows no paths for a merge commit, so prose existing only as a conflict resolution would be absent from the pool. That errs lenient. Measured with `--diff-merges=separate`: **+0 pool lines, 0 verdicts changed** in this repo. Real in principle, empty in practice.

## The red run

Per `CLAUDE.md` § *Proving a Gate Can Fail*. 46 files across 10 content items reclassify from `translated` to `stubs`; **nothing moves the other way**.

| item | locales |
|---|---|
| `guides/protecting-github-repositories` | de es ja zh-CN |
| `guides/reverse-engineering-a-cli-harness` | ja zh-CN |
| `skills/assess-github-repo-security` | de es ja zh-CN |
| `skills/create-workflow` | de es ja zh-CN |
| `skills/harden-github-repo-security` | de es ja zh-CN |
| `skills/restore-diagram-legibility` | de es ja zh-CN |
| `skills/setup-local-kubernetes` | caveman×3 wenyan×3 |
| `skills/setup-putior-ci` | caveman×3 wenyan×3 |
| `skills/version-ml-data` | caveman×3 wenyan×3 |
| `skills/write-helm-chart` | caveman×3 wenyan×3 |

Counts: de 352 → 347, es 347 → 342, ja/zh-CN 359 → 355, each compressed locale 350 → 346. Total stubs across all locales: 169.

`i18n/ja/guides/reverse-engineering-a-cli-harness.md` is 24,182 characters with **zero** CJK. It carries 5 lines English never had, so the prose rule alone spares it — the script rule is what catches it, which is the case for having two decisive rules rather than one.

`stale` drops in step, because the stub verdict returns before the staleness check. Recognising a scaffold improves the staleness number without anything being translated — worth knowing before reading these files as a work queue.

## Testing

`scripts/test/translation-status.test.js`, 20 tests. There was **no test file for `generate-translation-status.js` at all**, which is how #473 and #532 both survived in the same twelve lines; the script is also unrunnable as a test, walking ten locales over NTFS in ~10 minutes (#305). Extracting the verdict into `scripts/lib/translation-status.js` is what makes the assertions possible.

Mutants killed, after the review widened the set:

| file | mutation | killed by |
|---|---|---|
| `lib/translation-status.js` | `toLines(content)` → `content.split('\n')` | 2 tests |
| `lib/translation-status.js` | `script && !script.test(body)` → `false` | 3 tests |
| `lib/translation-status.js` | `if (isGated(fence))` → `if (false)` | 1 test |
| `lib/translation-status.js` | `foreign === 0` → `foreign <= 1` | 4 tests |
| `lib/translation-status.js` | `MIN_SUBSTANTIVE_LINES` 5 → 3 | 1 test |
| `lib/translation-status.js` | `length >= MIN_LINE_LENGTH` → `>` | 1 test |
| `lib/translation-status.js` | the batch parser's `missing` skip → `if (false)` | 1 test |
| `audit-skill-sections.js` | `toLines(raw)` → `raw.split('\n')` | 1 test |

One branch is knowingly uncovered and says so in the code: the `translationKey(...) === null` guard at the call site fires only for a `_`-prefixed or README mirror, none exist in `i18n/`, and adding one to the corpus purely as a fixture would be worse than the gap. The derivation itself is tested.

187/187 `test:scripts`; `validate:line-endings` clean; `check-readmes` clean.

## #532 AC3 — the audit, and what it took three passes to get right

The same line in `audit-skill-sections.js` was called broken, then safe, then broken again for a different reason. **Every step turned on which fixture was used**, which is the most useful thing this PR produced.

1. **First claim:** a CRLF copy "would report every required section missing." False — `sectionBody` compares `line.trim()`, and `\r` is a LineTerminator that `trim()` strips.
2. **Retraction:** so the site is safe, and the surviving mutant proves it. Also false — the mutant survived only because the fixture contained no fenced block.
3. **What is actually true**, found by adversarial review: the defect is one function down, at `:77`, and involves no split at all.

```js
const match = line.match(/^ {0,3}(`{3,}|~{3,})(.*)$/);
```

`.` does not match `\r` and an unanchored `$` asserts end of input, so ```` ```markdown\r ```` matches nothing, **no fence is ever detected**, and `fenceMask` returns an all-true mask. `create-skill` and `evolve-skill` embed a ```` ```markdown ```` fence holding a literal `## Common Pitfalls` template — the exact case that function's docstring exists for — so the audit locks onto the template and counts its bullets. `--missing` exits 1 on a zero count, so the gate fires on a healthy skill. This is the shape `lib/fences.js:14-18` documents as having once left 68 files with zero fences detected.

`FENCED_TEMPLATE_SKILL` is that fixture, and with it the mutant reverting `toLines(raw)` dies (1 test).

**`mutation-check.js`'s CR guard is reverted**, and that one was measured rather than reasoned. Its premise was that splitting on `\n` and rejoining rewrites line endings on untouched lines. It does not — the `\r` sits at the end of each split line and travels with it (`"a\r\nX\r\nb\r\n"` deletes to `"a\r\nb\r\n"`), and `--replace` never splits lines at all. The guard refused valid input for a failure that cannot happen.

**The audit's predicate was wrong too.** "Splits on `\n`" is syntactic; the defect class is "CR-sensitive matching applied to file content", and the two sets diverge in both directions. It raised a false alarm on `cli/lib/transformer.js` and `cli/lib/edge-transformer.js` — traced site by site, every comparison `.trim()`ed or prefix-anchored, **CRLF-safe**, so #555 is closed as a non-defect — and it missed `:77`, which has no split. #557 re-runs it as *end-anchored regex, or untrimmed whole-line `===`, applied to file content*.

## What this does not do

#473 AC5 ("the four files are translated, or the skill is removed from those locales") is a content action, not a detector action, and the honest list is now 46 files rather than 4. Authoring those translations is the failure class #478/#534 exist to remove, so it is filed as #554 rather than folded in here. The files are counted correctly as of this PR either way.

Also filed from this work: #556 (`i18n/_config.yml` carries a dead `source_counts` block, now wrong by 38 items).
