### PR TITLE
fix(viz): bump dompurify to 3.4.13 for the XSS advisory

### DIFF
--- a/viz/package-lock.json
+++ b/viz/package-lock.json
@@ -2056,9 +2056,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
Dependabot alert 35 — **medium**, open, with **no PR raised**, so the standing "handle Dependabot PRs automatically" order did not cover it.

Worth doing by hand because this one reaches the **published site**: the viz page renders mermaid diagrams, and dompurify is what sanitises them.

```
DOMPurify: IN_PLACE hook removal leaves a detached subtree executable, causing XSS
vulnerable:  <= 3.4.12        first patched:  3.4.13
manifest:    viz/package-lock.json        scope: runtime
```

Transitive via `mermaid@11.16.1`, whose declared range is `^3.3.3` — so 3.4.13 satisfies it and **no mermaid change is needed**. `npm update dompurify` moved the lockfile alone; `npm audit` now reports 0 vulnerabilities.

## A diagnostic trap worth recording

While investigating, the local tree said something different and wrong:

```
npm ls dompurify
└─┬ mermaid@11.12.3 invalid: "^11.16.0" from the root project
  └── dompurify@3.3.2
```

That is a **stale `node_modules`**, not the truth. The lockfile — which is what CI and the deploy actually install from — said `mermaid 11.16.1 -> dompurify 3.4.12`. Reading the installed tree instead of the lockfile would have produced a different diagnosis and a wrong fix.

## Verification

- `npm audit`: 0 vulnerabilities
- `npm run build` succeeds and leaves `viz/public/` unchanged, so the committed bundle needs no regeneration here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8