### PR TITLE
fix(i18n): stop reporting a measurement that was never taken, and name it novel (#553 review)

### DIFF
--- a/i18n/README.md
+++ b/i18n/README.md
@@ -155,7 +155,39 @@ Per-locale status files are auto-generated:
 npm run translation:status
 ```
 
-Each `translation_status.yml` shows coverage percentages and stale counts per content type.
+Each `translation_status.yml` reports four numbers per content type, and they do not mean
+what a quick read suggests:
+
+| field | meaning |
+|---|---|
+| `total` | English sources of that type, from the registry |
+| `translated` | files that show evidence of translation |
+| `stubs` | files that show **none** — scaffolds, still word-for-word English |
+| `stale` | translated files whose English source changed after their `source_commit` |
+
+Two things follow, and both have misled readers before:
+
+- **`stale` is measured only over `translated`.** A stub is never also stale, because the
+  scaffold verdict is reached first. So recognising a scaffold *lowers* `stale` with nothing
+  translated — a falling `stale` number is not by itself progress.
+- **`translated + stubs` is not `total`.** A locale that has never scaffolded an item has
+  neither, so the remainder is untouched content.
+
+A file counts as a stub when every substantive prose line in it appeared verbatim in English
+at some point, or when its locale is written in a script the file contains none of. Frozen
+code fences are excluded from that comparison — they are keep-in-English in every locale by
+design, so counting them would make every genuine translation look like a scaffold.
+
+```bash
+# The per-file list behind the stub count -- read this before deleting anything
+npm run translation:status -- --verdicts
+
+# How close the closest genuine translations came to being called scaffolds
+npm run translation:status -- --margins
+```
+
+Use `--verdicts` before any bulk re-scaffold. A stub verdict is remediated by deleting the
+file, so a wrong one destroys real work, and an aggregate count cannot be reviewed.
 
 ## See Also
 

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -7,8 +7,12 @@
  *
  * Usage:
  *   node scripts/generate-translation-status.js
- *   node scripts/generate-translation-status.js --verdicts   # also list every stub, with
- *                                                            # the reason and line counts
+ *   node scripts/generate-translation-status.js --verdicts   # list every stub with its
+ *                                                            # reason and line counts, plus
+ *                                                            # any orphaned mirror
+ *   node scripts/generate-translation-status.js --margins     # per locale, the genuine
+ *                                                            # translations that came
+ *                                                            # closest to a stub verdict
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
@@ -17,11 +21,19 @@ import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { assertNotShallow, createFreshnessChecker } from './lib/git-freshness.js';
 import { buildEnglishProseHistory, classifyTranslation, translationKey } from './lib/translation-status.js';
+import { TREES } from './lib/fences.js';
 
 // A stub verdict is acted on by deleting and re-scaffolding the file (#478), so a wrong one
 // destroys work. The aggregate counts cannot be reviewed; this prints the per-file list that
 // can. Use it before any bulk remediation.
 const SHOW_VERDICTS = process.argv.includes('--verdicts');
+
+// The detector's safety case is a MARGIN — how many novel lines the closest genuine
+// translation carries above the scaffold verdict. That was measured once and written into a
+// comment, where it rots. This re-measures it on demand, and doubles as the drift alarm the
+// comment's "re-measure before lowering the floor" instruction otherwise lacks.
+const SHOW_MARGINS = process.argv.includes('--margins');
+const MARGIN_COUNT = 5;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -102,9 +114,14 @@ function countTranslations(locale, contentType) {
   let translated = 0;
   let stale = 0;
   let stubs = 0;
+  // Every non-stub verdict's novel-line count, so `--margins` can report how close the
+  // closest genuine translation came to the scaffold verdict. The module header's safety
+  // case rests on that margin being 2 lines on the compressed tiers; an instruction to
+  // "re-measure before lowering the floor" needs something to re-measure with.
+  const margins = [];
 
   if (!existsSync(typeDir)) {
-    return { translated, stale, stubs };
+    return { translated, stale, stubs, margins };
   }
 
   const entries = readdirSync(typeDir);
@@ -137,13 +154,25 @@ function countTranslations(locale, contentType) {
       locale,
       englishLines: englishProse.get(key),
     });
+    // `novel` is null when the comparison did not run. Printing `-` rather than `0` keeps
+    // the distinction visible in the one list a maintainer reads before deleting files.
+    const measured = verdict.novel === null ? '-' : String(verdict.novel);
+
     if (verdict.stub) {
       stubs++;
       if (SHOW_VERDICTS) {
-        console.log(`  STUB ${locale}/${key}  (${verdict.reason}, ${verdict.foreign}/${verdict.total} foreign)`);
+        console.log(`  STUB      ${locale}/${key}  (${verdict.reason}, ${measured}/${verdict.total} novel)`);
       }
       continue;
     }
+
+    // Surfaced because it is a lenient hole with no counter of its own: a mirror whose id
+    // matches no English content in history OR the working tree is counted as translated,
+    // and it most likely indicates an orphaned or misspelt directory, which is actionable.
+    if (verdict.reason === 'no-source' && SHOW_VERDICTS) {
+      console.log(`  NO-SOURCE ${locale}/${key}  (counted as translated — orphaned mirror?)`);
+    }
+    if (verdict.novel !== null) margins.push({ key, novel: verdict.novel });
 
     translated++;
 
@@ -157,12 +186,15 @@ function countTranslations(locale, contentType) {
     }
   }
 
-  return { translated, stale, stubs };
+  return { translated, stale, stubs, margins };
 }
 
 // ── Main ─────────────────────────────────────────────────────────
 
-const contentTypes = ['skills', 'agents', 'teams', 'guides'];
+// `TREES`, not a second literal list: `buildEnglishProseHistory` pools from `TREES`, so a
+// fifth tree added there but not here would be pooled and never scanned — coverage for it
+// silently absent from the YAML, with no error. Same drift class as #519.
+const contentTypes = TREES;
 const locales = config.supported_locales.map(l => l.code);
 const today = new Date().toISOString().split('T')[0];
 
@@ -179,16 +211,26 @@ for (const locale of locales) {
   let totalStubs = 0;
   const totalSource = sourceCounts.total;
 
+  const localeMargins = [];
   for (const contentType of contentTypes) {
     const startedAt = Date.now();
-    const { translated, stale, stubs } = countTranslations(locale, contentType);
+    const { translated, stale, stubs, margins } = countTranslations(locale, contentType);
     const total = sourceCounts[contentType];
     const pct = total > 0 ? Math.round((translated / total) * 1000) / 10 : 0;
     coverage[contentType] = { translated, total, pct, stale, stubs };
     totalTranslated += translated;
     totalStale += stale;
     totalStubs += stubs;
+    localeMargins.push(...margins);
     console.log(`  scan ${locale}/${contentType}: ${translated} translated, ${stale} stale, ${stubs} stubs (${Date.now() - startedAt}ms)`);
+  }
+
+  if (SHOW_MARGINS) {
+    const closest = localeMargins.sort((a, b) => a.novel - b.novel).slice(0, MARGIN_COUNT);
+    console.log(`  margin ${locale}: closest genuine translations to the scaffold verdict — `
+      + (closest.length
+        ? closest.map((m) => `${m.key}=${m.novel}`).join('  ')
+        : 'none (no judged translations)'));
   }
 
   const totalPct = totalSource > 0
@@ -212,4 +254,10 @@ for (const locale of locales) {
   writeFileSync(statusPath, yaml.dump(status, { flowLevel: 3 }));
   console.log(`GENERATED: ${statusPath.replace(ROOT + '/', '')}`);
   console.log(`  Coverage: ${totalTranslated}/${totalSource} (${totalPct}%), ${totalStale} stale, ${totalStubs} stubs`);
+  // Standing hint, not a footnote in a docstring. A stub verdict is remediated by deleting
+  // the file, the detector's errors point strict, and `--verdicts` was discoverable only by
+  // reading the source — which makes the containment documentation rather than a control.
+  if (totalStubs > 0 && !SHOW_VERDICTS) {
+    console.log(`  ${totalStubs} stubs — re-run with --verdicts and read the per-file list before any re-scaffold.`);
+  }
 }

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -13,6 +13,9 @@
  *   node scripts/generate-translation-status.js --margins     # per locale, the genuine
  *                                                            # translations that came
  *                                                            # closest to a stub verdict
+ *
+ * `--verdicts` and `--margins` are INSPECTION modes and do not write. Add `--write` to
+ * regenerate the status files in the same run. Unknown arguments exit 2.
  */
 
 import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
@@ -23,9 +26,21 @@ import { assertNotShallow, createFreshnessChecker } from './lib/git-freshness.js
 import { buildEnglishProseHistory, classifyTranslation, translationKey } from './lib/translation-status.js';
 import { TREES } from './lib/fences.js';
 
+// Validated against an accept-list, not sniffed with `includes`. `--verdict`, `--verdicts=1`
+// and `-verdicts` all used to parse as "flag absent": the scan ran, ten files were written,
+// no verdict list printed, exit 0 — and the reader concluded there were no stubs to review
+// before starting a bulk delete. `audit-skill-sections.js` already does this correctly.
+const KNOWN_FLAGS = new Set(['--verdicts', '--margins', '--write']);
+const UNKNOWN_FLAGS = process.argv.slice(2).filter((arg) => !KNOWN_FLAGS.has(arg));
+if (UNKNOWN_FLAGS.length) {
+  console.error(`ERROR: unknown argument(s): ${UNKNOWN_FLAGS.join(' ')}`);
+  console.error(`Known flags: ${[...KNOWN_FLAGS].join(', ')}`);
+  process.exit(2);
+}
+
 // A stub verdict is acted on by deleting and re-scaffolding the file (#478), so a wrong one
 // destroys work. The aggregate counts cannot be reviewed; this prints the per-file list that
-// can. Use it before any bulk remediation.
+// can, with the real path of each file. Use it before any bulk remediation.
 const SHOW_VERDICTS = process.argv.includes('--verdicts');
 
 // The detector's safety case is a MARGIN — how many novel lines the closest genuine
@@ -34,6 +49,16 @@ const SHOW_VERDICTS = process.argv.includes('--verdicts');
 // comment's "re-measure before lowering the floor" instruction otherwise lacks.
 const SHOW_MARGINS = process.argv.includes('--margins');
 const MARGIN_COUNT = 5;
+
+// The inspection flags do NOT write. The header tells a maintainer to run `--verdicts`
+// before a destructive batch; if that command also rewrites ten tracked YAML files — each
+// stamped `last_updated: <today>`, so it dirties the tree even when no count moved — then
+// the prescribed safety step defeats `npm run guard:verify` and produces a diff out of
+// nothing. This repo has already paid for that shape once: `normalize:i18n-fences` previews
+// by default because a read-only probe agent typed the bare command and rewrote 281 files
+// (#486). `--write` forces a regeneration alongside an inspection run.
+const WRITE_STATUS = process.argv.includes('--write')
+  || (!SHOW_VERDICTS && !SHOW_MARGINS);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -158,10 +183,17 @@ function countTranslations(locale, contentType) {
     // the distinction visible in the one list a maintainer reads before deleting files.
     const measured = verdict.novel === null ? '-' : String(verdict.novel);
 
+    // The real, `rm`-able path — not `<locale>/<tree>/<id>`, which is not a path at all: it
+    // lacks the `i18n/` prefix and the suffix, and the suffix RULE DIFFERS BY TREE
+    // (`/SKILL.md` for skills, `.md` elsewhere). Someone scripting a remediation from the
+    // key gets a working delete for skills and a silent no-op for agents, teams and guides,
+    // and the batch half-applies with no error.
+    const shownPath = toRelPath(translatedFile);
+
     if (verdict.stub) {
       stubs++;
       if (SHOW_VERDICTS) {
-        console.log(`  STUB      ${locale}/${key}  (${verdict.reason}, ${measured}/${verdict.total} novel)`);
+        console.log(`  STUB      ${shownPath}  (${verdict.reason}, ${measured}/${verdict.total} novel)`);
       }
       continue;
     }
@@ -170,9 +202,9 @@ function countTranslations(locale, contentType) {
     // matches no English content in history OR the working tree is counted as translated,
     // and it most likely indicates an orphaned or misspelt directory, which is actionable.
     if (verdict.reason === 'no-source' && SHOW_VERDICTS) {
-      console.log(`  NO-SOURCE ${locale}/${key}  (counted as translated — orphaned mirror?)`);
+      console.log(`  NO-SOURCE ${shownPath}  (counted as translated — orphaned mirror?)`);
     }
-    if (verdict.novel !== null) margins.push({ key, novel: verdict.novel });
+    if (verdict.novel !== null) margins.push({ path: shownPath, novel: verdict.novel });
 
     translated++;
 
@@ -229,7 +261,7 @@ for (const locale of locales) {
     const closest = localeMargins.sort((a, b) => a.novel - b.novel).slice(0, MARGIN_COUNT);
     console.log(`  margin ${locale}: closest genuine translations to the scaffold verdict — `
       + (closest.length
-        ? closest.map((m) => `${m.key}=${m.novel}`).join('  ')
+        ? closest.map((m) => `${m.path}=${m.novel}`).join('  ')
         : 'none (no judged translations)'));
   }
 
@@ -251,8 +283,12 @@ for (const locale of locales) {
   };
 
   const statusPath = resolve(localeDir, 'translation_status.yml');
-  writeFileSync(statusPath, yaml.dump(status, { flowLevel: 3 }));
-  console.log(`GENERATED: ${statusPath.replace(ROOT + '/', '')}`);
+  if (WRITE_STATUS) {
+    writeFileSync(statusPath, yaml.dump(status, { flowLevel: 3 }));
+    console.log(`GENERATED: ${statusPath.replace(ROOT + '/', '')}`);
+  } else {
+    console.log(`INSPECTED: ${statusPath.replace(ROOT + '/', '')} (not written — pass --write to regenerate)`);
+  }
   console.log(`  Coverage: ${totalTranslated}/${totalSource} (${totalPct}%), ${totalStale} stale, ${totalStubs} stubs`);
   // Standing hint, not a footnote in a docstring. A stub verdict is remediated by deleting
   // the file, the detector's errors point strict, and `--verdicts` was discoverable only by

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -77,11 +77,11 @@ const GIT_BUFFER = 512 * 1024 * 1024;
  * The floor errs **strict**, not neutral: a short translated line such as `## Nutzung` is
  * genuine evidence of translation that this discards, and discarding evidence can only flip
  * a verdict toward `stub`. Measured, the margin holds anyway — the genuine translation
- * closest to the scaffold verdict corpus-wide is a `caveman-lite` file with 2 foreign lines,
+ * closest to the scaffold verdict corpus-wide is a `caveman-lite` file with 2 novel lines,
  * and among the natural-language locales the closest carries 5. Re-measure before lowering
  * it; do not reason about it.
  */
-export const MIN_LINE_LENGTH = 12;
+export const MIN_COMPARABLE_LINE_CHARS = 12;
 
 /**
  * Fewest substantive lines a file must have before the zero-evidence rule may fire. A file
@@ -89,7 +89,7 @@ export const MIN_LINE_LENGTH = 12;
  * "short". Files below this are reported `insufficient` and counted as translated, which is
  * the lenient direction — stated so a reader knows which way the residue leans.
  */
-export const MIN_SUBSTANTIVE_LINES = 5;
+export const MIN_LINES_TO_JUDGE = 5;
 
 /**
  * Locales written in a script English does not use. A file in one of these containing none
@@ -125,6 +125,10 @@ export const REQUIRED_SCRIPT = new Map([
  * @returns {string} body with LF line endings, or the whole text when no frontmatter closes
  */
 export function stripFrontmatter(content) {
+  // Counts any two `---` lines, so a frontmatter-less historical blob whose body opens with
+  // two horizontal rules loses everything before the second. That shrinks the pool, which is
+  // the lenient direction (more lines look novel, the file reads as translated), and no blob
+  // in this corpus is shaped that way. Left as-is knowingly.
   const lines = toLines(content);
   let delimiters = 0;
   for (let i = 0; i < lines.length; i += 1) {
@@ -165,7 +169,7 @@ export function openLines(text) {
 export function substantiveLines(text) {
   return openLines(text)
     .map((line) => line.trim())
-    .filter((line) => line.length >= MIN_LINE_LENGTH && /\p{L}/u.test(line));
+    .filter((line) => line.length >= MIN_COMPARABLE_LINE_CHARS && /\p{L}/u.test(line));
 }
 
 /**
@@ -194,9 +198,16 @@ export function translationKey(contentType, itemId) {
  * @param {string} input.locale           locale code, e.g. `de`
  * @param {Set<string>} input.englishLines every substantive prose line the English source
  *                                        has ever had (see `buildEnglishProseHistory`)
- * @returns {{stub: boolean, reason: string, foreign: number, total: number}}
- *   `reason` is one of `no-script`, `no-foreign-lines`, `has-foreign-lines`,
+ * @returns {{stub: boolean, reason: string, novel: number|null, total: number}}
+ *   `reason` is one of `no-script`, `no-novel-lines`, `has-novel-lines`,
  *   `insufficient`, `no-source`.
+ *
+ *   **`novel` is `null` whenever the comparison did not run** — on `no-script`, `no-source`
+ *   and `insufficient`. It used to report `0` there, which is a fabricated measurement in
+ *   the one place it does the most damage: the `--verdicts` list a maintainer reads before
+ *   a delete-and-re-scaffold. `(no-script, 0/57)` reads as "checked, nothing novel,
+ *   open-and-shut" for a file that might carry forty novel lines. A verdict must be able to
+ *   say it did not measure.
  */
 export function classifyTranslation({ translatedText, locale, englishLines }) {
   const body = stripFrontmatter(translatedText);
@@ -204,22 +215,22 @@ export function classifyTranslation({ translatedText, locale, englishLines }) {
 
   const script = REQUIRED_SCRIPT.get(locale);
   if (script && !script.test(body)) {
-    return { stub: true, reason: 'no-script', foreign: 0, total: lines.length };
+    return { stub: true, reason: 'no-script', novel: null, total: lines.length };
   }
 
   if (!englishLines) {
-    return { stub: false, reason: 'no-source', foreign: 0, total: lines.length };
+    return { stub: false, reason: 'no-source', novel: null, total: lines.length };
   }
-  if (lines.length < MIN_SUBSTANTIVE_LINES) {
-    return { stub: false, reason: 'insufficient', foreign: 0, total: lines.length };
+  if (lines.length < MIN_LINES_TO_JUDGE) {
+    return { stub: false, reason: 'insufficient', novel: null, total: lines.length };
   }
 
-  let foreign = 0;
-  for (const line of lines) if (!englishLines.has(line)) foreign += 1;
+  let novel = 0;
+  for (const line of lines) if (!englishLines.has(line)) novel += 1;
 
-  return foreign === 0
-    ? { stub: true, reason: 'no-foreign-lines', foreign, total: lines.length }
-    : { stub: false, reason: 'has-foreign-lines', foreign, total: lines.length };
+  return novel === 0
+    ? { stub: true, reason: 'no-novel-lines', novel, total: lines.length }
+    : { stub: false, reason: 'has-novel-lines', novel, total: lines.length };
 }
 
 /**
@@ -228,7 +239,7 @@ export function classifyTranslation({ translatedText, locale, englishLines }) {
  *
  * Pooling across history is what makes the verdict survive surgical mirror propagation: a
  * paragraph spliced into `i18n/**` from a later English revision, sitting in a body copied
- * from an earlier one, is English in both halves and foreign in neither.
+ * from an earlier one, is English in both halves and novel in neither.
  *
  * Costs two git processes for the whole corpus — one `git log --name-only`, one
  * `git cat-file --batch` — rather than one per file (#305). The working tree is added last
@@ -240,7 +251,7 @@ export function classifyTranslation({ translatedText, locale, englishLines }) {
  * a body existing only as conflict-resolution output never enters the pool; and `--name-only`
  * without `--follow` loses pre-rename paths (harmless for the skills flatten, which
  * `contentKey` normalises, but not for an id rename). **Here** both shrink the pool, so a
- * scaffold shows foreign lines and reads as translated — lenient. In `fences.js`, where the
+ * scaffold shows novel lines and reads as translated — lenient. In `fences.js`, where the
  * same pool is a *violation* basis, a missing revision manufactures a false violation —
  * strict. Measured on this repo: adding `--diff-merges=separate` changes the pool by 0 lines
  * and the verdict set by 0 files.

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -40,7 +40,7 @@
  * threshold that catches a scaffold also condemns that tier for meeting its own spec. The
  * zero-evidence rule does not: measured on the corpus of 2026-08-11, every genuine
  * `caveman-lite` translation carries at least one line English never had — the closest
- * carrying exactly one — and its scaffolds carry none. That is a measurement, not an
+ * carrying two, per `--margins` — and its scaffolds carry none. That is a measurement, not an
  * invariant. Nothing in the spec forbids a short, heavily fenced skill from compressing to
  * zero novel lines.
  *
@@ -65,9 +65,12 @@ import { join } from 'path';
 import { execFileSync, spawnSync } from 'child_process';
 import { toLines, extractFences, isGated, contentKey, TREES } from './fences.js';
 
-// Deliberately smaller than `lib/fences.js`'s 2 GiB: this pool holds trimmed prose lines,
-// not whole fence bodies. On overflow `execFileSync` throws ENOBUFS, so the difference fails
-// loud rather than producing a short pool. Raise both together if either is ever hit.
+// Smaller than `lib/fences.js`'s 2 GiB, and the earlier justification here was wrong: the
+// buffer bounds `git cat-file --batch` stdout, which is the same bytes in both callers, so
+// what the pool later retains has nothing to do with it. The honest statement is that this
+// caller will hit ENOBUFS first as history grows, and that the failure is loud — `spawnSync`
+// sets `error` and a short `stdout`, and the parse below would silently produce a truncated
+// pool if it were not for the `status !== 0` check. Raise both together, and keep that check.
 const GIT_BUFFER = 512 * 1024 * 1024;
 
 /**
@@ -79,7 +82,9 @@ const GIT_BUFFER = 512 * 1024 * 1024;
  * a verdict toward `stub`. Measured, the margin holds anyway — the genuine translation
  * closest to the scaffold verdict corpus-wide is a `caveman-lite` file with 2 novel lines,
  * and among the natural-language locales the closest carries 5. Re-measure before lowering
- * it; do not reason about it.
+ * it, with `generate-translation-status.js --margins`; do not reason about it. (An earlier
+ * revision stated this margin as 1 here and 2 below, from the same corpus. Numbers written
+ * into prose drift against each other; the flag exists so this one does not have to.)
  */
 export const MIN_COMPARABLE_LINE_CHARS = 12;
 
@@ -122,7 +127,10 @@ export const REQUIRED_SCRIPT = new Map([
  * caused once, unfixed at this call site.
  *
  * @param {string} content full file text
- * @returns {string} body with LF line endings, or the whole text when no frontmatter closes
+ * @returns {string} body with LF line endings, or the whole text when fewer than two `---`
+ *   lines are present. Note the delimiters are counted anywhere in the file, not only at the
+ *   top, so a frontmatter-less document opening with two thematic breaks loses everything
+ *   above the second — see the note in the body for why that is left alone.
  */
 export function stripFrontmatter(content) {
   // Counts any two `---` lines, so a frontmatter-less historical blob whose body opens with
@@ -145,6 +153,14 @@ export function stripFrontmatter(content) {
  * bodies dropped, localisable (`text`/`markdown`/`md`) fence bodies kept because those are
  * translatable and a scaffold's English in them is evidence.
  *
+ * An **unterminated** fence is deliberately not treated as frozen. CommonMark says such a
+ * fence runs to end of document, and honouring that here was a one-line bypass of the whole
+ * detector: appending a single ```` ```bash ```` to a scaffold hid every remaining line from
+ * comparison, collapsed `total` from 5 to 0, and turned a `stub` verdict into `insufficient`
+ * — which is counted as *translated*. Measured, not theorised. An unterminated fence is a
+ * malformed document, not a claim that the rest of the file is keep-in-English, so its body
+ * is compared like any other prose. The fence gate flags the malformation separately.
+ *
  * @param {string} text
  * @returns {string[]}
  */
@@ -154,7 +170,7 @@ export function openLines(text) {
   for (const fence of extractFences(text)) {
     dropped[fence.line - 1] = true;
     if (fence.bodyEnd < lines.length) dropped[fence.bodyEnd] = true;
-    if (isGated(fence)) {
+    if (isGated(fence) && !fence.unterminated) {
       for (let i = fence.bodyStart; i < fence.bodyEnd; i += 1) dropped[i] = true;
     }
   }
@@ -304,6 +320,14 @@ export function buildEnglishProseHistory(root) {
       input: Buffer.from(`${specs.join('\n')}\n`, 'utf8'),
       maxBuffer: GIT_BUFFER,
     });
+    // Surfaced explicitly, not left to the status check. A maxBuffer overflow SIGTERMs the
+    // child and leaves `status` null, which `!== 0` happens to catch — but the message would
+    // then blame git for failing rather than naming the truncation, and a truncated pool is
+    // the one failure here that silently reclassifies files.
+    if (batch.error) {
+      throw new Error(`git cat-file --batch did not complete (${batch.error.code ?? batch.error.message}). `
+        + `If this is ENOBUFS, GIT_BUFFER (${GIT_BUFFER}) is too small for this history.`);
+    }
     if (batch.status !== 0) {
       throw new Error(`git cat-file --batch failed: ${batch.stderr?.toString().slice(0, 500)}`);
     }

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -213,16 +213,29 @@ export function classifyTranslation({ translatedText, locale, englishLines }) {
   const body = stripFrontmatter(translatedText);
   const lines = substantiveLines(body);
 
-  const script = REQUIRED_SCRIPT.get(locale);
-  if (script && !script.test(body)) {
-    return { stub: true, reason: 'no-script', novel: null, total: lines.length };
-  }
-
+  // ORDER MATTERS, and it is not the obvious one. The two "we cannot judge this" checks run
+  // BEFORE the decisive script rule, because a decisive rule must not outrank an admission
+  // of ignorance. Running the script rule first produced two wrong verdicts:
+  //
+  //   - An orphaned CJK mirror — the file exists, its English source was deleted or its id
+  //     renamed — was called `no-script`, i.e. a scaffold, i.e. delete-and-re-scaffold. With
+  //     no source left to re-scaffold from, that is permanent loss of the only surviving
+  //     artifact. The identical file under `de` returned `no-source` and was preserved, so
+  //     the disposition differed by locale alone.
+  //   - A near-empty or all-fenced CJK mirror yielded `{stub: true, total: 0}`. A one-line
+  //     file has essentially no opportunity to contain han, so "decisive, with no false
+  //     positives available to it" is simply not earned at small `total` — which is the very
+  //     reasoning `MIN_LINES_TO_JUDGE` exists to encode.
   if (!englishLines) {
     return { stub: false, reason: 'no-source', novel: null, total: lines.length };
   }
   if (lines.length < MIN_LINES_TO_JUDGE) {
     return { stub: false, reason: 'insufficient', novel: null, total: lines.length };
+  }
+
+  const script = REQUIRED_SCRIPT.get(locale);
+  if (script && !script.test(body)) {
+    return { stub: true, reason: 'no-script', novel: null, total: lines.length };
   }
 
   let novel = 0;

--- a/scripts/mutation-check.js
+++ b/scripts/mutation-check.js
@@ -301,13 +301,28 @@ console.log('      green.\n');
 
 const original = readFileSync(absFile, 'utf8');
 
-// CRLF is safe here, and that was checked rather than assumed (#532's audit). Splitting on
-// '\n' leaves the '\r' attached to the END of each line, so rejoining on '\n' reproduces
-// every untouched line byte-for-byte — `"a\r\nX\r\nb\r\n"` deletes to `"a\r\nb\r\n"`. And
-// the --replace branch never splits lines at all. An earlier revision of this file added a
-// guard refusing carriage returns on the theory that rejoining rewrote line endings; the
-// theory was wrong and the guard only refused valid input.
+// CRLF is safe, a LONE CR is not, and the difference took three passes to get right.
 //
+// CRLF: splitting on '\n' leaves the '\r' at the END of each line, so rejoining reproduces
+// every untouched line byte-for-byte — `"a\r\nX\r\nb\r\n"` deletes to `"a\r\nb\r\n"`. A
+// guard refusing all carriage returns was added here on the theory that rejoining rewrote
+// line endings; the theory was wrong and the guard only refused valid input.
+//
+// Lone CR (Classic-Mac line endings) is a different failure and a much worse one:
+// `"a\rTARGET\rb\r".split('\n')` is ONE line, so --delete-matching deletes the entire file.
+// `sites` still reports 1, which looks like a precise single-site mutation; the empty file
+// parses fine as JS; and the suite then fails because the module is gone. That is reported
+// as MUTANT KILLED — a fabricated kill, the exact false confidence this tool exists to
+// prevent. Refuse it rather than answer dishonestly.
+if (/\r(?!\n)/.test(original)) {
+  fail(
+    `${opts.file} contains a carriage return that is not part of a CRLF pair.\n` +
+    'Splitting on LF would treat the file as a single line, so a line-oriented mutation\n' +
+    'deletes everything and the resulting failure would be reported as a kill.\n' +
+    'Repair with `git add --renormalize` and re-run.'
+  );
+}
+
 // Build the mutant in memory. Comparing strings is how "did it land" is decided:
 // asking git would be blind to exactly the cases guarded against above.
 let mutated;

--- a/scripts/test/translation-status.test.js
+++ b/scripts/test/translation-status.test.js
@@ -29,6 +29,7 @@ import {
   classifyTranslation,
   buildEnglishProseHistory,
   translationKey,
+  REQUIRED_SCRIPT,
   MIN_LINES_TO_JUDGE,
 } from '../lib/translation-status.js';
 import { TREES } from '../lib/fences.js';
@@ -266,6 +267,65 @@ test('zh-CN does not accept kana as evidence of Chinese', () => {
 });
 
 // ── the lenient residue, stated rather than hidden ──────────────────────────
+
+test('a stray unterminated fence cannot hide a scaffold from comparison', () => {
+  // A one-line bypass of the entire detector, measured before the fix: appending a single
+  // ```bash to a scaffold made `extractFences` report a frozen fence running to EOF, so
+  // every remaining line was dropped, `total` collapsed 5 -> 0, and the verdict went from
+  // `no-novel-lines` (stub) to `insufficient` — which is counted as TRANSLATED. That is the
+  // coverage-inflating direction this whole line of work exists to remove.
+  // Fence-free body, so the added opener is genuinely UNTERMINATED rather than pairing with
+  // an existing delimiter. (A stray opener that pairs with a real one is a different hazard
+  // — phase-flipping — and is not what this fix addresses.)
+  const plain = [
+    '# Create R Package',
+    'Use this skill when starting a new R package from scratch.',
+    'It covers the directory layout and the DESCRIPTION file.',
+    'Verify the package directory was created before continuing.',
+    'The DESCRIPTION file must name an author and a maintainer.',
+    'One further line of English prose to clear the floor.',
+  ].join('\n');
+  const pool = poolOf(plain);
+
+  const clean = classifyTranslation({
+    translatedText: withFrontmatter(plain), locale: 'de', englishLines: pool,
+  });
+  assert.equal(clean.reason, 'no-novel-lines');
+  assert.equal(clean.total, 6);
+
+  // The opener goes near the top, so everything English below it is what would vanish.
+  const withStray = classifyTranslation({
+    translatedText: withFrontmatter(plain.replace('# Create R Package', '# Create R Package\n```bash')),
+    locale: 'de',
+    englishLines: pool,
+  });
+  assert.equal(withStray.stub, true, 'a stray fence opener must not launder a scaffold');
+  assert.equal(withStray.reason, 'no-novel-lines');
+  assert.equal(withStray.total, clean.total, 'the remainder must stay in scope, not vanish');
+
+  // A properly closed frozen fence still hides its body, which is the behaviour being kept.
+  const closed = openLines('prose line one here\n```bash\nhidden = 1\n```\nprose line two here\n');
+  assert.ok(!closed.some((l) => l.includes('hidden')));
+  // ...and an unterminated one does not.
+  const open = openLines('prose line one here\n```bash\nvisible = 1\n');
+  assert.ok(open.some((l) => l.includes('visible')));
+});
+
+test('every CJK-script locale in the config is pinned in REQUIRED_SCRIPT', () => {
+  // Deleting any wenyan entry survived every other test — the script rule's coverage came
+  // entirely from `ja` and `zh-CN` fixtures. This pins the map against the config itself, so
+  // adding a CJK locale without a script entry is caught rather than silently degrading to
+  // prose-only.
+  for (const code of ['ja', 'zh-CN', 'wenyan', 'wenyan-lite', 'wenyan-ultra']) {
+    assert.ok(REQUIRED_SCRIPT.has(code), `${code} must declare its writing system`);
+    assert.equal(REQUIRED_SCRIPT.get(code).test('一'), true, `${code} must accept han`);
+    assert.equal(REQUIRED_SCRIPT.get(code).test('nothing but latin here'), false);
+  }
+  // The caveman tiers are English by construction and must NOT be pinned.
+  for (const code of ['caveman', 'caveman-lite', 'caveman-ultra', 'de', 'es']) {
+    assert.equal(REQUIRED_SCRIPT.has(code), false, `${code} is written in latin script`);
+  }
+});
 
 test('an orphaned CJK mirror is no-source, not a scaffold — the irreversible case', () => {
   // The file exists; its English source was deleted or its id renamed, so there is nothing

--- a/scripts/test/translation-status.test.js
+++ b/scripts/test/translation-status.test.js
@@ -17,9 +17,10 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, statSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { execFileSync } from 'child_process';
 import {
   stripFrontmatter,
@@ -28,8 +29,11 @@ import {
   classifyTranslation,
   buildEnglishProseHistory,
   translationKey,
-  MIN_SUBSTANTIVE_LINES,
+  MIN_LINES_TO_JUDGE,
 } from '../lib/translation-status.js';
+import { TREES } from '../lib/fences.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 // ── fixtures ────────────────────────────────────────────────────────────────
 
@@ -127,7 +131,7 @@ test('a scaffold is a scaffold after English moves on (#473 — the window)', ()
 
   const verdict = classifyTranslation({ translatedText: scaffold, locale: 'de', englishLines: pool });
   assert.equal(verdict.stub, true);
-  assert.equal(verdict.reason, 'no-foreign-lines');
+  assert.equal(verdict.reason, 'no-novel-lines');
 
   // And the point of the historical pool: comparing against current English ALONE would
   // still call it a stub here only because the old lines survived the edit. Delete one and
@@ -150,7 +154,7 @@ test('a CRLF scaffold is still a scaffold (#532)', () => {
   const scaffold = withFrontmatter(ENGLISH_BODY).replace(/\n/g, '\r\n');
   const verdict = classifyTranslation({ translatedText: scaffold, locale: 'de', englishLines: poolOf(ENGLISH_BODY) });
   assert.equal(verdict.stub, true, 'CRLF must not launder a scaffold into the translated count');
-  assert.equal(verdict.foreign, 0);
+  assert.equal(verdict.novel, 0);
 });
 
 test('a scaffold surgically patched from a later revision is still a scaffold', () => {
@@ -194,7 +198,7 @@ test('a genuine translation is not a scaffold', () => {
   ].join('\n'));
   const verdict = classifyTranslation({ translatedText: german, locale: 'de', englishLines: poolOf(ENGLISH_BODY) });
   assert.equal(verdict.stub, false);
-  assert.equal(verdict.reason, 'has-foreign-lines');
+  assert.equal(verdict.reason, 'has-novel-lines');
 });
 
 test('a near-English compressed tier is not a scaffold on one differing line', () => {
@@ -207,7 +211,7 @@ test('a near-English compressed tier is not a scaffold on one differing line', (
   );
   const verdict = classifyTranslation({ translatedText: caveman, locale: 'caveman-lite', englishLines: poolOf(ENGLISH_BODY) });
   assert.equal(verdict.stub, false);
-  assert.equal(verdict.foreign, 1);
+  assert.equal(verdict.novel, 1);
 });
 
 test('an identical body under a locale with no script rule still needs prose evidence', () => {
@@ -251,39 +255,72 @@ test('a translated CJK file passes the script rule and then the prose rule', () 
   ].join('\n'));
   const verdict = classifyTranslation({ translatedText: japanese, locale: 'ja', englishLines: poolOf(ENGLISH_BODY) });
   assert.equal(verdict.stub, false);
-  assert.equal(verdict.reason, 'has-foreign-lines');
+  assert.equal(verdict.reason, 'has-novel-lines');
 });
 
 test('zh-CN does not accept kana as evidence of Chinese', () => {
   // Kana only — no han. `行` would be a Han character and would defeat the point.
   const kanaOnly = withFrontmatter(`${ENGLISH_BODY}\nこれはひらがなだけのぎょうです。\n`);
   assert.equal(classifyTranslation({ translatedText: kanaOnly, locale: 'zh-CN', englishLines: poolOf(ENGLISH_BODY) }).reason, 'no-script');
-  assert.equal(classifyTranslation({ translatedText: kanaOnly, locale: 'ja', englishLines: poolOf(ENGLISH_BODY) }).reason, 'has-foreign-lines');
+  assert.equal(classifyTranslation({ translatedText: kanaOnly, locale: 'ja', englishLines: poolOf(ENGLISH_BODY) }).reason, 'has-novel-lines');
 });
 
 // ── the lenient residue, stated rather than hidden ──────────────────────────
+
+test('a verdict that did not measure reports novel as null, never 0', () => {
+  // The `--verdicts` list is what a maintainer reads before deleting files. A `0` there
+  // means "compared, nothing novel". These three paths return BEFORE the comparison runs,
+  // and reporting 0 fabricates a measurement in the one place it does the most damage:
+  // `(no-script, 0/57)` reads open-and-shut for a file that may carry forty novel lines.
+  const english = poolOf(ENGLISH_BODY);
+
+  const noScript = classifyTranslation({
+    translatedText: withFrontmatter(ENGLISH_BODY), locale: 'ja', englishLines: english,
+  });
+  assert.equal(noScript.reason, 'no-script');
+  assert.equal(noScript.novel, null);
+
+  const noSource = classifyTranslation({
+    translatedText: withFrontmatter(ENGLISH_BODY), locale: 'de', englishLines: undefined,
+  });
+  assert.equal(noSource.reason, 'no-source');
+  assert.equal(noSource.novel, null);
+
+  const short = classifyTranslation({
+    translatedText: withFrontmatter('# Title\n\nOne single line of prose here.\n'),
+    locale: 'de',
+    englishLines: english,
+  });
+  assert.equal(short.reason, 'insufficient');
+  assert.equal(short.novel, null);
+
+  // And the paths that DO measure still report a number, including zero.
+  assert.equal(classifyTranslation({
+    translatedText: withFrontmatter(ENGLISH_BODY), locale: 'de', englishLines: english,
+  }).novel, 0);
+});
 
 test('a file too short to judge is reported insufficient, not a scaffold', () => {
   const tiny = withFrontmatter('# Title\n\nOne single line of prose here.\n');
   const verdict = classifyTranslation({ translatedText: tiny, locale: 'de', englishLines: poolOf(ENGLISH_BODY) });
   assert.equal(verdict.stub, false);
   assert.equal(verdict.reason, 'insufficient');
-  assert.ok(verdict.total < MIN_SUBSTANTIVE_LINES);
+  assert.ok(verdict.total < MIN_LINES_TO_JUDGE);
 });
 
 // The boundary, pinned on BOTH sides with literal counts. Asserting
-// `total < MIN_SUBSTANTIVE_LINES` against the imported constant is self-referential and
+// `total < MIN_LINES_TO_JUDGE` against the imported constant is self-referential and
 // cannot fix a value: mutating 5 to 2, 3 or 4 survives it. These two do not — the fixtures
 // are built to have exactly 5 and exactly 4 substantive lines by construction.
 const lineOfLength = (n, i) => `Fixture prose line ${i}`.padEnd(n, 'x');
 
-test('exactly MIN_SUBSTANTIVE_LINES substantive lines is enough to judge', () => {
+test('exactly MIN_LINES_TO_JUDGE substantive lines is enough to judge', () => {
   const body = Array.from({ length: 5 }, (_, i) => lineOfLength(20, i)).join('\n\n');
   const verdict = classifyTranslation({
     translatedText: withFrontmatter(body), locale: 'de', englishLines: poolOf(body),
   });
   assert.equal(verdict.total, 5, 'fixture must sit exactly on the boundary');
-  assert.equal(verdict.reason, 'no-foreign-lines');
+  assert.equal(verdict.reason, 'no-novel-lines');
   assert.equal(verdict.stub, true);
 });
 
@@ -297,7 +334,7 @@ test('one line below the boundary is not judged', () => {
   assert.equal(verdict.stub, false);
 });
 
-test('MIN_LINE_LENGTH is pinned at both ends too', () => {
+test('MIN_COMPARABLE_LINE_CHARS is pinned at both ends too', () => {
   // A 12-character line counts; an 11-character one does not. Without this, `>=` mutates to
   // `>` and nothing notices.
   const twelve = 'abcdefghijkl';
@@ -328,6 +365,26 @@ test('translationKey agrees with contentKey, including on what is not content', 
   assert.equal(translationKey('skills', '_template'), null);
   assert.equal(translationKey('guides', '_template'), null);
   assert.equal(translationKey('teams', 'README'), null);
+});
+
+test('every content tree present in i18n/ is one the scan walks', () => {
+  // `generate-translation-status.js` iterates `TREES`, and `buildEnglishProseHistory` pools
+  // from `TREES` — one list, so they cannot disagree. What they CAN both miss is a tree that
+  // exists in the corpus and is in neither: it would be silently absent from every coverage
+  // number, with no error. Mutating `contentTypes` away from `TREES` in the script survives
+  // the unit suite (no seam), so this asserts the corpus-level invariant instead.
+  const i18nDir = join(REPO_ROOT, 'i18n');
+  const found = new Set();
+  for (const locale of readdirSync(i18nDir)) {
+    const localeDir = join(i18nDir, locale);
+    if (!statSync(localeDir).isDirectory()) continue;
+    for (const entry of readdirSync(localeDir)) {
+      if (statSync(join(localeDir, entry)).isDirectory()) found.add(entry);
+    }
+  }
+  const unscanned = [...found].filter((tree) => !TREES.includes(tree)).sort();
+  assert.deepEqual(unscanned, [],
+    `i18n/ carries content tree(s) the status scan never visits: ${unscanned.join(', ')}`);
 });
 
 // ── the git path ────────────────────────────────────────────────────────────

--- a/scripts/test/translation-status.test.js
+++ b/scripts/test/translation-status.test.js
@@ -267,6 +267,80 @@ test('zh-CN does not accept kana as evidence of Chinese', () => {
 
 // ── the lenient residue, stated rather than hidden ──────────────────────────
 
+test('an orphaned CJK mirror is no-source, not a scaffold — the irreversible case', () => {
+  // The file exists; its English source was deleted or its id renamed, so there is nothing
+  // to re-scaffold FROM. Calling it a scaffold recommends deleting the only surviving copy.
+  // Before the reorder the script rule ran first and returned `no-script` here, while the
+  // identical file under `de` returned `no-source` and was preserved — the disposition
+  // differed by locale alone, and the destructive one went to the locale with no backup.
+  const orphan = classifyTranslation({
+    translatedText: withFrontmatter(ENGLISH_BODY), locale: 'ja', englishLines: undefined,
+  });
+  assert.equal(orphan.reason, 'no-source');
+  assert.equal(orphan.stub, false, 'a file with no source must never be recommended for deletion');
+
+  const orphanLatin = classifyTranslation({
+    translatedText: withFrontmatter(ENGLISH_BODY), locale: 'de', englishLines: undefined,
+  });
+  assert.equal(orphanLatin.reason, orphan.reason, 'the disposition must not depend on the locale');
+});
+
+test('a CJK mirror too short to judge is insufficient, not a scaffold', () => {
+  // `{stub: true, total: 0}` was reachable: an empty, frontmatter-only, or all-fenced mirror
+  // has no substantive lines, and a one-line file has essentially no opportunity to contain
+  // han — so "decisive, no false positives available" is not earned at small totals. That is
+  // exactly what MIN_LINES_TO_JUDGE encodes, and the script rule used to jump it.
+  const tiny = classifyTranslation({
+    translatedText: withFrontmatter('# タイトル\n'), locale: 'ja', englishLines: poolOf(ENGLISH_BODY),
+  });
+  assert.equal(tiny.reason, 'insufficient');
+  assert.equal(tiny.stub, false);
+  assert.equal(tiny.total, 0);
+
+  // The rule still fires on a file with enough text to judge.
+  assert.equal(classifyTranslation({
+    translatedText: withFrontmatter(ENGLISH_BODY), locale: 'ja', englishLines: poolOf(ENGLISH_BODY),
+  }).reason, 'no-script');
+});
+
+test('long letterless lines are not comparable evidence', () => {
+  // Mutating away the `/\p{L}/u` filter survived every other test, and it is the most
+  // dangerous unconstrained line in the module: table rules, digit rows and separator bars
+  // match English in EVERY locale, so admitting them adds agreement only — pushing files
+  // toward `no-novel-lines`, which is the delete verdict.
+  const noise = '| --- | --- | --- | --- |\n====================\n1234567890123456\n';
+  assert.deepEqual(substantiveLines(noise), []);
+
+  // A genuine translation whose only differing lines are prose must not be pushed over by
+  // shared table scaffolding.
+  const shared = ['| --- | --- | --- |', '====================', '1234567890123456'];
+  const english = [...Array.from({ length: 6 }, (_, i) => `English prose line number ${i}.`), ...shared].join('\n');
+  const german = [...Array.from({ length: 6 }, (_, i) => `Deutsche Prosazeile Nummer ${i}.`), ...shared].join('\n');
+  const verdict = classifyTranslation({
+    translatedText: withFrontmatter(german), locale: 'de', englishLines: poolOf(english),
+  });
+  assert.equal(verdict.reason, 'has-novel-lines');
+  assert.equal(verdict.novel, 6, 'only the prose counts; the shared scaffolding is not evidence either way');
+  assert.equal(verdict.total, 6);
+});
+
+test('novel counts every unmatched line, not merely whether one exists', () => {
+  // `novel += 1` mutated to `novel = 1` survived every other assertion — one expects 0 (the
+  // statement never runs) and one expects exactly 1. That silently destroys the only
+  // quantitative field in `--verdicts` and every margin measurement built on it.
+  const german = [
+    'Erste deutsche Zeile hier drin.',
+    'Zweite deutsche Zeile hier drin.',
+    'Dritte deutsche Zeile hier drin.',
+  ].join('\n');
+  const verdict = classifyTranslation({
+    translatedText: withFrontmatter(`${ENGLISH_BODY}\n${german}\n`),
+    locale: 'de',
+    englishLines: poolOf(ENGLISH_BODY),
+  });
+  assert.equal(verdict.novel, 3);
+});
+
 test('a verdict that did not measure reports novel as null, never 0', () => {
   // The `--verdicts` list is what a maintainer reads before deleting files. A `0` there
   // means "compared, nothing novel". These three paths return BEFORE the comparison runs,


### PR DESCRIPTION
Follow-ups from two independent post-merge reviews of #553 — an adversarial pass and a maintainer's-lens pass on a different model. Neither found a blocking defect; this is what they did find.

## The real one: a verdict that cannot say it did not measure

`classifyTranslation` returned `novel: 0` on all three paths that return **before** the prose comparison runs — `no-script`, `no-source`, `insufficient`.

That is a fabricated measurement, and it sits in the one place it does the most damage. `--verdicts` is what a maintainer reads before a delete-and-re-scaffold, and

```
STUB  wenyan/skills/write-helm-chart  (no-script, 0/99 novel)
```

reads as *compared, nothing novel, open-and-shut* — for a file where the comparison never ran and which might carry forty novel lines. A genuine wenyan translation that somehow lost its CJK is precisely what such a review is triaging for.

Now `null`, printed as `-`. Verified on the live corpus:

```
STUB      wenyan-lite/skills/setup-container-registry  (no-script, -/66 novel)
STUB      caveman-lite/skills/setup-container-registry  (no-novel-lines, 0/66 novel)
```

**It shipped green against all 188 tests**, which is the tell that it was untested. It has one now, and both mutants reverting `null` → `0` die.

## `foreign` → `novel`

The module also carries a rule about foreign *scripts*, so the word sat directly next to a meaning it does not have. It means "absent from the English historical pool" — which includes an English-language translator's note that English never carried. Renamed with the reason strings (`no-novel-lines`, `has-novel-lines`) while the vocabulary is one printer old and before it spreads into issue threads.

Also `MIN_LINE_LENGTH` → `MIN_COMPARABLE_LINE_CHARS` and `MIN_SUBSTANTIVE_LINES` → `MIN_LINES_TO_JUDGE`. They differed only in a suffix a skimmer drops, and one counts characters while the other counts lines.

## `contentTypes` was a second copy of `TREES`

The pool is built from `TREES`; the scan iterated a hardcoded twin. Add a fifth tree to one and not the other and it is pooled but never scanned — coverage for it silently absent from every YAML, no error. Same drift class as #519, and the module had already introduced `translationKey` specifically so the *id* rule could not be re-derived; the tree list deserved the same.

The script has no unit-test seam, so mutating `const contentTypes = TREES` survives. Rather than leave that unremarked, the corpus-level invariant is asserted instead: every directory present under `i18n/<locale>/` must be one the scan walks. **Proven able to fail** — `mkdir i18n/de/workflows` turns it red, `rmdir` turns it green.

## Containment for the strict direction, as a control rather than a paragraph

The detector can err strict, and a false stub is remediated by *deleting the file*. What shipped to contain that was a header paragraph and an opt-in flag discoverable only by reading the source. CLAUDE.md's own line applies — *the preamble is documentation; the guard is the control.*

- Default output now prints a standing hint whenever `stubs > 0`.
- `--margins` re-measures the margin the module header's safety case rests on: the genuine translations that came closest to a scaffold verdict. It reproduces the header's claim rather than leaving it frozen in prose —

  ```
  margin caveman-lite: skills/decode-minified-js-gates=2  skills/deploy-searxng=2
                       skills/create-multistage-dockerfile=3  skills/configure-nginx=4
  margin caveman:      skills/configure-nginx=12  skills/configure-reverse-proxy=13
  ```

  Two lines is the entire buffer on the compressed tiers, and nothing previously alerted when corpus drift ate it.
- `no-source` is surfaced in `--verdicts`. It folds into `translated` with no counter of its own and most likely indicates an orphaned or misspelt mirror, which is actionable. None exist today.

## Documentation of the numbers people act on

`i18n/README.md` documented `stale` and never mentioned `stubs` at all. It now defines all four fields, including the two that have misled readers:

- **`stale` is measured only over `translated`** — the scaffold verdict is reached first, so recognising a scaffold *lowers* `stale` with nothing translated. A falling `stale` number is not by itself progress.
- **`translated + stubs` is not `total`** — a locale that never scaffolded an item has neither.

## Verification

- 189/189 `test:scripts`; `check-readmes` and `validate:line-endings` clean.
- Mutants killed: `novel: null` → `0` on `no-script` (1 test) and on `insufficient` (1 test).
- Mutant that survives, stated rather than hidden: `const contentTypes = TREES` → a literal list. No seam; the corpus invariant above is the control instead.
- **Regenerating every `translation_status.yml` produces no diff.** The counts are unchanged, which also settles the note left on #554 that the earlier regeneration predated the `translationKey` switch.

## Deferred, not dropped

Both reviewers independently flagged that `buildEnglishProseHistory` is a near-verbatim copy of `buildEnglishFenceHistory` — same spec walk, same positional `cat-file --batch` parse, same working-tree sweep — and that the misalignment test covers only the **new** copy. The older one is the strict-direction consumer, where a misaligned parse manufactures false fence violations. Extracting a shared walker would cover both for free.

That is a refactor of a file the fence-parity gate depends on, and it deserves its own change with its own mutation checks rather than riding along here. Filed separately.