### PR TITLE
fix(i18n): delete the dead content_types key, and test the path that exposes (#574)

### DIFF
--- a/i18n/_config.yml
+++ b/i18n/_config.yml
@@ -41,4 +41,3 @@ supported_locales:
     name: 文言文極
     name_en: Wenyan Ultra
     status: active
-content_types: [skills, agents, teams, guides]

--- a/scripts/test/check-readme-translation-parity.test.js
+++ b/scripts/test/check-readme-translation-parity.test.js
@@ -131,6 +131,19 @@ test('parseLocales throws rather than returning a short list', () => {
   assert.throws(() => parseLocales('supported_locales:\n  - code: de\n    status: active\n'), /no name/);
 });
 
+test('parseLocales handles a block that runs to end of file', () => {
+  // Newly reachable in production once `content_types:` was deleted (#574): that key used to
+  // be the first dedented line, so it was always what stopped the loop. With it gone the loop
+  // terminates by exhausting `lines` instead — a different path, and the whole argument for
+  // deleting the key was that nothing changes, so the path it newly reaches needs a test
+  // rather than an assurance.
+  const toEof = 'version: "1.0"\nsupported_locales:\n  - code: de\n    name: Deutsch\n    status: active\n';
+  assert.deepEqual(parseLocales(toEof), [{ code: 'de', name: 'Deutsch' }]);
+
+  // Also with no trailing newline at all, which is what a hand-edit can leave behind.
+  assert.deepEqual(parseLocales(toEof.trimEnd()), [{ code: 'de', name: 'Deutsch' }]);
+});
+
 test('parseLocales stops at the end of the block', () => {
   const withTrailer = `${CONFIG}other_key:\n  - code: nope\n    name: Nope\n`;
   assert.deepEqual(parseLocales(withTrailer).map((l) => l.code), ['de', 'ja']);

--- a/scripts/test/check-readme-translation-parity.test.js
+++ b/scripts/test/check-readme-translation-parity.test.js
@@ -19,6 +19,9 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import {
   parseLocales,
   parseStatus,
@@ -28,6 +31,8 @@ import {
   FALLBACK_MARK,
   UNMEASURED
 } from '../check-readme-translation-parity.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 // ── Fixtures ─────────────────────────────────────────────────────
 
@@ -131,17 +136,44 @@ test('parseLocales throws rather than returning a short list', () => {
   assert.throws(() => parseLocales('supported_locales:\n  - code: de\n    status: active\n'), /no name/);
 });
 
-test('parseLocales handles a block that runs to end of file', () => {
-  // Newly reachable in production once `content_types:` was deleted (#574): that key used to
-  // be the first dedented line, so it was always what stopped the loop. With it gone the loop
-  // terminates by exhausting `lines` instead — a different path, and the whole argument for
-  // deleting the key was that nothing changes, so the path it newly reaches needs a test
-  // rather than an assurance.
-  const toEof = 'version: "1.0"\nsupported_locales:\n  - code: de\n    name: Deutsch\n    status: active\n';
-  assert.deepEqual(parseLocales(toEof), [{ code: 'de', name: 'Deutsch' }]);
+test('parseLocales reads the LAST line of a block that runs to end of file', () => {
+  // #574 deleted `content_types:`, which used to be the first dedented line and therefore
+  // always what stopped the block scan. The production file now takes the exhaustion path
+  // that only synthetic fixtures reached before.
+  //
+  // The first version of this test was theatre, and review said so. It asserted a config
+  // ending `    status: active\n`, which four existing fixtures in this file already cover —
+  // and worse, it could not detect an off-by-one in the very bound it was named for. Mutate
+  // the loop to `i < lines.length - 1` and every one of those fixtures survives, because each
+  // ends on a line whose loss changes nothing: a trailing `''`, or a `continue` line such as
+  // `status:`.
+  //
+  // So the final line has to be LOAD-BEARING. With `name:` last and no trailing newline, the
+  // mutant skips it, `name` stays null, and the parser throws `/no name/` — red under the
+  // mutant, green against the real code.
+  assert.deepEqual(
+    parseLocales('supported_locales:\n  - code: de\n    name: Deutsch'),
+    [{ code: 'de', name: 'Deutsch' }],
+  );
 
-  // Also with no trailing newline at all, which is what a hand-edit can leave behind.
-  assert.deepEqual(parseLocales(toEof.trimEnd()), [{ code: 'de', name: 'Deutsch' }]);
+  // The same shape WITH a trailing newline, so both terminations are pinned.
+  assert.deepEqual(
+    parseLocales('supported_locales:\n  - code: de\n    name: Deutsch\n'),
+    [{ code: 'de', name: 'Deutsch' }],
+  );
+});
+
+test('parseLocales reads the real i18n/_config.yml, which now ends at the block', () => {
+  // The only assertion here that touches the actual EOF-terminated file. Everything else is
+  // synthetic, and #574's change is precisely a change to the real file's shape — so without
+  // this, nothing at unit level would notice if that file stopped parsing.
+  const config = readFileSync(resolve(REPO_ROOT, 'i18n/_config.yml'), 'utf8');
+  assert.ok(!/^content_types:/m.test(config), 'the dead key must stay gone');
+  assert.deepEqual(
+    parseLocales(config).map((l) => l.code),
+    ['de', 'zh-CN', 'ja', 'es', 'caveman-lite', 'caveman', 'caveman-ultra',
+      'wenyan-lite', 'wenyan', 'wenyan-ultra'],
+  );
 });
 
 test('parseLocales stops at the end of the block', () => {


### PR DESCRIPTION
`content_types: [skills, agents, teams, guides]` in `i18n/_config.yml` is read by nothing — `rg -n content_types` returns the definition and no other hit. It duplicated, **in data**, a list that is a hardcoded literal in several scripts (#568 is consolidating those), so it was a third copy of a fact with no consumer.

## Why this wasn't bundled into #556

`content_types` was the first dedented line after `supported_locales:`, so it was always what stopped `parseLocales`' block scan. Deleting it makes the loop terminate by **exhausting `lines`** instead — a genuinely different path, newly reachable in production.

#556's entire argument was that nothing changes. This one changes something, and a claim like that deserves a test rather than an assurance. So the test came first, covering both shapes a hand-edit can leave:

```js
supported_locales: … running to EOF with a trailing newline
supported_locales: … running to EOF with none
```

## Rejected: keeping it as #568's single source of truth

Tempting — #568 needs one place to define the content-type list. But a hand-maintained list duplicating what the directory structure already states rots exactly the way `source_counts` did: it was wrong by **38 items** when #556 removed it. #568's module derives the list in code, where a stale copy is a failing import rather than a silently wrong value.

## Verification

- All 10 locales still parse
- `validate-integrity.sh` **PASSED** (A8 reads this file)
- `check-readmes`, `validate:readme-parity`, `validate:line-endings` green
- `test:scripts` **232/232** (30 in the parity file)

Byte-exact removal via a script that refuses to run unless `content_types` is the expected final line — the same guard #556 used, for the same reason (in-place `sed` can silently no-op on this NTFS mount).

Closes #574. Refs #556, #572, #568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8