### PR TITLE
fix(readmes): publish the measured translation count, not the file count (#560)

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -30,6 +30,11 @@ on:
       - 'scripts/generate-readmes.js'
       - 'scripts/generate-translation-status.js'
       - 'scripts/lib/git-freshness.js'
+      # The stub verdict itself. Extracted to a lib in #553, but never added
+      # here -- so a change to what counts as an untranslated scaffold did not
+      # regenerate the counts it decides. Load-bearing since #560, because the
+      # README table now derives from those counts too.
+      - 'scripts/lib/translation-status.js'
   workflow_dispatch:
 
 jobs:
@@ -56,8 +61,17 @@ jobs:
           node-version: '24'
           cache: 'npm'
       - run: npm ci
-      - run: node scripts/generate-readmes.js
+      # Order is load-bearing (#560): the README translations table now reads
+      # i18n/*/translation_status.yml, so the status files must be regenerated
+      # FIRST. Run the other way round and the table renders last cycle's
+      # numbers while the same commit overwrites the file it read -- the two
+      # surfaces disagree again, one cycle behind, and both land in one commit.
       - run: npm run translation:status
+      - run: node scripts/generate-readmes.js
+      # Fails the job if the two committed surfaces disagree, rather than
+      # auto-committing a contradiction. Parses both artifacts independently;
+      # it never calls the generator.
+      - run: npm run validate:readme-parity
       # SHA-pinned: https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v7
       - uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d
         with:

--- a/.github/workflows/validate-integrity.yml
+++ b/.github/workflows/validate-integrity.yml
@@ -11,6 +11,13 @@ on:
       - 'scripts/**'
       - '.claude/**'
       - '.github/workflows/update-readmes.yml'
+      # B13 compares root README.md against i18n/*/translation_status.yml, and
+      # this job is its only PR-level caller. Without README.md here, a hand
+      # edit to the very table the gate guards merges with every check green.
+      # Self-listed for the same reason: a PR that drops this job's setup-node
+      # step (or its own paths) must not be able to bypass the job.
+      - 'README.md'
+      - '.github/workflows/validate-integrity.yml'
       # A8 derives its expected translation_status set from i18n/_config.yml and
       # B6 reads i18n/*/ — without this, a new-locale PR bypasses both (#362).
       - 'i18n/**'
@@ -31,6 +38,8 @@ on:
       - 'scripts/**'
       - '.claude/**'
       - '.github/workflows/update-readmes.yml'
+      - 'README.md'
+      - '.github/workflows/validate-integrity.yml'
       - 'i18n/**'
       - 'viz/R/glyphs.R'
       - 'viz/R/agent_glyphs.R'

--- a/.github/workflows/validate-integrity.yml
+++ b/.github/workflows/validate-integrity.yml
@@ -50,5 +50,14 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # B13 shells out to node. The runner image ships one, but relying on
+      # that implicitly means a future image change turns the gate red (or,
+      # worse, makes it skippable) for reasons unrelated to the repo. No
+      # `npm ci`: every script this job runs is dependency-free, which is the
+      # constraint A8 documents and B13 was written to respect.
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
       - name: Run integrity checks
         run: bash scripts/validate-integrity.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `scripts/generate-readmes.js` — the published README translations table counted files, not translations, so every cell was `translated + stubs`: it read `de 383/500 (76.6%)` where `i18n/de/translation_status.yml` measured `347/500 (69.4%)`. The table now renders the status files' figures verbatim (denominators and `pct` included, so the two surfaces cannot disagree by rounding) and breaks `stubs` out as its own column. Existence counting survives only for a locale with no status file, and such a cell is marked `*`. (#560)
+
+### Added
+- `scripts/check-readme-translation-parity.js` + integrity check B13 — gates the README table against `i18n/*/translation_status.yml`. It parses both committed artifacts and never calls the generator: a regenerate-and-compare gate agrees with any generator bug, which is why `check-readmes` passed throughout (it also runs only in `release.yml`). Iterates locales rather than table rows, so a deleted row is visible. (#560)
+
+### Changed
+- CI: `update-readmes.yml` now runs `translation:status` **before** `generate-readmes.js`. With the table deriving from the status files, the old order rendered last cycle's numbers while the same commit overwrote the file it read. The job also asserts parity before auto-committing, and `scripts/lib/translation-status.js` was added to its trigger paths — the #553 lib extraction meant a change to what counts as an untranslated scaffold did not regenerate the counts it decides. (#560)
+
 ## [1.3.0] - 2026-05-03
 
 ### Added
@@ -24,7 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - i18n: cleared 140 stale translations across de/zh-CN/ja/es (issue #243)
 - i18n: normalized ~970 source_commit values to 8-char short hashes; resolved ~647 false-positive stale warnings
 - i18n: fixed scaffold-before-creation source_commit race (source_commit now captured at scaffold time, not at source creation)
-- `scripts/generate-translation-status.js` — was counting file existence as "translated", masking 70 caveman/wenyan stubs per locale + 3 stubs per original locale. Now uses body-equality vs English source to discriminate translated files from scaffolded stubs; emits separate `stubs` count.
+- `scripts/generate-translation-status.js` — was counting file existence as "translated", masking 70 caveman/wenyan stubs per locale + 3 stubs per original locale. Now uses body-equality vs English source to discriminate translated files from scaffolded stubs; emits separate `stubs` count. **Scope correction (see #560):** this fixed that one script. `scripts/generate-readmes.js` kept counting file existence for the published README table until #560, so the front-page number stayed wrong — and body-equality itself was replaced in #553, because a surgically-patched mirror equals no English revision.
 - `scripts/translate-content.sh` — skills branch sed `/^  tags:/a\\` was injecting locale fields between `tags:` and the first list item, breaking the YAML list. Now uses end-of-frontmatter insertion (matches agents/teams/guides pattern). Surfaced when zh-CN translator hit 5 broken stubs in coverage-closure wave.
 - `.gitignore` — added `.claude/settings*.json` (per-user dev config); fixed missing newline that merged `*.knit.md` and `CONTINUE_HERE.md` rules
 

--- a/README.md
+++ b/README.md
@@ -186,18 +186,18 @@ New here? Start with [Understanding the System](guides/understanding-the-system.
 ## Translations
 
 <!-- AUTO:START:translations -->
-| Locale | Language | Skills | Agents | Teams | Guides | Total |
-|---|---|---|---|---|---|---|
-| de | Deutsch | 366/369 | 6/75 | 6/22 | 5/34 | 383/500 (76.6%) |
-| zh-CN | 简体中文 | 366/369 | 6/75 | 6/22 | 5/34 | 383/500 (76.6%) |
-| ja | 日本語 | 366/369 | 6/75 | 6/22 | 5/34 | 383/500 (76.6%) |
-| es | Español | 366/369 | 6/75 | 6/22 | 5/34 | 383/500 (76.6%) |
-| caveman-lite | Caveman Lite | 352/369 | 0/75 | 0/22 | 0/34 | 352/500 (70.4%) |
-| caveman | Caveman | 352/369 | 0/75 | 0/22 | 0/34 | 352/500 (70.4%) |
-| caveman-ultra | Caveman Ultra | 352/369 | 0/75 | 0/22 | 0/34 | 352/500 (70.4%) |
-| wenyan-lite | 文言文輕 | 352/369 | 0/75 | 0/22 | 0/34 | 352/500 (70.4%) |
-| wenyan | 文言文 | 352/369 | 0/75 | 0/22 | 0/34 | 352/500 (70.4%) |
-| wenyan-ultra | 文言文極 | 352/369 | 0/75 | 0/22 | 0/34 | 352/500 (70.4%) |
+| Locale | Language | Skills | Agents | Teams | Guides | Total | Stubs |
+|---|---|---|---|---|---|---|---|
+| de | Deutsch | 340/369 | 3/75 | 1/22 | 3/34 | 347/500 (69.4%) | 36 |
+| zh-CN | 简体中文 | 349/369 | 3/75 | 1/22 | 2/34 | 355/500 (71%) | 28 |
+| ja | 日本語 | 349/369 | 3/75 | 1/22 | 2/34 | 355/500 (71%) | 28 |
+| es | Español | 335/369 | 3/75 | 1/22 | 3/34 | 342/500 (68.4%) | 41 |
+| caveman-lite | Caveman Lite | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 6 |
+| caveman | Caveman | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 6 |
+| caveman-ultra | Caveman Ultra | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 6 |
+| wenyan-lite | 文言文輕 | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 6 |
+| wenyan | 文言文 | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 6 |
+| wenyan-ultra | 文言文極 | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 6 |
 <!-- AUTO:END:translations -->
 
 See [i18n/README.md](i18n/README.md) for the translation contributor guide.

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -173,6 +173,18 @@ Two things follow, and both have misled readers before:
 - **`translated + stubs` is not `total`.** A locale that has never scaffolded an item has
   neither, so the remainder is untouched content.
 
+The root `README.md` coverage table renders these same numbers, and only these — it reads the
+status files rather than counting what exists on disk (#560). Its cells use two markers:
+
+| marker | meaning |
+|---|---|
+| `*` | file count, not a measurement — that locale has no `translation_status.yml` yet |
+| `-` | not measured (the `Stubs` column of a locale with no status file). Never `0`, which would read as "no stubs found" |
+
+`scripts/check-readme-translation-parity.js` (integrity check B13) fails if the two ever
+disagree. It parses both committed files rather than regenerating the table, so it still sees
+a generator that goes back to counting files.
+
 A file counts as a stub when every substantive prose line in it appeared verbatim in English
 at some point, or when its locale is written in a script the file contains none of. Frozen
 code fences are excluded from that comparison — they are keep-in-English in every locale by

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "validate:integrity": "bash scripts/validate-integrity.sh",
     "validate:translations": "node scripts/check-translation-freshness.js",
     "validate:i18n-parity": "node scripts/check-i18n-frontmatter-parity.js",
+    "validate:readme-parity": "node scripts/check-readme-translation-parity.js",
     "validate:i18n-fences": "node scripts/check-i18n-fence-parity.js",
     "validate:yaml-fences": "node scripts/check-yaml-fences.js",
     "check:placeholder-drift": "node scripts/check-placeholder-drift.js",

--- a/scripts/check-readme-translation-parity.js
+++ b/scripts/check-readme-translation-parity.js
@@ -1,0 +1,334 @@
+#!/usr/bin/env node
+/**
+ * Cross-surface parity gate: the published README translation table vs the
+ * per-locale i18n/<code>/translation_status.yml files (#560).
+ *
+ * These are the project's two reader-facing statements of the same fact, and
+ * until #560 they were independent derivations: generate-readmes.js counted
+ * files with readdirSync/existsSync while generate-translation-status.js
+ * judged each file's content. Every README cell was therefore
+ * `translated + stubs` -- the README said `de 383/500 (76.6%)` where the
+ * status files said `347/500 (69.4%)`. Nothing could catch it: check-readmes
+ * regenerates the table with the same generator and compares it against
+ * itself, so it agrees with any generator bug.
+ *
+ * This check deliberately does NOT call the generator. It parses the two
+ * COMMITTED artifacts and compares them. That is what makes it able to see a
+ * reintroduced existence count: a regenerate-and-compare gate would render
+ * 366, read 366, and pass.
+ *
+ * Dependency-free on purpose: validate-integrity.yml runs the integrity
+ * script with no `npm ci`, and A8 documents keeping that parse free of
+ * js-yaml. The two YAML inputs are machine-generated with a fixed shape, so a
+ * shape-restricted parser is honest here -- and it fails closed (exit 2)
+ * rather than guessing whenever the shape is not the one it knows.
+ *
+ * Exit codes:
+ *   0  the two surfaces agree
+ *   1  they disagree (the defect this exists to catch)
+ *   2  the comparison could not be made at all (missing markers, unparseable
+ *      input, no locales) -- never read this as a pass
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+export const CONTENT_TYPES = ['skills', 'agents', 'teams', 'guides'];
+
+/** Marker suffix a cell carries when the generator fell back to file counting. */
+export const FALLBACK_MARK = '*';
+
+/** Rendered when a number was not measured (never `0`, which reads as "none"). */
+export const UNMEASURED = '-';
+
+/**
+ * Locale codes and display names from i18n/_config.yml.
+ *
+ * Shape-restricted to the `supported_locales:` block's `- code:` / `name:`
+ * pairs. Anything else throws rather than returning a short list -- a
+ * silently-truncated locale list would make the row-set comparison below
+ * pass by not looking.
+ */
+export function parseLocales(configText) {
+  const lines = configText.split('\n');
+  const start = lines.findIndex((l) => /^supported_locales:\s*$/.test(l));
+  if (start === -1) throw new Error('i18n/_config.yml: no `supported_locales:` block');
+
+  const locales = [];
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i].replace(/\r$/, '');
+    if (/^\S/.test(line)) break; // dedented out of the block
+    if (/^\s*$/.test(line)) continue;
+    const code = line.match(/^\s*-\s+code:\s*(\S+)\s*$/);
+    if (code) {
+      locales.push({ code: code[1], name: null });
+      continue;
+    }
+    const name = line.match(/^\s*name:\s*(.+?)\s*$/);
+    if (name && locales.length) {
+      if (locales[locales.length - 1].name === null) {
+        locales[locales.length - 1].name = name[1];
+      }
+      continue;
+    }
+    if (/^\s*(name_en|status):/.test(line)) continue;
+    throw new Error(`i18n/_config.yml: unrecognised line in supported_locales: ${JSON.stringify(line)}`);
+  }
+  if (!locales.length) throw new Error('i18n/_config.yml: supported_locales is empty');
+  for (const l of locales) {
+    if (!l.name) throw new Error(`i18n/_config.yml: locale '${l.code}' has no name`);
+  }
+  return locales;
+}
+
+/**
+ * `coverage:` numbers from one translation_status.yml.
+ *
+ * Returns { skills|agents|teams|guides|total: { translated, total, pct, stubs } }
+ * with pct kept as the VERBATIM string from the file. Re-deriving it here with
+ * different rounding than generate-translation-status.js would be the
+ * two-derivations defect reborn inside one cell.
+ */
+export function parseStatus(statusText) {
+  const lines = statusText.split('\n').map((l) => l.replace(/\r$/, ''));
+  const start = lines.findIndex((l) => /^coverage:\s*$/.test(l));
+  if (start === -1) throw new Error('translation_status.yml: no `coverage:` block');
+
+  const coverage = {};
+  let current = null;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^\S/.test(line)) break;
+    if (/^\s*$/.test(line)) continue;
+    const section = line.match(/^ {2}(\w[\w-]*):\s*$/);
+    if (section) {
+      current = section[1];
+      coverage[current] = {};
+      continue;
+    }
+    const field = line.match(/^ {4}(\w+):\s*(\S+)\s*$/);
+    if (field && current) {
+      coverage[current][field[1]] = field[2];
+      continue;
+    }
+    throw new Error(`translation_status.yml: unrecognised line in coverage: ${JSON.stringify(line)}`);
+  }
+
+  for (const key of [...CONTENT_TYPES, 'total']) {
+    if (!coverage[key]) throw new Error(`translation_status.yml: coverage.${key} missing`);
+    for (const field of ['translated', 'total', 'pct', 'stubs']) {
+      if (coverage[key][field] === undefined) {
+        throw new Error(`translation_status.yml: coverage.${key}.${field} missing`);
+      }
+    }
+  }
+  return coverage;
+}
+
+/**
+ * Rows of the README's AUTO:translations table, keyed by locale code.
+ *
+ * A malformed row is an error, not a skip: a row this parser cannot read is a
+ * row it cannot compare, and skipping it would report agreement it never
+ * established.
+ */
+export function parseReadmeTable(readmeText, markerName = 'translations') {
+  const open = `<!-- AUTO:START:${markerName} -->`;
+  const close = `<!-- AUTO:END:${markerName} -->`;
+  const from = readmeText.indexOf(open);
+  const to = readmeText.indexOf(close);
+  if (from === -1 || to === -1 || to < from) {
+    throw new Error(`README: AUTO:${markerName} markers missing or inverted`);
+  }
+
+  const block = readmeText.slice(from + open.length, to);
+  const rows = new Map();
+  for (const raw of block.split('\n')) {
+    const line = raw.replace(/\r$/, '').trim();
+    if (!line.startsWith('|')) continue;
+    const cells = line.split('|').slice(1, -1).map((c) => c.trim());
+    if (!cells.length) continue;
+    if (/^-+$/.test(cells[0]) || cells[0] === 'Locale') continue; // header / separator
+    if (cells.length !== 8) {
+      throw new Error(`README: translations row has ${cells.length} cells, expected 8: ${JSON.stringify(line)}`);
+    }
+    const [code, name, skills, agents, teams, guides, total, stubs] = cells;
+    if (rows.has(code)) throw new Error(`README: duplicate translations row for locale '${code}'`);
+    rows.set(code, { code, name, skills, agents, teams, guides, total, stubs });
+  }
+  if (!rows.size) throw new Error('README: AUTO:translations block contains no data rows');
+  return rows;
+}
+
+/** `340/369` (optionally marked) -> { translated, total, fallback }. */
+function parseRatioCell(cell, label) {
+  const fallback = cell.endsWith(FALLBACK_MARK);
+  const bare = fallback ? cell.slice(0, -FALLBACK_MARK.length) : cell;
+  const m = bare.match(/^(\d+)\/(\d+)$/);
+  if (!m) throw new Error(`README: cell '${label}' is not N/M: ${JSON.stringify(cell)}`);
+  return { translated: m[1], total: m[2], fallback };
+}
+
+/** `347/500 (69.4%)` (optionally marked) -> { translated, total, pct, fallback }. */
+function parseTotalCell(cell) {
+  const fallback = cell.endsWith(FALLBACK_MARK);
+  const bare = fallback ? cell.slice(0, -FALLBACK_MARK.length) : cell;
+  const m = bare.match(/^(\d+)\/(\d+)\s+\((\d+(?:\.\d+)?)%\)$/);
+  if (!m) throw new Error(`README: total cell is not 'N/M (P%)': ${JSON.stringify(cell)}`);
+  return { translated: m[1], total: m[2], pct: m[3], fallback };
+}
+
+/**
+ * Compare the parsed surfaces. Pure: takes already-read text so the unit
+ * tests exercise the same code path CI does, on fixtures rather than the repo.
+ *
+ * `statusTexts` maps locale code -> file text, or to `null` when that locale
+ * has no status file on disk.
+ */
+export function compareSurfaces({ locales, readmeRows, statusTexts }) {
+  const failures = [];
+  const seen = new Set();
+
+  for (const locale of locales) {
+    const { code } = locale;
+    seen.add(code);
+    const row = readmeRows.get(code);
+    if (!row) {
+      // Iterating locales (not README rows) is what lets a DELETED row be
+      // seen at all; a loop over rows can only ever check what is present.
+      failures.push(`locale '${code}' is in i18n/_config.yml but has no row in the README translations table`);
+      continue;
+    }
+
+    const statusText = statusTexts.get(code);
+    let coverage = null;
+    if (statusText != null) {
+      try {
+        coverage = parseStatus(statusText);
+      } catch (err) {
+        failures.push(`locale '${code}': ${err.message}`);
+        continue;
+      }
+    }
+
+    let cells;
+    try {
+      cells = {
+        skills: parseRatioCell(row.skills, `${code}.skills`),
+        agents: parseRatioCell(row.agents, `${code}.agents`),
+        teams: parseRatioCell(row.teams, `${code}.teams`),
+        guides: parseRatioCell(row.guides, `${code}.guides`),
+        total: parseTotalCell(row.total)
+      };
+    } catch (err) {
+      failures.push(err.message);
+      continue;
+    }
+
+    const marked = Object.values(cells).some((c) => c.fallback);
+
+    if (coverage === null) {
+      // No status file: the fallback count is the only number available, and
+      // the table must say so rather than presenting it as measured.
+      if (!marked) {
+        failures.push(
+          `locale '${code}' has no i18n/${code}/translation_status.yml, so its README numbers are a file count, ` +
+          `but the row is not marked '${FALLBACK_MARK}' -- an unmeasured number is presented as measured`
+        );
+      }
+      if (row.stubs !== UNMEASURED) {
+        failures.push(`locale '${code}' has no status file, so stubs is unmeasured; expected '${UNMEASURED}', README says '${row.stubs}'`);
+      }
+      continue;
+    }
+
+    // A status file exists, so nothing may be marked as a fallback: a marked
+    // cell here means the generator silently fell back with real data on disk.
+    if (marked) {
+      failures.push(
+        `locale '${code}' has a translation_status.yml but its README row is marked '${FALLBACK_MARK}' ` +
+        `(the generator fell back to file counting while measured numbers exist)`
+      );
+      continue;
+    }
+
+    for (const ct of CONTENT_TYPES) {
+      const expected = coverage[ct];
+      const actual = cells[ct];
+      if (actual.translated !== String(expected.translated)) {
+        failures.push(
+          `${code}.${ct}: README says translated=${actual.translated}, ` +
+          `i18n/${code}/translation_status.yml says ${expected.translated} ` +
+          `(stubs=${expected.stubs}; ${Number(expected.translated) + Number(expected.stubs)} would be an existence count)`
+        );
+      }
+      if (actual.total !== String(expected.total)) {
+        failures.push(`${code}.${ct}: README denominator ${actual.total} != status total ${expected.total}`);
+      }
+    }
+
+    const expectedTotal = coverage.total;
+    if (cells.total.translated !== String(expectedTotal.translated)) {
+      failures.push(
+        `${code}.total: README says translated=${cells.total.translated}, ` +
+        `status says ${expectedTotal.translated} ` +
+        `(stubs=${expectedTotal.stubs}; ${Number(expectedTotal.translated) + Number(expectedTotal.stubs)} would be an existence count)`
+      );
+    }
+    if (cells.total.total !== String(expectedTotal.total)) {
+      failures.push(`${code}.total: README denominator ${cells.total.total} != status total ${expectedTotal.total}`);
+    }
+    if (cells.total.pct !== String(expectedTotal.pct)) {
+      failures.push(`${code}.total: README pct ${cells.total.pct}% != status pct ${expectedTotal.pct}%`);
+    }
+    if (row.stubs !== String(expectedTotal.stubs)) {
+      failures.push(`${code}: README stubs column ${row.stubs} != status stubs ${expectedTotal.stubs}`);
+    }
+    if (row.name !== locale.name) {
+      failures.push(`${code}: README language '${row.name}' != i18n/_config.yml name '${locale.name}'`);
+    }
+  }
+
+  // Reverse containment: a row for a locale the config does not list.
+  for (const code of readmeRows.keys()) {
+    if (!seen.has(code)) {
+      failures.push(`README translations table has a row for '${code}', which is not a supported locale in i18n/_config.yml`);
+    }
+  }
+
+  return { failures, checked: locales.length };
+}
+
+function main() {
+  let locales;
+  let readmeRows;
+  const statusTexts = new Map();
+  try {
+    locales = parseLocales(readFileSync(resolve(ROOT, 'i18n/_config.yml'), 'utf8'));
+    readmeRows = parseReadmeTable(readFileSync(resolve(ROOT, 'README.md'), 'utf8'));
+    for (const { code } of locales) {
+      const p = resolve(ROOT, `i18n/${code}/translation_status.yml`);
+      statusTexts.set(code, existsSync(p) ? readFileSync(p, 'utf8') : null);
+    }
+  } catch (err) {
+    console.error(`FAIL: README/translation-status parity could not be evaluated: ${err.message}`);
+    console.error('       (exit 2 -- this is not a pass)');
+    process.exit(2);
+  }
+
+  const { failures, checked } = compareSurfaces({ locales, readmeRows, statusTexts });
+  if (failures.length) {
+    console.error(`FAIL: README translations table disagrees with i18n/*/translation_status.yml (${failures.length} discrepancies across ${checked} locales)`);
+    for (const f of failures) console.error(`  - ${f}`);
+    console.error('  Fix: npm run update-readmes (after npm run translation:status), then commit both.');
+    process.exit(1);
+  }
+  console.log(`OK: README translations table matches i18n/*/translation_status.yml for all ${checked} locales`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main();
+}

--- a/scripts/check-readme-translation-parity.js
+++ b/scripts/check-readme-translation-parity.js
@@ -45,12 +45,33 @@ export const FALLBACK_MARK = '*';
 export const UNMEASURED = '-';
 
 /**
+ * One YAML scalar: strips matching outer quotes and an unquoted trailing
+ * comment. `- code: "zh-CN"` and `name: Deutsch # German` are both legal YAML
+ * that js-yaml reads correctly, and capturing them verbatim produced a red
+ * gate whose message blamed the README for a quoting choice in _config.yml.
+ */
+function scalar(raw) {
+  const value = raw.trim();
+  const quote = value[0];
+  if ((quote === '"' || quote === "'") && value.length >= 2 && value.endsWith(quote)) {
+    return value.slice(1, -1);
+  }
+  const comment = value.indexOf(' #');
+  return comment === -1 ? value : value.slice(0, comment).trim();
+}
+
+/**
  * Locale codes and display names from i18n/_config.yml.
  *
  * Shape-restricted to the `supported_locales:` block's `- code:` / `name:`
  * pairs. Anything else throws rather than returning a short list -- a
  * silently-truncated locale list would make the row-set comparison below
  * pass by not looking.
+ *
+ * Duplicate keys throw, because js-yaml (which every other consumer of this
+ * file uses) throws `duplicated mapping key`. A parser advertising that it
+ * fails closed rather than guessing must not quietly resolve a duplicate to
+ * first-wins while the generator beside it crashes on the same bytes.
  */
 export function parseLocales(configText) {
   const lines = configText.split('\n');
@@ -62,16 +83,18 @@ export function parseLocales(configText) {
     const line = lines[i].replace(/\r$/, '');
     if (/^\S/.test(line)) break; // dedented out of the block
     if (/^\s*$/.test(line)) continue;
-    const code = line.match(/^\s*-\s+code:\s*(\S+)\s*$/);
+    const code = line.match(/^\s*-\s+code:\s*(.+?)\s*$/);
     if (code) {
-      locales.push({ code: code[1], name: null });
+      locales.push({ code: scalar(code[1]), name: null });
       continue;
     }
     const name = line.match(/^\s*name:\s*(.+?)\s*$/);
     if (name && locales.length) {
-      if (locales[locales.length - 1].name === null) {
-        locales[locales.length - 1].name = name[1];
+      const current = locales[locales.length - 1];
+      if (current.name !== null) {
+        throw new Error(`i18n/_config.yml: locale '${current.code}' has a duplicate name: key (js-yaml would throw)`);
       }
+      current.name = scalar(name[1]);
       continue;
     }
     if (/^\s*(name_en|status):/.test(line)) continue;
@@ -106,11 +129,19 @@ export function parseStatus(statusText) {
     const section = line.match(/^ {2}(\w[\w-]*):\s*$/);
     if (section) {
       current = section[1];
+      // Duplicates throw rather than resolving last-wins: js-yaml rejects a
+      // `duplicated mapping key`, so a silently-accepted duplicate would let
+      // a doctored pair sit green under this gate while every generator that
+      // reads the same file crashes.
+      if (coverage[current]) throw new Error(`translation_status.yml: duplicate coverage.${current} section (js-yaml would throw)`);
       coverage[current] = {};
       continue;
     }
     const field = line.match(/^ {4}(\w+):\s*(\S+)\s*$/);
     if (field && current) {
+      if (coverage[current][field[1]] !== undefined) {
+        throw new Error(`translation_status.yml: duplicate coverage.${current}.${field[1]} key (js-yaml would throw)`);
+      }
       coverage[current][field[1]] = field[2];
       continue;
     }
@@ -228,15 +259,30 @@ export function compareSurfaces({ locales, readmeRows, statusTexts }) {
       continue;
     }
 
-    const marked = Object.values(cells).some((c) => c.fallback);
+    // Checked for every row, measured or not. This used to sit below the
+    // fallback branch's `continue`, so a fallback row's language was never
+    // compared to anything.
+    if (row.name !== locale.name) {
+      failures.push(`${code}: README language '${row.name}' != i18n/_config.yml name '${locale.name}'`);
+    }
+
+    const numberCells = Object.values(cells);
+    const markedCount = numberCells.filter((c) => c.fallback).length;
+    const marked = markedCount > 0;
 
     if (coverage === null) {
       // No status file: the fallback count is the only number available, and
-      // the table must say so rather than presenting it as measured.
-      if (!marked) {
+      // the table must say so rather than presenting it as measured. EVERY
+      // cell must carry the mark -- `some` let a row with one marked cell and
+      // four arbitrary unmarked ones pass, which is exactly the "unmeasured
+      // number presented as measured" this branch exists to reject.
+      if (markedCount !== numberCells.length) {
+        const how = markedCount === 0
+          ? 'the row is not marked'
+          : `only ${markedCount} of its ${numberCells.length} number cells are marked`;
         failures.push(
           `locale '${code}' has no i18n/${code}/translation_status.yml, so its README numbers are a file count, ` +
-          `but the row is not marked '${FALLBACK_MARK}' -- an unmeasured number is presented as measured`
+          `but ${how} '${FALLBACK_MARK}' -- an unmeasured number is presented as measured`
         );
       }
       if (row.stubs !== UNMEASURED) {
@@ -286,9 +332,6 @@ export function compareSurfaces({ locales, readmeRows, statusTexts }) {
     }
     if (row.stubs !== String(expectedTotal.stubs)) {
       failures.push(`${code}: README stubs column ${row.stubs} != status stubs ${expectedTotal.stubs}`);
-    }
-    if (row.name !== locale.name) {
-      failures.push(`${code}: README language '${row.name}' != i18n/_config.yml name '${locale.name}'`);
     }
   }
 

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -531,6 +531,54 @@ function generateTestsReadme() {
 
 // ── Translation coverage ─────────────────────────────────────────
 
+// A file existing under i18n/<locale>/ says a scaffold was created, not that
+// anyone translated it. Counting files is what made this table read
+// `de 383/500 (76.6%)` while i18n/de/translation_status.yml said
+// `347/500 (69.4%)` -- every cell was exactly `translated + stubs` (#560).
+// So the numbers below come from the status files, which judge content, and
+// `stubs` gets its own column: the point is not a smaller number, it is an
+// honest split. Existence counting survives only as the fallback for a locale
+// with no status file, and such a cell is marked so an unmeasured number is
+// never presented as measured.
+//
+// Every figure is rendered VERBATIM from the YAML, including denominators and
+// pct. Recomputing pct here with different rounding than
+// generate-translation-status.js would be the same two-derivations defect
+// rebuilt inside a single cell. scripts/check-readme-translation-parity.js
+// gates the result by parsing both committed artifacts -- it never calls this
+// function, or it would agree with any bug in it.
+//
+// Ordering matters in .github/workflows/update-readmes.yml: `npm run
+// translation:status` must run BEFORE this generator, or the table renders
+// last cycle's numbers and the same commit overwrites the file it read.
+
+/** Marker on a cell whose number is a file count, not a measurement. */
+const FALLBACK_MARK = '*';
+/** Rendered where a number was not measured. Never `0`, which reads as "none". */
+const UNMEASURED = '-';
+
+function countExistingTranslations(localeDir, contentTypes) {
+  const counts = {};
+  let total = 0;
+  for (const ct of contentTypes) {
+    const typeDir = resolve(localeDir, ct);
+    let count = 0;
+    if (existsSync(typeDir)) {
+      for (const entry of readdirSync(typeDir)) {
+        const entryPath = resolve(typeDir, entry);
+        if (ct === 'skills') {
+          if (statSync(entryPath).isDirectory() && existsSync(resolve(entryPath, 'SKILL.md'))) count++;
+        } else if (entry.endsWith('.md')) {
+          count++;
+        }
+      }
+    }
+    counts[ct] = count;
+    total += count;
+  }
+  return { counts, total };
+}
+
 function generateTranslationsSection() {
   const i18nDir = resolve(ROOT, 'i18n');
   const configPath = resolve(i18nDir, '_config.yml');
@@ -541,8 +589,9 @@ function generateTranslationsSection() {
   const i18nConfig = yaml.load(readFileSync(configPath, 'utf8'));
   const locales = i18nConfig.supported_locales || [];
   const contentTypes = ['skills', 'agents', 'teams', 'guides'];
-  // Derive source counts from registries (single source of truth)
-  // instead of manually-maintained i18n/_config.yml source_counts
+  // Fallback denominators only. Measured rows take theirs from the status
+  // file, so the two surfaces cannot disagree about the denominator either.
+  // Registry drift stays guarded by integrity checks A4/A5.
   const sourceCounts = {
     skills: totalSkills,
     agents: totalAgents,
@@ -556,38 +605,44 @@ function generateTranslationsSection() {
   }
 
   const rows = [];
-  rows.push('| Locale | Language | Skills | Agents | Teams | Guides | Total |');
-  rows.push('|---|---|---|---|---|---|---|');
+  rows.push('| Locale | Language | Skills | Agents | Teams | Guides | Total | Stubs |');
+  rows.push('|---|---|---|---|---|---|---|---|');
+
+  let anyFallback = false;
 
   for (const locale of locales) {
     const localeDir = resolve(i18nDir, locale.code);
-    const counts = {};
-    let total = 0;
+    const statusPath = resolve(localeDir, 'translation_status.yml');
+    const coverage = existsSync(statusPath)
+      ? (yaml.load(readFileSync(statusPath, 'utf8')) || {}).coverage
+      : null;
 
-    for (const ct of contentTypes) {
-      const typeDir = resolve(localeDir, ct);
-      let count = 0;
-      if (existsSync(typeDir)) {
-        const entries = readdirSync(typeDir);
-        for (const entry of entries) {
-          const entryPath = resolve(typeDir, entry);
-          if (ct === 'skills') {
-            if (statSync(entryPath).isDirectory() && existsSync(resolve(entryPath, 'SKILL.md'))) {
-              count++;
-            }
-          } else {
-            if (entry.endsWith('.md')) count++;
-          }
-        }
-      }
-      counts[ct] = count;
-      total += count;
+    if (coverage && contentTypes.every((ct) => coverage[ct]) && coverage.total) {
+      const cell = (ct) => `${coverage[ct].translated}/${coverage[ct].total}`;
+      const t = coverage.total;
+      rows.push(
+        `| ${locale.code} | ${locale.name} | ${cell('skills')} | ${cell('agents')} | ` +
+        `${cell('teams')} | ${cell('guides')} | ${t.translated}/${t.total} (${t.pct}%) | ${t.stubs} |`
+      );
+      continue;
     }
 
-    const totalSource = sourceCounts.total || 409;
-    const pct = totalSource > 0 ? Math.round((total / totalSource) * 1000) / 10 : 0;
+    anyFallback = true;
+    const { counts, total } = countExistingTranslations(localeDir, contentTypes);
+    const m = FALLBACK_MARK;
+    const pct = sourceCounts.total > 0 ? Math.round((total / sourceCounts.total) * 1000) / 10 : 0;
     rows.push(
-      `| ${locale.code} | ${locale.name} | ${counts.skills}/${sourceCounts.skills || 0} | ${counts.agents}/${sourceCounts.agents || 0} | ${counts.teams}/${sourceCounts.teams || 0} | ${counts.guides}/${sourceCounts.guides || 0} | ${total}/${totalSource} (${pct}%) |`
+      `| ${locale.code} | ${locale.name} | ${counts.skills}/${sourceCounts.skills}${m} | ` +
+      `${counts.agents}/${sourceCounts.agents}${m} | ${counts.teams}/${sourceCounts.teams}${m} | ` +
+      `${counts.guides}/${sourceCounts.guides}${m} | ${total}/${sourceCounts.total} (${pct}%)${m} | ${UNMEASURED} |`
+    );
+  }
+
+  if (anyFallback) {
+    rows.push('');
+    rows.push(
+      `${FALLBACK_MARK} File count, not a measurement -- this locale has no ` +
+      '`translation_status.yml`. Run `npm run translation:status` to measure it.'
     );
   }
 

--- a/scripts/test/check-readme-translation-parity.test.js
+++ b/scripts/test/check-readme-translation-parity.test.js
@@ -287,6 +287,59 @@ test('a fallback marker while a status file exists is caught', () => {
   assert.match(failures[0], /has a translation_status\.yml but its README row is marked/);
 });
 
+test('a PARTIALLY marked status-less row is caught', () => {
+  // Was a live fail-open: the marked test used `some`, so one marked cell
+  // excused four unmarked ones carrying arbitrary numbers -- precisely the
+  // "unmeasured number presented as measured" this branch rejects. (#562 F2)
+  const mixed = `| ja | 日本語 | 366/369${FALLBACK_MARK} | 6/75 | 6/22 | 5/34 | 383/500 (76.6%) | ${UNMEASURED} |`;
+  const statuses = [['de', DE_STATUS], ['ja', null]];
+  const { failures } = compare([DE_ROW_CORRECT, mixed], { statuses });
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /only 1 of its 5 number cells are marked/);
+});
+
+test('a status-less row still has its language checked', () => {
+  // The name check sat below the fallback branch's `continue`, so a fallback
+  // row's language was compared to nothing. (#562 F2)
+  const wrongName = `| ja | Japanisch | 366/369${FALLBACK_MARK} | 6/75${FALLBACK_MARK} | 6/22${FALLBACK_MARK} | 5/34${FALLBACK_MARK} | 383/500 (76.6%)${FALLBACK_MARK} | ${UNMEASURED} |`;
+  const statuses = [['de', DE_STATUS], ['ja', null]];
+  const { failures } = compare([DE_ROW_CORRECT, wrongName], { statuses });
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /README language 'Japanisch' != .* '日本語'/);
+});
+
+// ── Duplicate keys: the fail-closed promise ──────────────────────
+// js-yaml throws `duplicated mapping key`, so every other consumer of these
+// files crashes on a duplicate. A parser that advertises fail-closed must not
+// resolve one to last-wins and report OK. (#562 F3)
+
+test('a duplicate coverage section throws instead of taking last-wins', () => {
+  const doctored = `${DE_STATUS}  skills:\n    translated: 999\n    total: 369\n    pct: 99\n    stale: 0\n    stubs: 0\n`;
+  assert.throws(() => parseStatus(doctored), /duplicate coverage\.skills section/);
+});
+
+test('a duplicate coverage field throws', () => {
+  const doctored = DE_STATUS.replace('    stubs: 26\n', '    stubs: 26\n    translated: 999\n');
+  assert.throws(() => parseStatus(doctored), /duplicate coverage\.skills\.translated key/);
+});
+
+test('a duplicate locale name throws instead of taking first-wins', () => {
+  const doctored = CONFIG.replace('    name: Deutsch\n', '    name: Deutsch\n    name: Klingon\n');
+  assert.throws(() => parseLocales(doctored), /locale 'de' has a duplicate name/);
+});
+
+// ── Legal YAML the verbatim parser used to mangle (#562 F6) ──────
+
+test('quoted codes and names are read as YAML reads them', () => {
+  const quoted = `supported_locales:\n  - code: "zh-CN"\n    name: '简体中文'\n    status: active\n`;
+  assert.deepEqual(parseLocales(quoted), [{ code: 'zh-CN', name: '简体中文' }]);
+});
+
+test('a trailing comment is not captured as part of the value', () => {
+  const commented = 'supported_locales:\n  - code: de # the German locale\n    name: Deutsch # German\n';
+  assert.deepEqual(parseLocales(commented), [{ code: 'de', name: 'Deutsch' }]);
+});
+
 test('a status-less locale reporting a stub count is caught', () => {
   const marked = `| ja | 日本語 | 366/369${FALLBACK_MARK} | 6/75${FALLBACK_MARK} | 6/22${FALLBACK_MARK} | 5/34${FALLBACK_MARK} | 383/500 (76.6%)${FALLBACK_MARK} | 0 |`;
   const statuses = [['de', DE_STATUS], ['ja', null]];

--- a/scripts/test/check-readme-translation-parity.test.js
+++ b/scripts/test/check-readme-translation-parity.test.js
@@ -1,0 +1,296 @@
+/**
+ * Unit tests for `scripts/check-readme-translation-parity.js` (#560).
+ *
+ * The defect this gate exists to catch shipped on the repo front page for
+ * months and survived a release whose CHANGELOG claimed to have fixed exactly
+ * this class: the README table counted files, so every cell was
+ * `translated + stubs`. Nothing could see it, because the only check that
+ * touched the README regenerated it with the same generator and compared it
+ * against itself.
+ *
+ * So the load-bearing test here is `replays the real #560 numbers` below: it
+ * feeds the actual pre-fix `de` row and the actual `de` coverage block into
+ * the comparison and asserts it goes red, naming 340 and 26. That fixture is
+ * the historical defect, frozen. The rest of the tests each name a way the
+ * gate could quietly stop looking -- a deleted row, an unparseable cell, a
+ * fallback that hides a measured number -- because a gate that skips is
+ * indistinguishable from a gate that passes.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseLocales,
+  parseStatus,
+  parseReadmeTable,
+  compareSurfaces,
+  CONTENT_TYPES,
+  FALLBACK_MARK,
+  UNMEASURED
+} from '../check-readme-translation-parity.js';
+
+// ── Fixtures ─────────────────────────────────────────────────────
+
+const CONFIG = `version: "1.0"
+source_locale: en
+supported_locales:
+  - code: de
+    name: Deutsch
+    name_en: German
+    status: active
+  - code: ja
+    name: 日本語
+    name_en: Japanese
+    status: active
+`;
+
+/** The real i18n/de/translation_status.yml coverage block, as committed. */
+const DE_STATUS = `locale: de
+last_updated: '2026-08-11'
+coverage:
+  skills:
+    translated: 340
+    total: 369
+    pct: 92.1
+    stale: 166
+    stubs: 26
+  agents:
+    translated: 3
+    total: 75
+    pct: 4
+    stale: 3
+    stubs: 3
+  teams:
+    translated: 1
+    total: 22
+    pct: 4.5
+    stale: 1
+    stubs: 5
+  guides:
+    translated: 3
+    total: 34
+    pct: 8.8
+    stale: 2
+    stubs: 2
+  total:
+    translated: 347
+    total: 500
+    pct: 69.4
+    stale: 172
+    stubs: 36
+`;
+
+const JA_STATUS = DE_STATUS.replace("locale: de", "locale: ja");
+
+function table(rows) {
+  return [
+    '<!-- AUTO:START:translations -->',
+    '| Locale | Language | Skills | Agents | Teams | Guides | Total | Stubs |',
+    '|---|---|---|---|---|---|---|---|',
+    ...rows,
+    '<!-- AUTO:END:translations -->'
+  ].join('\n');
+}
+
+/** The corrected `de` row: translated-only, with stubs broken out. */
+const DE_ROW_CORRECT = '| de | Deutsch | 340/369 | 3/75 | 1/22 | 3/34 | 347/500 (69.4%) | 36 |';
+/** The row as the pre-#560 generator actually rendered it (existence counts). */
+const DE_ROW_PREFIX = '| de | Deutsch | 366/369 | 6/75 | 6/22 | 5/34 | 383/500 (76.6%) | 36 |';
+const JA_ROW_CORRECT = '| ja | 日本語 | 340/369 | 3/75 | 1/22 | 3/34 | 347/500 (69.4%) | 36 |';
+
+function compare(rows, { statuses } = {}) {
+  const locales = parseLocales(CONFIG);
+  const readmeRows = parseReadmeTable(table(rows));
+  const statusTexts = new Map(statuses ?? [['de', DE_STATUS], ['ja', JA_STATUS]]);
+  return compareSurfaces({ locales, readmeRows, statusTexts });
+}
+
+// ── parseLocales ─────────────────────────────────────────────────
+
+test('parseLocales reads codes and display names in order', () => {
+  assert.deepEqual(parseLocales(CONFIG), [
+    { code: 'de', name: 'Deutsch' },
+    { code: 'ja', name: '日本語' }
+  ]);
+});
+
+test('parseLocales throws rather than returning a short list', () => {
+  // A truncated locale list would make the row-set comparison pass by not
+  // looking -- the failure mode is silent, so the parse must be loud.
+  assert.throws(() => parseLocales('version: "1.0"\n'), /supported_locales/);
+  assert.throws(() => parseLocales('supported_locales:\n'), /empty/);
+  assert.throws(
+    () => parseLocales('supported_locales:\n  - code: de\n    unexpected: x\n'),
+    /unrecognised line/
+  );
+  assert.throws(() => parseLocales('supported_locales:\n  - code: de\n    status: active\n'), /no name/);
+});
+
+test('parseLocales stops at the end of the block', () => {
+  const withTrailer = `${CONFIG}other_key:\n  - code: nope\n    name: Nope\n`;
+  assert.deepEqual(parseLocales(withTrailer).map((l) => l.code), ['de', 'ja']);
+});
+
+// ── parseStatus ──────────────────────────────────────────────────
+
+test('parseStatus reads every coverage section', () => {
+  const coverage = parseStatus(DE_STATUS);
+  for (const ct of [...CONTENT_TYPES, 'total']) assert.ok(coverage[ct], `missing ${ct}`);
+  assert.equal(coverage.skills.translated, '340');
+  assert.equal(coverage.skills.stubs, '26');
+  assert.equal(coverage.total.translated, '347');
+  assert.equal(coverage.total.stubs, '36');
+});
+
+test('parseStatus keeps pct verbatim, not re-derived', () => {
+  // Re-deriving pct here with different rounding than
+  // generate-translation-status.js is the two-derivations defect reborn
+  // inside one cell, and would leave the gate permanently red.
+  assert.equal(parseStatus(DE_STATUS).total.pct, '69.4');
+  assert.equal(parseStatus(DE_STATUS).agents.pct, '4', 'whole-number pct must not gain a .0');
+});
+
+test('parseStatus throws on a missing block or field', () => {
+  assert.throws(() => parseStatus('locale: de\n'), /no `coverage:` block/);
+  const noStubs = DE_STATUS.replace('    stubs: 26\n', '');
+  assert.throws(() => parseStatus(noStubs), /coverage\.skills\.stubs missing/);
+  const noTotal = DE_STATUS.replace(/  total:\n(?:.*\n){5}/, '');
+  assert.throws(() => parseStatus(noTotal), /coverage\.total missing/);
+});
+
+test('parseStatus tolerates CRLF', () => {
+  const coverage = parseStatus(DE_STATUS.replace(/\n/g, '\r\n'));
+  assert.equal(coverage.total.translated, '347');
+});
+
+// ── parseReadmeTable ─────────────────────────────────────────────
+
+test('parseReadmeTable keys rows by locale and skips header and separator', () => {
+  const rows = parseReadmeTable(table([DE_ROW_CORRECT, JA_ROW_CORRECT]));
+  assert.deepEqual([...rows.keys()], ['de', 'ja']);
+  assert.equal(rows.get('de').skills, '340/369');
+  assert.equal(rows.get('de').stubs, '36');
+});
+
+test('parseReadmeTable throws on missing or inverted markers', () => {
+  assert.throws(() => parseReadmeTable('# README\n'), /markers missing/);
+  const inverted = '<!-- AUTO:END:translations -->\n<!-- AUTO:START:translations -->';
+  assert.throws(() => parseReadmeTable(inverted), /markers missing or inverted/);
+});
+
+test('parseReadmeTable refuses a row it cannot compare', () => {
+  // A malformed row must be an error, not a skip: skipping reports agreement
+  // that was never established. The 7-cell case is the literal pre-fix table.
+  const sevenCell = '| de | Deutsch | 366/369 | 6/75 | 6/22 | 5/34 | 383/500 (76.6%) |';
+  assert.throws(() => parseReadmeTable(table([sevenCell])), /7 cells, expected 8/);
+});
+
+test('parseReadmeTable rejects duplicate and empty tables', () => {
+  assert.throws(() => parseReadmeTable(table([DE_ROW_CORRECT, DE_ROW_CORRECT])), /duplicate/);
+  assert.throws(() => parseReadmeTable(table([])), /no data rows/);
+});
+
+// ── compareSurfaces: the defect ──────────────────────────────────
+
+test('replays the real #560 numbers and goes red on every one', () => {
+  const { failures } = compare([DE_ROW_PREFIX, JA_ROW_CORRECT]);
+  const text = failures.join('\n');
+
+  // skills 366 = 340 translated + 26 stubs; the message must say so, because
+  // "366 != 340" alone does not tell a maintainer it is an existence count.
+  assert.match(text, /de\.skills: README says translated=366/);
+  assert.match(text, /says 340/);
+  assert.match(text, /366 would be an existence count/);
+  assert.match(text, /de\.agents: README says translated=6/);
+  assert.match(text, /de\.teams: README says translated=6/);
+  assert.match(text, /de\.guides: README says translated=5/);
+  assert.match(text, /de\.total: README says translated=383/);
+  assert.match(text, /de\.total: README pct 76\.6% != status pct 69\.4%/);
+
+  // ja is correct in this fixture and must not be implicated.
+  assert.ok(!/^.*\bja\./m.test(text.replace(/日本語/g, '')), `ja should be clean:\n${text}`);
+});
+
+test('agreement produces no failures', () => {
+  const { failures, checked } = compare([DE_ROW_CORRECT, JA_ROW_CORRECT]);
+  assert.deepEqual(failures, []);
+  assert.equal(checked, 2);
+});
+
+// ── compareSurfaces: ways the gate could stop looking ────────────
+
+test('a deleted row is caught (iteration is over locales, not rows)', () => {
+  // A loop over README rows can never see a row that is not there. This is
+  // the same blind spot as a history-match gate that cannot see a deletion.
+  const { failures } = compare([DE_ROW_CORRECT]);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /locale 'ja' is in i18n\/_config\.yml but has no row/);
+});
+
+test('a row for an unsupported locale is caught', () => {
+  const stray = '| xx | Klingon | 1/369 | 0/75 | 0/22 | 0/34 | 1/500 (0.2%) | 0 |';
+  const statuses = [['de', DE_STATUS], ['ja', JA_STATUS], ['xx', null]];
+  const { failures } = compare([DE_ROW_CORRECT, JA_ROW_CORRECT, stray], { statuses });
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /row for 'xx', which is not a supported locale/);
+});
+
+test('a mismatched denominator, pct, stub count, or language is caught', () => {
+  const cases = [
+    ['| de | Deutsch | 340/999 | 3/75 | 1/22 | 3/34 | 347/500 (69.4%) | 36 |', /denominator 999 != status total 369/],
+    ['| de | Deutsch | 340/369 | 3/75 | 1/22 | 3/34 | 347/500 (70.0%) | 36 |', /pct 70\.0% != status pct 69\.4%/],
+    ['| de | Deutsch | 340/369 | 3/75 | 1/22 | 3/34 | 347/500 (69.4%) | 0 |', /stubs column 0 != status stubs 36/],
+    ['| de | Deutsched | 340/369 | 3/75 | 1/22 | 3/34 | 347/500 (69.4%) | 36 |', /language 'Deutsched' != .* 'Deutsch'/]
+  ];
+  for (const [row, expected] of cases) {
+    const { failures } = compare([row, JA_ROW_CORRECT]);
+    assert.equal(failures.length, 1, `expected exactly one failure for ${row}`);
+    assert.match(failures[0], expected);
+  }
+});
+
+test('an unparseable cell fails rather than being skipped', () => {
+  const bad = '| de | Deutsch | many | 3/75 | 1/22 | 3/34 | 347/500 (69.4%) | 36 |';
+  const { failures } = compare([bad, JA_ROW_CORRECT]);
+  assert.match(failures.join('\n'), /de\.skills' is not N\/M/);
+});
+
+test('a malformed status file fails rather than being skipped', () => {
+  const statuses = [['de', 'locale: de\n'], ['ja', JA_STATUS]];
+  const { failures } = compare([DE_ROW_CORRECT, JA_ROW_CORRECT], { statuses });
+  assert.match(failures.join('\n'), /locale 'de': .*no `coverage:` block/);
+});
+
+// ── compareSurfaces: the fallback path ───────────────────────────
+// All ten real locales have a status file, so the corpus can never exercise
+// these. Without fixtures the fallback branch would ship untested.
+
+test('a locale with no status file must be marked, and its stubs unmeasured', () => {
+  const marked = `| ja | 日本語 | 366/369${FALLBACK_MARK} | 6/75${FALLBACK_MARK} | 6/22${FALLBACK_MARK} | 5/34${FALLBACK_MARK} | 383/500 (76.6%)${FALLBACK_MARK} | ${UNMEASURED} |`;
+  const statuses = [['de', DE_STATUS], ['ja', null]];
+  const { failures } = compare([DE_ROW_CORRECT, marked], { statuses });
+  assert.deepEqual(failures, []);
+});
+
+test('an unmarked row with no status file is caught', () => {
+  const statuses = [['de', DE_STATUS], ['ja', null]];
+  const { failures } = compare([DE_ROW_CORRECT, JA_ROW_CORRECT], { statuses });
+  assert.match(failures.join('\n'), /not marked '\*' -- an unmeasured number is presented as measured/);
+});
+
+test('a fallback marker while a status file exists is caught', () => {
+  // This is the generator silently falling back with real data on disk --
+  // the number would be an existence count again, wearing an excuse.
+  const marked = `| ja | 日本語 | 366/369${FALLBACK_MARK} | 6/75 | 6/22 | 5/34 | 383/500 (76.6%) | 36 |`;
+  const { failures } = compare([DE_ROW_CORRECT, marked]);
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /has a translation_status\.yml but its README row is marked/);
+});
+
+test('a status-less locale reporting a stub count is caught', () => {
+  const marked = `| ja | 日本語 | 366/369${FALLBACK_MARK} | 6/75${FALLBACK_MARK} | 6/22${FALLBACK_MARK} | 5/34${FALLBACK_MARK} | 383/500 (76.6%)${FALLBACK_MARK} | 0 |`;
+  const statuses = [['de', DE_STATUS], ['ja', null]];
+  const { failures } = compare([DE_ROW_CORRECT, marked], { statuses });
+  assert.equal(failures.length, 1);
+  assert.match(failures[0], /stubs is unmeasured; expected '-'/);
+});

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -572,8 +572,15 @@ if ! command -v node >/dev/null 2>&1; then
   echo "FAIL: node not available, so B13 could not be evaluated (this is not a pass)"
   failed=1
 else
-  b13_out=$(node scripts/check-readme-translation-parity.js 2>&1)
-  b13_rc=$?
+  # `|| b13_rc=$?` is load-bearing: this script runs under `set -e`, and a
+  # bare `b13_out=$(...)` assignment aborts the whole script the moment the
+  # checker exits non-zero. That still fails closed, but it prints nothing --
+  # no discrepancy list, no summary -- so CI would go red with no diagnostic
+  # and every line below here would be dead. Proving the checker can fail is
+  # not the same as proving the check that runs it can report a failure; this
+  # PR exists because of that exact distinction.
+  b13_rc=0
+  b13_out=$(node scripts/check-readme-translation-parity.js 2>&1) || b13_rc=$?
   echo "$b13_out"
   # 0 = agree, 1 = disagree, 2 = could not evaluate. Anything non-zero fails.
   if [ "$b13_rc" -ne 0 ]; then

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -553,6 +553,34 @@ else
   echo "SKIP: ~/.claude/skills not present (e.g. CI)"
 fi
 
+# B13: README / translation-status parity (#560)
+# The README translations table and i18n/*/translation_status.yml are the two
+# reader-facing statements of the same fact, and were independent derivations
+# until #560: the table counted files, so every cell was `translated + stubs`
+# (`de 383/500 (76.6%)` vs a measured `347/500 (69.4%)`). check-readmes could
+# not see it -- it regenerates the table with the same generator and compares
+# it against itself, so it agrees with any generator bug, and it runs only in
+# release.yml anyway. This check parses both COMMITTED artifacts instead, and
+# lives here because this workflow triggers on i18n/** and scripts/** for both
+# pushes and PRs.
+# Dependency-free by design (see A8): node only, no npm ci, no js-yaml.
+echo "--- B13: README / translation-status parity ---"
+if ! command -v node >/dev/null 2>&1; then
+  # Fail, never skip: "no interpreter" is an unevaluated check, and an
+  # unevaluated check reported as OK is the failure mode this whole issue is
+  # about.
+  echo "FAIL: node not available, so B13 could not be evaluated (this is not a pass)"
+  failed=1
+else
+  b13_out=$(node scripts/check-readme-translation-parity.js 2>&1)
+  b13_rc=$?
+  echo "$b13_out"
+  # 0 = agree, 1 = disagree, 2 = could not evaluate. Anything non-zero fails.
+  if [ "$b13_rc" -ne 0 ]; then
+    failed=1
+  fi
+fi
+
 echo ""
 echo "=== Summary ==="
 if [ "$failed" -ne 0 ]; then


### PR DESCRIPTION
The README translations table counted files. Every cell was `translated + stubs` — it read `de 383/500 (76.6%)` where `i18n/de/translation_status.yml` measured `347/500 (69.4%)`, and 383 is exactly 347 + 36.

That made the whole #532/#473 line of work a correction to a number nobody reads: the front-page figure came from a different derivation entirely.

## Why nothing caught it

`check-readmes` regenerates the table with the same generator and compares it against itself, so it agrees with any generator bug — and it runs only in `release.yml`, not on PRs or pushes. CI committed both contradicting numbers in one job.

## Changes

| | |
|---|---|
| `generate-readmes.js` | Renders the status files' figures **verbatim** — denominators and `pct` included, so the surfaces cannot disagree by rounding either. `stubs` becomes its own column. |
| `check-readme-translation-parity.js` + **B13** | Gates the result by parsing both **committed** artifacts. Never calls the generator. |
| `update-readmes.yml` | Runs `translation:status` **before** `generate-readmes.js`, asserts parity before auto-committing, and gains `scripts/lib/translation-status.js` in its trigger paths. |
| `validate-integrity.yml` | Pins `setup-node` rather than leaning on the runner image. |
| `CHANGELOG.md` | Scope correction on the v1.3.0 claim. |

Existence counting survives only for a locale with **no** status file, and marks the cell `*` so an unmeasured number is never presented as measured. All ten locales have status files, so the corpus can never exercise that path — it ships with fixtures instead.

## Design notes

**The gate parses, it does not regenerate.** A regenerate-and-compare gate is `check-readmes` again: reintroduce existence counting and it renders 366, reads 366, passes. This one reads 366 and 340 and goes red.

**It iterates locales, not table rows.** A loop over rows can only ever check what is present — a deleted row is invisible to it.

**Ordering was load-bearing.** With the table deriving from the status files, the old step order would have rendered last cycle's numbers while the same commit overwrote the file it read: the same defect, one cycle behind.

## Verification

- `test:scripts` **217/217** (195 → 217; +22 new)
- `validate-integrity.sh` PASSED, B13 green across all 10 locales
- `check-readmes`, `validate:line-endings` green

**The gate was shown able to fail** (`CLAUDE.md` § *Proving a Gate Can Fail*) — one mutation per surface, both `MUTANT KILLED`, both restored green:

```
--file README.md                     --delete-matching '| de | Deutsch | 340/369 | ... | 36 |'   -> exit 1
--file i18n/de/translation_status.yml --delete-matching 'translated: 340'                        -> exit 1
```

The 22 tests also freeze the historical defect as a fixture: the real pre-fix `de` row against the real `de` coverage block, asserted red naming `340` and *"would be an existence count"*. That is permanent regression protection, which a one-off mutation is not.

**The published figures are re-derived, not copied.** Regenerating all ten status files with the post-#558 detector produced byte-identical output — so #558's fixes closed a latent bypass rather than an active miscount, and today's numbers are current.

Closes #560. Refs #553, #473, #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8