### PR TITLE
fix(i18n): delete the dead source_counts block (#556)

### DIFF
--- a/i18n/_config.yml
+++ b/i18n/_config.yml
@@ -42,9 +42,3 @@ supported_locales:
     name_en: Wenyan Ultra
     status: active
 content_types: [skills, agents, teams, guides]
-source_counts:
-  skills: 350
-  agents: 72
-  teams: 16
-  guides: 24
-  total: 462


### PR DESCRIPTION
`i18n/_config.yml` carried a hand-maintained count block that nothing reads and that had drifted wrong by 38 items:

| | claimed | real |
|---|---|---|
| skills | 350 | 369 |
| agents | 72 | 75 |
| teams | 16 | 22 |
| guides | 24 | 34 |
| **total** | **462** | **500** |

## Verified dead, not assumed

`git grep -n source_counts -- .` returns the definition and nothing else — including untracked and hidden paths. The R sources were checked rather than waved past: `viz/`'s `get_config()` reads `viz/config.yml`, not this file, and its "i18n" hits are the i18n skill *domain* (glyph/palette names).

Every real consumer touches only `.supported_locales` — `generate-readmes.js`, `generate-translation-status.js`, `viz/build-data.js`, and `check-readme-translation-parity.js`, whose `parseLocales` loop breaks at the first non-indented line. `content_types:` already terminates it, so `source_counts` was never even reached.

## The verification has a poison control

Deletion was tested in a scratch clone across three variants — and the third is the point:

| | parity | readmes | status | build-data | A8 |
|---|---|---|---|---|---|
| **deleted** vs baseline | identical | identical | identical | identical | identical |
| **poisoned** vs baseline | exit 0→2 | README rewritten to the no-translations fallback | exit 0→1 | all locale data lost | 10 → 9 locales |

Without the poison run, "identical under deletion" could just mean the pipeline died the same way twice. It didn't — every consumer demonstrably goes red when the file is actually broken.

The one generated file that *differed* under deletion, `viz/public/data/skills.json`, was run down rather than waved off: the only differing key is `meta.generated`, a timestamp. `nodes 466, links 1904, nodesWithLocales 378, totalLocaleTags 3624` — identical. Under poison those collapse to 0, so `build-data`'s `|| []` failure is output-visible and its "identical" is meaningful.

## Deleted, not refreshed

Correcting the numbers to 369/75/22/34 would rebuild exactly the defect #560/#562 just removed: a hand-maintained count duplicating an authoritative source, with no reader, rotting again at the next skill added. Both generators already derive these from the registries and label that the single source of truth.

## Byte-exact removal

Via a script, not `sed`: the worktree file is **CRLF** while the index is LF (#474), and in-place `sed` can silently no-op on this NTFS mount. The script refuses to run unless the block is exactly the six expected lines. CRLF count 50 → 44 — precisely the six removed — and `content_types:` keeps its terminator.

## Verification

- `validate:line-endings`, `validate:readme-parity`, `check-readmes` green
- `validate-integrity.sh` (incl. A8, B13) green
- All 10 locales still parse

Closes #556. Refs #560, #562, #474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8