### PR TITLE
refactor(scripts): extract the pure half of generate-readmes so it can be tested (#566)

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -41,6 +41,13 @@ on:
       # file_pattern and the negations, never generator-input triggers.
       - 'scripts/lib/readme-sections.js'
       - 'scripts/lib/content-types.js'
+      # The middle of the chain, and it was skipped while BOTH endpoints were listed:
+      #   generate-translation-status.js -> lib/translation-status.js -> lib/fences.js
+      # fences.js is not a passive re-exporter — extractFences, isGated, contentKey,
+      # fenceShape and hasSwallowedOpener decide stub classification, which sets the
+      # translated/stubs figures the README renders verbatim. A push touching only this file
+      # changed generated output while matching no trigger path.
+      - 'scripts/lib/fences.js'
       # The toolchain is an input too. generate-readmes.js parses YAML with js-yaml, so a
       # Dependabot bump that changes `yaml.load` behaviour changes generated output while
       # touching no content file and no generator -- nothing here matched, so the healer never

--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -35,6 +35,12 @@ on:
       # regenerate the counts it decides. Load-bearing since #560, because the
       # README table now derives from those counts too.
       - 'scripts/lib/translation-status.js'
+      # Same reason, and the same mistake waiting to be repeated (#566): the pure half of
+      # generate-readmes.js now lives here, so a change to how a section RENDERS must
+      # regenerate the sections it decides. Nothing would catch the omission — A8 validates
+      # file_pattern and the negations, never generator-input triggers.
+      - 'scripts/lib/readme-sections.js'
+      - 'scripts/lib/content-types.js'
       # The toolchain is an input too. generate-readmes.js parses YAML with js-yaml, so a
       # Dependabot bump that changes `yaml.load` behaviour changes generated output while
       # touching no content file and no generator -- nothing here matched, so the healer never

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -17,6 +17,9 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { CONTENT_TYPES } from './lib/content-types.js';
+import {
+  replaceSection, renderTranslationsTable, FALLBACK_MARK, UNMEASURED,
+} from './lib/readme-sections.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -85,39 +88,10 @@ function teamDisplayName(teamId) {
 /**
  * Sections whose AUTO markers were missing, collected across every processed file.
  *
- * Module-level rather than threaded through return values: `replaceSection` is called in a
- * reduce over `Object.entries(sections)`, and the marker case has to survive that fold
- * without changing the shape every generator returns.
+ * Module-level because `replaceSection` is called in a fold over the section map, and the
+ * marker case has to survive that fold without changing the shape every generator returns.
  */
 const missingMarkers = [];
-
-/**
- * Replace content between AUTO markers in a file.
- * Returns true if the file changed.
- */
-function replaceSection(content, sectionName, newInner) {
-  const startTag = `<!-- AUTO:START:${sectionName} -->`;
-  const endTag = `<!-- AUTO:END:${sectionName} -->`;
-  const startIdx = content.indexOf(startTag);
-  const endIdx = content.indexOf(endTag);
-  if (startIdx === -1 || endIdx === -1) {
-    // Deleting a marker used to be PERMANENT SILENT DRIFT. This returned the content
-    // unchanged, so `--check` computed `changed === false` and exited 0 on a warning nobody
-    // reads in a green job — and the healer took the same path, so `update-readmes.yml` could
-    // not repair it either. The section simply stopped being generated, for good, with every
-    // gate in the repo green. That is worse than the staleness #563 exists to catch, and it is
-    // the "a match-based gate cannot see a deletion" class exactly.
-    //
-    // Missing markers are now fatal in both modes. Fatal rather than "stale" because
-    // regenerating cannot fix it: there is nowhere to put the content. A human has to restore
-    // the marker pair.
-    missingMarkers.push(sectionName);
-    return content;
-  }
-  const before = content.slice(0, startIdx + startTag.length);
-  const after = content.slice(endIdx);
-  return `${before}\n${newInner}\n${after}`;
-}
 
 /**
  * Process a file: apply all section replacements, write if changed.
@@ -127,7 +101,9 @@ function processFile(filePath, sections) {
   const original = readFileSync(filePath, 'utf8');
   let content = original;
   for (const [name, generator] of Object.entries(sections)) {
-    content = replaceSection(content, name, generator());
+    const result = replaceSection(content, name, generator());
+    if (!result.matched) missingMarkers.push(name);
+    content = result.content;
   }
   const changed = content !== original;
   if (changed && !CHECK_MODE) {
@@ -572,11 +548,6 @@ function generateTestsReadme() {
 // translation:status` must run BEFORE this generator, or the table renders
 // last cycle's numbers and the same commit overwrites the file it read.
 
-/** Marker on a cell whose number is a file count, not a measurement. */
-const FALLBACK_MARK = '*';
-/** Rendered where a number was not measured. Never `0`, which reads as "none". */
-const UNMEASURED = '-';
-
 function countExistingTranslations(localeDir, contentTypes) {
   const counts = {};
   let total = 0;
@@ -624,49 +595,28 @@ function generateTranslationsSection() {
     return '*No translations configured yet.*';
   }
 
-  const rows = [];
-  rows.push('| Locale | Language | Skills | Agents | Teams | Guides | Total | Stubs | Unjudged |');
-  rows.push('|---|---|---|---|---|---|---|---|---|');
-
-  let anyFallback = false;
-
-  for (const locale of locales) {
+  // I/O here, rendering in the lib. This function is now only "read the per-locale status
+  // files and hand them over" — everything that decides what a cell SAYS lives in
+  // renderTranslationsTable, where a test can reach it. That split is the whole of #566: the
+  // core line of #560's fix could be deleted with the entire suite staying green, because
+  // this logic sat inside a module that cannot be imported without writing nine files.
+  const localeRecords = locales.map((locale) => {
     const localeDir = resolve(i18nDir, locale.code);
     const statusPath = resolve(localeDir, 'translation_status.yml');
-    const coverage = existsSync(statusPath)
-      ? (yaml.load(readFileSync(statusPath, 'utf8')) || {}).coverage
-      : null;
+    return {
+      code: locale.code,
+      name: locale.name,
+      coverage: existsSync(statusPath)
+        ? (yaml.load(readFileSync(statusPath, 'utf8')) || {}).coverage
+        : null,
+      // Computed for every locale, including measured ones. Cheap, and it keeps the
+      // measured/fallback PREDICATE in one place rather than splitting it across the
+      // caller and the renderer.
+      fallback: countExistingTranslations(localeDir, contentTypes),
+    };
+  });
 
-    if (coverage && contentTypes.every((ct) => coverage[ct]) && coverage.total) {
-      const cell = (ct) => `${coverage[ct].translated}/${coverage[ct].total}`;
-      const t = coverage.total;
-      rows.push(
-        `| ${locale.code} | ${locale.name} | ${cell('skills')} | ${cell('agents')} | ` +
-        `${cell('teams')} | ${cell('guides')} | ${t.translated}/${t.total} (${t.pct}%) | ${t.stubs} | ${t.unjudged} |`
-      );
-      continue;
-    }
-
-    anyFallback = true;
-    const { counts, total } = countExistingTranslations(localeDir, contentTypes);
-    const m = FALLBACK_MARK;
-    const pct = sourceCounts.total > 0 ? Math.round((total / sourceCounts.total) * 1000) / 10 : 0;
-    rows.push(
-      `| ${locale.code} | ${locale.name} | ${counts.skills}/${sourceCounts.skills}${m} | ` +
-      `${counts.agents}/${sourceCounts.agents}${m} | ${counts.teams}/${sourceCounts.teams}${m} | ` +
-      `${counts.guides}/${sourceCounts.guides}${m} | ${total}/${sourceCounts.total} (${pct}%)${m} | ${UNMEASURED} | ${UNMEASURED} |`
-    );
-  }
-
-  if (anyFallback) {
-    rows.push('');
-    rows.push(
-      `${FALLBACK_MARK} File count, not a measurement -- this locale has no ` +
-      '`translation_status.yml`. Run `npm run translation:status` to measure it.'
-    );
-  }
-
-  return rows.join('\n');
+  return renderTranslationsTable(localeRecords, sourceCounts, contentTypes);
 }
 
 // ── Main ─────────────────────────────────────────────────────────

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -17,9 +17,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { CONTENT_TYPES } from './lib/content-types.js';
-import {
-  replaceSection, renderTranslationsTable, FALLBACK_MARK, UNMEASURED,
-} from './lib/readme-sections.js';
+import { applySections, renderTranslationsTable } from './lib/readme-sections.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -99,12 +97,11 @@ const missingMarkers = [];
  */
 function processFile(filePath, sections) {
   const original = readFileSync(filePath, 'utf8');
-  let content = original;
-  for (const [name, generator] of Object.entries(sections)) {
-    const result = replaceSection(content, name, generator());
-    if (!result.matched) missingMarkers.push(name);
-    content = result.content;
-  }
+  // The fold AND the miss policy both live in the lib. Keeping the policy here meant the
+  // "a missing marker is fatal" wiring sat in a file no test can import: deleting one line
+  // left every gate green, which is the defect this file's own comments narrate.
+  const { content, missing } = applySections(original, sections);
+  missingMarkers.push(...missing);
   const changed = content !== original;
   if (changed && !CHECK_MODE) {
     writeFileSync(filePath, content);

--- a/scripts/lib/readme-sections.js
+++ b/scripts/lib/readme-sections.js
@@ -47,12 +47,46 @@ export function replaceSection(content, sectionName, newInner) {
   const endTag = `<!-- AUTO:END:${sectionName} -->`;
   const startIdx = content.indexOf(startTag);
   const endIdx = content.indexOf(endTag);
-  if (startIdx === -1 || endIdx === -1) {
+  // `endIdx < startIdx` is an END tag sitting ABOVE its START — malformed, and it used to
+  // report success while corrupting the file: the slices overlap, so the output duplicated
+  // essentially the whole document, and grew again on every subsequent run. A miss is the
+  // honest answer, and it routes to the same fatal path as a deleted marker.
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
     return { content, matched: false };
   }
   const before = content.slice(0, startIdx + startTag.length);
   const after = content.slice(endIdx);
   return { content: `${before}\n${newInner}\n${after}`, matched: true };
+}
+
+/**
+ * Apply every section in `sections` to `content`, collecting the misses.
+ *
+ * The POLICY, not just the mechanism, and it lives here for one reason: after `replaceSection`
+ * moved to this lib, the "a miss is fatal" wiring sat in `generate-readmes.js` — the file this
+ * whole extraction exists because nobody can import. Deleting the single line
+ * `if (!result.matched) missingMarkers.push(name)` left every gate in the repo green, which is
+ * the permanent-silent-drift defect recreated one level up.
+ *
+ * The old `replaceSection` applied the miss policy internally, so every caller inherited it.
+ * Making callers opt in via `matched` was a regression in the API's DEFAULT safety even though
+ * it was not a regression in behaviour. This function restores the safe default and puts it
+ * where a test can reach it.
+ *
+ * @param {string} content
+ * @param {Record<string, () => string>} sections marker name -> body generator
+ * @returns {{content: string, missing: string[]}} `missing` names every section whose markers
+ *   were absent or inverted, in the order encountered
+ */
+export function applySections(content, sections) {
+  let next = content;
+  const missing = [];
+  for (const [name, generate] of Object.entries(sections)) {
+    const result = replaceSection(next, name, generate());
+    if (!result.matched) missing.push(name);
+    next = result.content;
+  }
+  return { content: next, missing };
 }
 
 /**

--- a/scripts/lib/readme-sections.js
+++ b/scripts/lib/readme-sections.js
@@ -1,0 +1,123 @@
+/**
+ * readme-sections.js — the pure parts of README generation (#566).
+ *
+ * `scripts/generate-readmes.js` writes nine committed files and had NO unit test, because it
+ * is not merely untested — it is *unimportable*. It reads the registries at module scope and
+ * runs its MANAGED loop at module scope, so importing it from a test reads the real registries
+ * and WRITES ALL NINE FILES (`CHECK_MODE` is false unless `--check` is in `process.argv`,
+ * which a test runner's argv lacks). The seam therefore has to be extract-to-lib, never
+ * import-the-script.
+ *
+ * Confirmed cost of that gap: deleting the core line of #560's fix left the entire suite green
+ * (`MUTANT SURVIVED`). Only CI-time artifact comparison caught it.
+ *
+ * `MANAGED` deliberately stays in `generate-readmes.js`, at column 0 and unexported: integrity
+ * check A8 static-parses that block by literal path with sed, and it reports "could not derive
+ * generated files" — failing closed, but without distinguishing "moved" from "reformatted".
+ *
+ * Zero imports, so this module is safe to reach from anywhere including the no-`npm ci`
+ * integrity job. That is a property to preserve, not an accident. (Note the constraint binds
+ * what `validate-integrity.yml` INVOKES; `ci-scripts.yml` does run `npm ci`, so the tests of
+ * this module may use dependencies freely.)
+ */
+
+/** Marker suffix a translations cell carries when the generator fell back to file counting. */
+export const FALLBACK_MARK = '*';
+
+/** Rendered where a number was not measured. Never `0`, which reads as "none". */
+export const UNMEASURED = '-';
+
+/**
+ * Replace the body between a section's AUTO markers.
+ *
+ * Returns `matched: false` rather than throwing or warning, so the caller decides the policy.
+ * That distinction is load-bearing: this used to `console.warn` and return the content
+ * unchanged, which made `--check` compute "no change" and exit 0 on a warning nobody reads in
+ * a green job. Deleting a marker pair was permanent silent drift — the section stopped being
+ * generated for good, and the auto-commit healer took the same path, so nothing could repair
+ * it either.
+ *
+ * @param {string} content    full file text
+ * @param {string} sectionName the AUTO marker name
+ * @param {string} newInner   replacement body, without surrounding newlines
+ * @returns {{content: string, matched: boolean}}
+ */
+export function replaceSection(content, sectionName, newInner) {
+  const startTag = `<!-- AUTO:START:${sectionName} -->`;
+  const endTag = `<!-- AUTO:END:${sectionName} -->`;
+  const startIdx = content.indexOf(startTag);
+  const endIdx = content.indexOf(endTag);
+  if (startIdx === -1 || endIdx === -1) {
+    return { content, matched: false };
+  }
+  const before = content.slice(0, startIdx + startTag.length);
+  const after = content.slice(endIdx);
+  return { content: `${before}\n${newInner}\n${after}`, matched: true };
+}
+
+/**
+ * Render the translations coverage table from already-loaded per-locale data.
+ *
+ * The function #560 fixed and #566 exists to make testable. It takes records rather than
+ * reading the filesystem, so a test can hand it a locale with a status file, one without, and
+ * one with a partial file, and assert the rendered row — which is what nothing could do while
+ * this logic lived inside an unimportable script.
+ *
+ * The measured-vs-fallback PREDICATE stays in here, deliberately. Splitting it — caller
+ * decides which branch, renderer formats it — is the guard-proxy-predicate anti-pattern this
+ * repo has already been bitten by: the two copies drift, and the gate ends up asserting
+ * something adjacent to what the consumer actually does.
+ *
+ * Every measured figure is rendered VERBATIM from the status file, denominators and `pct`
+ * included. Recomputing `pct` here with different rounding than
+ * `generate-translation-status.js` would be #560's two-derivations defect rebuilt inside a
+ * single cell.
+ *
+ * @param {Array<{code: string, name: string, coverage: object|null,
+ *   fallback: {counts: Record<string, number>, total: number}}>} locales
+ * @param {{skills: number, agents: number, teams: number, guides: number, total: number}} sourceCounts
+ * @param {string[]} contentTypes
+ * @returns {string} the markdown table, plus a footnote when any row fell back
+ */
+export function renderTranslationsTable(locales, sourceCounts, contentTypes) {
+  const rows = [
+    '| Locale | Language | Skills | Agents | Teams | Guides | Total | Stubs | Unjudged |',
+    '|---|---|---|---|---|---|---|---|---|',
+  ];
+  let anyFallback = false;
+
+  for (const locale of locales) {
+    const { coverage } = locale;
+    if (coverage && contentTypes.every((ct) => coverage[ct]) && coverage.total) {
+      const cell = (ct) => `${coverage[ct].translated}/${coverage[ct].total}`;
+      const t = coverage.total;
+      rows.push(
+        `| ${locale.code} | ${locale.name} | ${cell('skills')} | ${cell('agents')} | `
+        + `${cell('teams')} | ${cell('guides')} | ${t.translated}/${t.total} (${t.pct}%) | `
+        + `${t.stubs} | ${t.unjudged} |`,
+      );
+      continue;
+    }
+
+    anyFallback = true;
+    const { counts, total } = locale.fallback;
+    const m = FALLBACK_MARK;
+    const pct = sourceCounts.total > 0 ? Math.round((total / sourceCounts.total) * 1000) / 10 : 0;
+    rows.push(
+      `| ${locale.code} | ${locale.name} | ${counts.skills}/${sourceCounts.skills}${m} | `
+      + `${counts.agents}/${sourceCounts.agents}${m} | ${counts.teams}/${sourceCounts.teams}${m} | `
+      + `${counts.guides}/${sourceCounts.guides}${m} | ${total}/${sourceCounts.total} (${pct}%)${m} | `
+      + `${UNMEASURED} | ${UNMEASURED} |`,
+    );
+  }
+
+  if (anyFallback) {
+    rows.push('');
+    rows.push(
+      `${FALLBACK_MARK} File count, not a measurement -- this locale has no `
+      + '`translation_status.yml`. Run `npm run translation:status` to measure it.',
+    );
+  }
+
+  return rows.join('\n');
+}

--- a/scripts/test/dependency-free.test.js
+++ b/scripts/test/dependency-free.test.js
@@ -83,6 +83,18 @@ test('the parity checker resolves with no node_modules anywhere above it', () =>
   );
 });
 
+test('readme-sections.js keeps the zero-import property it claims', () => {
+  // Its header asserts "zero imports, a property to preserve, not an accident" — and nothing
+  // enforced it. `generate-readmes.js` runs under `npm ci` in every job that invokes it, so
+  // adding `import * as yaml from 'js-yaml'` there would leave every gate green. This repo
+  // names that shape: a docstring guarantee is an untested assertion.
+  const { stderr } = importFromBareTree('lib/readme-sections.js');
+  assert.ok(
+    !RESOLUTION_FAILURE.test(stderr),
+    `readme-sections.js acquired a package dependency:\n${stderr.split('\n').slice(0, 6).join('\n')}`,
+  );
+});
+
 test('a package import anywhere in that closure is detected (non-vacuity control)', () => {
   // Without this, the test above proves nothing: a probe that silently failed to run the
   // import at all would also produce no resolution error. `generate-readmes.js` imports

--- a/scripts/test/readme-sections.test.js
+++ b/scripts/test/readme-sections.test.js
@@ -1,0 +1,176 @@
+/**
+ * Unit tests for `scripts/lib/readme-sections.js` (#566).
+ *
+ * `scripts/generate-readmes.js` writes nine committed files and had no unit test at all,
+ * because it cannot be imported: it reads the registries and runs its MANAGED loop at module
+ * scope, so an `import()` from a test writes all nine files. The measured cost of that gap —
+ * deleting the core line of #560's fix left the whole suite green:
+ *
+ *     mutation-check --file scripts/generate-readmes.js \
+ *       --delete-matching 'const cell = (ct) =>' --test 'npm run test:scripts'
+ *     -> MUTANT SURVIVED
+ *
+ * That line now lives in `renderTranslationsTable`, and the last test below is the one that
+ * kills it. Everything else here exists so the extraction itself is covered rather than
+ * trusted.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  replaceSection, renderTranslationsTable, FALLBACK_MARK, UNMEASURED,
+} from '../lib/readme-sections.js';
+
+const doc = (inner) => [
+  '# Title',
+  'Hand-written prose above.',
+  '<!-- AUTO:START:stats -->',
+  inner,
+  '<!-- AUTO:END:stats -->',
+  'Hand-written prose below.',
+  '',
+].join('\n');
+
+// ── replaceSection ──────────────────────────────────────────────────────────
+
+test('replaceSection swaps the body and leaves everything else byte-identical', () => {
+  const before = doc('old body');
+  const { content, matched } = replaceSection(before, 'stats', 'new body');
+  assert.equal(matched, true);
+  assert.equal(content, doc('new body'));
+  // The hand-written halves are what a generator must never touch.
+  assert.ok(content.includes('Hand-written prose above.'));
+  assert.ok(content.includes('Hand-written prose below.'));
+});
+
+test('replaceSection round-trips a multi-line body', () => {
+  const body = ['| a | b |', '|---|---|', '| 1 | 2 |'].join('\n');
+  const { content } = replaceSection(doc('x'), 'stats', body);
+  assert.equal(content, doc(body));
+});
+
+test('replaceSection is idempotent', () => {
+  const once = replaceSection(doc('x'), 'stats', 'y').content;
+  const twice = replaceSection(once, 'stats', 'y').content;
+  assert.equal(once, twice);
+});
+
+test('replaceSection reports a miss instead of silently returning the input', () => {
+  // The defect this shape exists to prevent: it used to `console.warn` and return the content
+  // unchanged, so `--check` computed "no change" and exited 0 on a warning nobody reads in a
+  // green job. Deleting a marker pair was permanent silent drift — the section stopped being
+  // generated for good, and the healer took the same path, so nothing could repair it.
+  const noMarkers = '# Title\nNo markers here at all.\n';
+  const { content, matched } = replaceSection(noMarkers, 'stats', 'new body');
+  assert.equal(matched, false, 'a missing marker must be REPORTED, not swallowed');
+  assert.equal(content, noMarkers, 'and the content must be left alone for the caller to decide');
+
+  // Half a pair is still a miss — an END without a START, and vice versa.
+  assert.equal(replaceSection('<!-- AUTO:START:stats -->\nx\n', 'stats', 'y').matched, false);
+  assert.equal(replaceSection('<!-- AUTO:END:stats -->\n', 'stats', 'y').matched, false);
+});
+
+test('replaceSection touches only the named section', () => {
+  const two = [
+    '<!-- AUTO:START:alpha -->', 'A', '<!-- AUTO:END:alpha -->',
+    '<!-- AUTO:START:beta -->', 'B', '<!-- AUTO:END:beta -->', '',
+  ].join('\n');
+  const { content } = replaceSection(two, 'beta', 'B2');
+  assert.ok(content.includes('\nA\n'), 'alpha must be untouched');
+  assert.ok(content.includes('\nB2\n'));
+  assert.ok(!content.includes('\nB\n'));
+});
+
+// ── renderTranslationsTable ─────────────────────────────────────────────────
+
+const SOURCE = { skills: 369, agents: 75, teams: 22, guides: 34, total: 500 };
+const TYPES = ['skills', 'agents', 'teams', 'guides'];
+
+const coverageOf = (translated, stubs, unjudged) => ({
+  skills: { translated: translated - 6, total: 369 },
+  agents: { translated: 3, total: 75 },
+  teams: { translated: 1, total: 22 },
+  guides: { translated: 2, total: 34 },
+  total: { translated, total: 500, pct: 66.8, stubs, unjudged },
+});
+
+test('a measured locale renders the STATUS figures, not a file count', () => {
+  // The #560 regression, frozen. The status file says 334 translated with 35 stubs; a
+  // generator that counted files would render 369 (334 + 35), which is precisely the defect
+  // that sat on the repo front page for months.
+  const rendered = renderTranslationsTable(
+    [{
+      code: 'de',
+      name: 'Deutsch',
+      coverage: coverageOf(334, 35, 14),
+      // Deliberately populated and DIFFERENT, so a renderer reading the wrong field is caught.
+      fallback: { counts: { skills: 369, agents: 6, teams: 6, guides: 5 }, total: 386 },
+    }],
+    SOURCE,
+    TYPES,
+  );
+
+  assert.match(rendered, /\| de \| Deutsch \| 328\/369 \| 3\/75 \| 1\/22 \| 2\/34 \| 334\/500 \(66\.8%\) \| 35 \| 14 \|/);
+  assert.ok(!rendered.includes('386'), 'the file count must not appear anywhere');
+  assert.ok(!rendered.includes(FALLBACK_MARK), 'a measured row carries no fallback mark');
+});
+
+test('pct and denominators are rendered verbatim, never recomputed', () => {
+  // Recomputing pct here with different rounding than generate-translation-status.js is
+  // #560's two-derivations defect rebuilt inside a single cell — and the parity gate would
+  // then be permanently red.
+  const coverage = coverageOf(334, 35, 14);
+  coverage.total.pct = 66.8;
+  const a = renderTranslationsTable(
+    [{ code: 'de', name: 'D', coverage, fallback: { counts: {}, total: 0 } }], SOURCE, TYPES,
+  );
+  assert.match(a, /\(66\.8%\)/);
+
+  coverage.total.pct = 70;
+  const b = renderTranslationsTable(
+    [{ code: 'de', name: 'D', coverage, fallback: { counts: {}, total: 0 } }], SOURCE, TYPES,
+  );
+  assert.match(b, /\(70%\)/, 'a whole-number pct must not gain a .0');
+});
+
+test('a locale with no status file falls back, and SAYS so', () => {
+  const rendered = renderTranslationsTable(
+    [{
+      code: 'xx',
+      name: 'Xish',
+      coverage: null,
+      fallback: { counts: { skills: 9, agents: 1, teams: 1, guides: 1 }, total: 12 },
+    }],
+    SOURCE,
+    TYPES,
+  );
+
+  // EVERY number cell marked — a partially marked row presents unmeasured numbers as measured.
+  assert.match(rendered, new RegExp(`9/369\\${FALLBACK_MARK}`));
+  assert.match(rendered, new RegExp(`12/500 \\(2\\.4%\\)\\${FALLBACK_MARK}`));
+  assert.match(rendered, new RegExp(`\\| ${UNMEASURED} \\| ${UNMEASURED} \\|`), 'stubs and unjudged are unmeasured');
+  assert.match(rendered, /File count, not a measurement/, 'and the footnote must appear');
+});
+
+test('a PARTIAL status file falls back rather than rendering half a row', () => {
+  // The predicate lives in the renderer on purpose. A coverage object missing one content
+  // type would otherwise render `undefined/undefined` in that cell.
+  const partial = coverageOf(334, 35, 14);
+  delete partial.guides;
+  const rendered = renderTranslationsTable(
+    [{ code: 'de', name: 'D', coverage: partial, fallback: { counts: { skills: 1, agents: 1, teams: 1, guides: 1 }, total: 4 } }],
+    SOURCE,
+    TYPES,
+  );
+  assert.ok(!rendered.includes('undefined'));
+  assert.match(rendered, new RegExp(`\\${FALLBACK_MARK}`));
+});
+
+test('the footnote appears only when something actually fell back', () => {
+  const allMeasured = renderTranslationsTable(
+    [{ code: 'de', name: 'D', coverage: coverageOf(334, 35, 14), fallback: { counts: {}, total: 0 } }],
+    SOURCE,
+    TYPES,
+  );
+  assert.ok(!allMeasured.includes('File count, not a measurement'));
+});

--- a/scripts/test/readme-sections.test.js
+++ b/scripts/test/readme-sections.test.js
@@ -18,7 +18,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  replaceSection, renderTranslationsTable, FALLBACK_MARK, UNMEASURED,
+  replaceSection, applySections, renderTranslationsTable, FALLBACK_MARK, UNMEASURED,
 } from '../lib/readme-sections.js';
 
 const doc = (inner) => [
@@ -68,6 +68,54 @@ test('replaceSection reports a miss instead of silently returning the input', ()
   // Half a pair is still a miss — an END without a START, and vice versa.
   assert.equal(replaceSection('<!-- AUTO:START:stats -->\nx\n', 'stats', 'y').matched, false);
   assert.equal(replaceSection('<!-- AUTO:END:stats -->\n', 'stats', 'y').matched, false);
+});
+
+test('an INVERTED marker pair is a miss, not a silent corruption', () => {
+  // Pre-existing logic, faithfully moved — and wrong. With END above START the slices
+  // overlap, so the function reported success while the output duplicated essentially the
+  // whole document, and grew again on every run. Half-pairs were tested; this third
+  // malformed case was not.
+  const inverted = '<!-- AUTO:END:stats -->\nmid\n<!-- AUTO:START:stats -->\n';
+  const { content, matched } = replaceSection(inverted, 'stats', 'y');
+  assert.equal(matched, false, 'an inverted pair must not report success');
+  assert.equal(content, inverted, 'and must not be rewritten');
+
+  // The property that actually matters: it cannot grow the document.
+  const once = replaceSection(inverted, 'stats', 'y').content;
+  const twice = replaceSection(once, 'stats', 'y').content;
+  assert.equal(once.length, inverted.length);
+  assert.equal(twice, once);
+});
+
+// ── applySections: the policy, where a test can reach it ────────────────────
+
+test('applySections reports every missing section, so the caller can be fatal', () => {
+  // MAJOR finding of the #579 review. After replaceSection moved to this lib, the
+  // "a miss is fatal" wiring sat in generate-readmes.js — the file this extraction exists
+  // because nobody can import. Deleting one line there left every gate green: the permanent
+  // silent drift defect, recreated one level up.
+  const { content, missing } = applySections(doc('old'), {
+    stats: () => 'new',
+    absent: () => 'never placed',
+  });
+  assert.deepEqual(missing, ['absent']);
+  assert.ok(content.includes('\nnew\n'), 'the section that DID match is still applied');
+});
+
+test('applySections reports nothing missing when every marker is present', () => {
+  const { missing } = applySections(doc('old'), { stats: () => 'new' });
+  assert.deepEqual(missing, []);
+});
+
+test('applySections threads content through several sections in order', () => {
+  const two = [
+    '<!-- AUTO:START:alpha -->', 'A', '<!-- AUTO:END:alpha -->',
+    '<!-- AUTO:START:beta -->', 'B', '<!-- AUTO:END:beta -->', '',
+  ].join('\n');
+  const { content, missing } = applySections(two, { alpha: () => 'A2', beta: () => 'B2' });
+  assert.deepEqual(missing, []);
+  assert.ok(content.includes('\nA2\n') && content.includes('\nB2\n'),
+    'a fold that dropped earlier results would lose one of these');
 });
 
 test('replaceSection touches only the named section', () => {


### PR DESCRIPTION
`generate-readmes.js` writes **nine** committed files and had no unit test — because it is not merely untested, it is **unimportable**. It reads the registries at module scope and runs its `MANAGED` loop at module scope, so an `import()` from a test reads the real registries and **writes all nine files** (`CHECK_MODE` is false unless `--check` is in `process.argv`, which a test runner's argv lacks).

So the seam has to be extract-to-lib, never import-the-script.

## The acceptance criterion, measured

```
--delete-matching 'const cell = (ct) =>' --test 'npm run test:scripts'

before:  MUTANT SURVIVED          (all 224 tests green)
after:   MUTANT KILLED by 3 failing test(s)
```

That line is the core of #560's fix — the one that renders `translated` instead of a file count. Deleting it left the entire suite green.

## What moved

`scripts/lib/readme-sections.js` takes `replaceSection` and a new pure `renderTranslationsTable(localeRecords, sourceCounts, contentTypes)`. `generateTranslationsSection` is now only *"read the per-locale status files and hand them over"*; everything that decides what a cell **says** is reachable from a test.

**The predicate stays in the renderer, deliberately.** Splitting it — caller picks the branch, lib formats it — is the guard-proxy-predicate anti-pattern this repo has already been bitten by: the copies drift, and the gate ends up asserting something adjacent to what the consumer does. A partial-coverage fixture pins it.

**`replaceSection` returns `{content, matched}`** rather than pushing to a module-level array, so the caller owns the policy. Behaviour is unchanged: a missing marker is still fatal (exit 2), because regenerating cannot restore a section that has nowhere to go.

## What deliberately did not move

`MANAGED` stays in `generate-readmes.js`, at column 0 and unexported. Integrity check A8 static-parses that block **by literal path** with `sed`; moving or reformatting it makes A8 report "could not derive generated files" — failing closed, but unhelpfully. Verified A8 still reports all 19 auto-generated files.

## The omission that nothing would catch

`scripts/lib/readme-sections.js` is now an **input** to the generator, so it is added to `update-readmes.yml`'s trigger paths. A8 validates `file_pattern` and the negations — never generator-input triggers. That file already carries a comment about this exact omission for `scripts/lib/translation-status.js` in #553: *"a change to what counts as an untranslated scaffold did not regenerate the counts it decides."* Repeating it was the most likely mistake in this PR.

## Verification

- **Refactor gate, run rather than asserted:** `npm run update-readmes` leaves all nine outputs **byte-identical**; `check-readmes` reports "All files are up to date."
- `test:scripts` 246 → **256** (10 new)
- `validate-integrity.sh` PASSED, B13 exit 0, `validate:line-endings` green

The first new test freezes the #560 regression directly: a status file saying `334` translated with `35` stubs, and a `fallback` field deliberately populated with the file count `386` — so a renderer reading the wrong field is **caught**, not merely unlucky.

Closes #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8