### PR TITLE
fix(i18n): the fence shape counted fences that cannot affect the mask (#571)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,16 +188,16 @@ New here? Start with [Understanding the System](guides/understanding-the-system.
 <!-- AUTO:START:translations -->
 | Locale | Language | Skills | Agents | Teams | Guides | Total | Stubs | Unjudged |
 |---|---|---|---|---|---|---|---|---|
-| de | Deutsch | 328/369 | 3/75 | 1/22 | 2/34 | 334/500 (66.8%) | 35 | 14 |
-| zh-CN | 简体中文 | 320/369 | 3/75 | 1/22 | 2/34 | 326/500 (65.2%) | 26 | 31 |
-| ja | 日本語 | 338/369 | 3/75 | 1/22 | 2/34 | 344/500 (68.8%) | 26 | 13 |
-| es | Español | 323/369 | 3/75 | 1/22 | 2/34 | 329/500 (65.8%) | 40 | 14 |
-| caveman-lite | Caveman Lite | 345/369 | 0/75 | 0/22 | 0/34 | 345/500 (69%) | 5 | 2 |
-| caveman | Caveman | 345/369 | 0/75 | 0/22 | 0/34 | 345/500 (69%) | 5 | 2 |
-| caveman-ultra | Caveman Ultra | 345/369 | 0/75 | 0/22 | 0/34 | 345/500 (69%) | 5 | 2 |
+| de | Deutsch | 340/369 | 3/75 | 1/22 | 2/34 | 346/500 (69.2%) | 35 | 2 |
+| zh-CN | 简体中文 | 342/369 | 3/75 | 1/22 | 2/34 | 348/500 (69.6%) | 26 | 9 |
+| ja | 日本語 | 347/369 | 3/75 | 1/22 | 2/34 | 353/500 (70.6%) | 26 | 4 |
+| es | Español | 334/369 | 3/75 | 1/22 | 2/34 | 340/500 (68%) | 40 | 3 |
+| caveman-lite | Caveman Lite | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 5 | 1 |
+| caveman | Caveman | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 5 | 1 |
+| caveman-ultra | Caveman Ultra | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 5 | 1 |
 | wenyan-lite | 文言文輕 | 342/369 | 0/75 | 0/22 | 0/34 | 342/500 (68.4%) | 5 | 5 |
 | wenyan | 文言文 | 342/369 | 0/75 | 0/22 | 0/34 | 342/500 (68.4%) | 5 | 5 |
-| wenyan-ultra | 文言文極 | 343/369 | 0/75 | 0/22 | 0/34 | 343/500 (68.6%) | 5 | 4 |
+| wenyan-ultra | 文言文極 | 345/369 | 0/75 | 0/22 | 0/34 | 345/500 (69%) | 5 | 2 |
 <!-- AUTO:END:translations -->
 
 See [i18n/README.md](i18n/README.md) for the translation contributor guide.

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -7,16 +7,16 @@ This directory contains translations of agent-almanac content into multiple lang
 <!-- AUTO:START:i18n-locales -->
 | Code | Language | Skills | Agents | Teams | Guides | Translated | Stale |
 |---|---|---|---|---|---|---|---|
-| de | Deutsch | 328/369 | 3/75 | 1/22 | 2/34 | 334/500 (66.8%) | 160 |
-| zh-CN | 简体中文 | 320/369 | 3/75 | 1/22 | 2/34 | 326/500 (65.2%) | 149 |
-| ja | 日本語 | 338/369 | 3/75 | 1/22 | 2/34 | 344/500 (68.8%) | 159 |
-| es | Español | 323/369 | 3/75 | 1/22 | 2/34 | 329/500 (65.8%) | 159 |
-| caveman-lite | Caveman Lite | 345/369 | 0/75 | 0/22 | 0/34 | 345/500 (69%) | 306 |
-| caveman | Caveman | 345/369 | 0/75 | 0/22 | 0/34 | 345/500 (69%) | 306 |
-| caveman-ultra | Caveman Ultra | 345/369 | 0/75 | 0/22 | 0/34 | 345/500 (69%) | 306 |
+| de | Deutsch | 340/369 | 3/75 | 1/22 | 2/34 | 346/500 (69.2%) | 171 |
+| zh-CN | 简体中文 | 342/369 | 3/75 | 1/22 | 2/34 | 348/500 (69.6%) | 168 |
+| ja | 日本語 | 347/369 | 3/75 | 1/22 | 2/34 | 353/500 (70.6%) | 166 |
+| es | Español | 334/369 | 3/75 | 1/22 | 2/34 | 340/500 (68%) | 168 |
+| caveman-lite | Caveman Lite | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 307 |
+| caveman | Caveman | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 307 |
+| caveman-ultra | Caveman Ultra | 346/369 | 0/75 | 0/22 | 0/34 | 346/500 (69.2%) | 307 |
 | wenyan-lite | 文言文輕 | 342/369 | 0/75 | 0/22 | 0/34 | 342/500 (68.4%) | 303 |
 | wenyan | 文言文 | 342/369 | 0/75 | 0/22 | 0/34 | 342/500 (68.4%) | 303 |
-| wenyan-ultra | 文言文極 | 343/369 | 0/75 | 0/22 | 0/34 | 343/500 (68.6%) | 301 |
+| wenyan-ultra | 文言文極 | 345/369 | 0/75 | 0/22 | 0/34 | 345/500 (69%) | 303 |
 <!-- AUTO:END:i18n-locales -->
 
 Generated from `i18n/_config.yml` and each locale's `translation_status.yml` — the same

--- a/i18n/caveman-lite/translation_status.yml
+++ b/i18n/caveman-lite/translation_status.yml
@@ -2,12 +2,12 @@ locale: caveman-lite
 last_updated: '2026-08-12'
 coverage:
   skills:
-    translated: 345
+    translated: 346
     total: 369
-    pct: 93.5
-    stale: 306
+    pct: 93.8
+    stale: 307
     stubs: 5
-    unjudged: 2
+    unjudged: 1
   agents:
     translated: 0
     total: 75
@@ -30,9 +30,9 @@ coverage:
     stubs: 0
     unjudged: 0
   total:
-    translated: 345
+    translated: 346
     total: 500
-    pct: 69
-    stale: 306
+    pct: 69.2
+    stale: 307
     stubs: 5
-    unjudged: 2
+    unjudged: 1

--- a/i18n/caveman-ultra/translation_status.yml
+++ b/i18n/caveman-ultra/translation_status.yml
@@ -2,12 +2,12 @@ locale: caveman-ultra
 last_updated: '2026-08-12'
 coverage:
   skills:
-    translated: 345
+    translated: 346
     total: 369
-    pct: 93.5
-    stale: 306
+    pct: 93.8
+    stale: 307
     stubs: 5
-    unjudged: 2
+    unjudged: 1
   agents:
     translated: 0
     total: 75
@@ -30,9 +30,9 @@ coverage:
     stubs: 0
     unjudged: 0
   total:
-    translated: 345
+    translated: 346
     total: 500
-    pct: 69
-    stale: 306
+    pct: 69.2
+    stale: 307
     stubs: 5
-    unjudged: 2
+    unjudged: 1

--- a/i18n/caveman/translation_status.yml
+++ b/i18n/caveman/translation_status.yml
@@ -2,12 +2,12 @@ locale: caveman
 last_updated: '2026-08-12'
 coverage:
   skills:
-    translated: 345
+    translated: 346
     total: 369
-    pct: 93.5
-    stale: 306
+    pct: 93.8
+    stale: 307
     stubs: 5
-    unjudged: 2
+    unjudged: 1
   agents:
     translated: 0
     total: 75
@@ -30,9 +30,9 @@ coverage:
     stubs: 0
     unjudged: 0
   total:
-    translated: 345
+    translated: 346
     total: 500
-    pct: 69
-    stale: 306
+    pct: 69.2
+    stale: 307
     stubs: 5
-    unjudged: 2
+    unjudged: 1

--- a/i18n/de/translation_status.yml
+++ b/i18n/de/translation_status.yml
@@ -2,12 +2,12 @@ locale: de
 last_updated: '2026-08-12'
 coverage:
   skills:
-    translated: 328
+    translated: 340
     total: 369
-    pct: 88.9
-    stale: 155
+    pct: 92.1
+    stale: 166
     stubs: 25
-    unjudged: 13
+    unjudged: 1
   agents:
     translated: 3
     total: 75
@@ -30,9 +30,9 @@ coverage:
     stubs: 2
     unjudged: 1
   total:
-    translated: 334
+    translated: 346
     total: 500
-    pct: 66.8
-    stale: 160
+    pct: 69.2
+    stale: 171
     stubs: 35
-    unjudged: 14
+    unjudged: 2

--- a/i18n/es/translation_status.yml
+++ b/i18n/es/translation_status.yml
@@ -2,12 +2,12 @@ locale: es
 last_updated: '2026-08-12'
 coverage:
   skills:
-    translated: 323
+    translated: 334
     total: 369
-    pct: 87.5
-    stale: 154
+    pct: 90.5
+    stale: 163
     stubs: 30
-    unjudged: 13
+    unjudged: 2
   agents:
     translated: 3
     total: 75
@@ -30,9 +30,9 @@ coverage:
     stubs: 2
     unjudged: 1
   total:
-    translated: 329
+    translated: 340
     total: 500
-    pct: 65.8
-    stale: 159
+    pct: 68
+    stale: 168
     stubs: 40
-    unjudged: 14
+    unjudged: 3

--- a/i18n/ja/translation_status.yml
+++ b/i18n/ja/translation_status.yml
@@ -2,12 +2,12 @@ locale: ja
 last_updated: '2026-08-12'
 coverage:
   skills:
-    translated: 338
+    translated: 347
     total: 369
-    pct: 91.6
-    stale: 154
+    pct: 94
+    stale: 161
     stubs: 16
-    unjudged: 12
+    unjudged: 3
   agents:
     translated: 3
     total: 75
@@ -30,9 +30,9 @@ coverage:
     stubs: 2
     unjudged: 1
   total:
-    translated: 344
+    translated: 353
     total: 500
-    pct: 68.8
-    stale: 159
+    pct: 70.6
+    stale: 166
     stubs: 26
-    unjudged: 13
+    unjudged: 4

--- a/i18n/wenyan-ultra/translation_status.yml
+++ b/i18n/wenyan-ultra/translation_status.yml
@@ -2,12 +2,12 @@ locale: wenyan-ultra
 last_updated: '2026-08-12'
 coverage:
   skills:
-    translated: 343
+    translated: 345
     total: 369
-    pct: 93
-    stale: 301
+    pct: 93.5
+    stale: 303
     stubs: 5
-    unjudged: 4
+    unjudged: 2
   agents:
     translated: 0
     total: 75
@@ -30,9 +30,9 @@ coverage:
     stubs: 0
     unjudged: 0
   total:
-    translated: 343
+    translated: 345
     total: 500
-    pct: 68.6
-    stale: 301
+    pct: 69
+    stale: 303
     stubs: 5
-    unjudged: 4
+    unjudged: 2

--- a/i18n/zh-CN/translation_status.yml
+++ b/i18n/zh-CN/translation_status.yml
@@ -2,12 +2,12 @@ locale: zh-CN
 last_updated: '2026-08-12'
 coverage:
   skills:
-    translated: 320
+    translated: 342
     total: 369
-    pct: 86.7
-    stale: 144
+    pct: 92.7
+    stale: 163
     stubs: 16
-    unjudged: 30
+    unjudged: 8
   agents:
     translated: 3
     total: 75
@@ -30,9 +30,9 @@ coverage:
     stubs: 2
     unjudged: 1
   total:
-    translated: 326
+    translated: 348
     total: 500
-    pct: 65.2
-    stale: 149
+    pct: 69.6
+    stale: 168
     stubs: 26
-    unjudged: 31
+    unjudged: 9

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -279,7 +279,19 @@ export function toLines(text) {
  */
 export function fenceShape(text) {
   return extractFences(text)
-    .filter((f) => !f.unterminated)
+    // GATED fences only, and this is the whole point of the invariant rather than a detail.
+    // The mask `openLines` builds drops FROZEN bodies and keeps localisable ones, so a
+    // well-formed `text`/`markdown` fence added or removed in translation cannot corrupt the
+    // measurement — it is translatable prose either way. Counting it in the shape cost 62 real
+    // translations their verdict for a change that provably could not affect them: measured on
+    // the corpus, 76 files mismatched on the all-fence shape and 62 of those had an intact
+    // frozen mask. That is the strict direction, which this module's header names as the
+    // expensive one.
+    //
+    // It costs no attack coverage, because every construction that corrupts the mask does so
+    // with a GATED fence, or swallows one. A stray localisable opener still changes this shape:
+    // it swallows the real frozen fence, which then disappears from the gated list.
+    .filter((f) => !f.unterminated && isGated(f))
     // A lang-empty fence renders as `{`, not as the empty string. Empty made a single such
     // terminated fence spell the shape `''` — identical to the shape of a file with NO fences
     // at all. So if any English revision was fence-free, an untagged wrap around the whole

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -282,15 +282,27 @@ export function fenceShape(text) {
     // GATED fences only, and this is the whole point of the invariant rather than a detail.
     // The mask `openLines` builds drops FROZEN bodies and keeps localisable ones, so a
     // well-formed `text`/`markdown` fence added or removed in translation cannot corrupt the
-    // measurement — it is translatable prose either way. Counting it in the shape cost 62 real
+    // measurement — it is translatable prose either way. Counting it in the shape cost real
     // translations their verdict for a change that provably could not affect them: measured on
     // the corpus, 76 files mismatched on the all-fence shape and 62 of those had an intact
-    // frozen mask. That is the strict direction, which this module's header names as the
-    // expensive one.
+    // frozen mask. 59 of those 62 recovered; the other 3 are held by a second, independent
+    // cause. That is the strict direction, which this module's header names as the expensive
+    // one.
     //
-    // It costs no attack coverage, because every construction that corrupts the mask does so
-    // with a GATED fence, or swallows one. A stray localisable opener still changes this shape:
-    // it swallows the real frozen fence, which then disappears from the gated list.
+    // What it costs, stated conditionally because the unconditional version was wrong. A stray
+    // localisable opener still CHANGES this shape — it swallows the real frozen fence, which
+    // disappears from the gated list — but changing only CATCHES when the new shape is absent
+    // from the pool, and the new shape is often `''`, which any gated-fence-free revision
+    // pools. Fences accrete, so that is common rather than exotic. There the catcher is
+    // `hasSwallowedOpener`, and the membership tests behind it; a test pins that fallback
+    // explicitly rather than leaving it to this comment.
+    //
+    // It also gives up an accidental tripwire: under the all-fence shape a `yaml`->`text`
+    // retag (#481's escape hatch, which also evades the parity gate) usually changed the shape
+    // and was flagged here. Under gated-only it is invisible whenever the pre-addition revision
+    // already pooled the shorter shape. That tripwire was never designed, never tested, and
+    // never documented — but it was real, and its loss belongs on the record rather than in
+    // silence. Tag-sequence parity (#481) is the durable close.
     .filter((f) => !f.unterminated && isGated(f))
     // A lang-empty fence renders as `{`, not as the empty string. Empty made a single such
     // terminated fence spell the shape `''` — identical to the shape of a file with NO fences

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -554,7 +554,19 @@ export function buildEnglishProseHistory(root) {
     // from the English prose pool", i.e. novel, i.e. evidence of translation. Pooling them
     // separately lets the verdict say what is actually true — this line is English, it is
     // simply English we normally decline to compare.
+    const bodyLines = toLines(body);
     for (const fence of extractFences(body)) {
+      // The fence's own OPENER line, for every fence, terminated or not, gated or not.
+      // `openLines` drops delimiter lines unconditionally, so they were in NO pool — and an
+      // opener long enough to be comparable (```javascript is 13 chars with letters) counted
+      // as NOVEL the moment a corrupted mask exposed it. That is novelty fabricated out of
+      // pure markdown syntax: a byte-identical scaffold wrapped in one ````text fence reported
+      // `has-novel-lines`, a positive claim of translation, on the strength of a backtick line.
+      // Closers need no such treatment — a bare ``` is 3 chars with no letter, so it can never
+      // clear the comparability filter.
+      const opener = bodyLines[fence.line - 1];
+      if (opener !== undefined) for (const l of rawComparableLines(opener)) entry.fenceLines.add(l);
+
       if (!isGated(fence) || fence.unterminated) continue;
       // RAW here too, and for the mirror-image reason: English content nested gated-in-gated
       // would never enter the frozen pool, so if a corrupted mask later EXPOSED it, it would

--- a/scripts/test/translation-status.test.js
+++ b/scripts/test/translation-status.test.js
@@ -37,7 +37,7 @@ import {
   REQUIRED_SCRIPT,
   MIN_LINES_TO_JUDGE,
 } from '../lib/translation-status.js';
-import { TREES, fenceShape, hasSwallowedOpener, extractFences, isGated } from '../lib/fences.js';
+import { TREES, fenceShape, hasSwallowedOpener, extractFences, isGated, toLines } from '../lib/fences.js';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -90,9 +90,15 @@ const poolOf = (...bodies) => ({
   // Mirrors buildEnglishProseHistory's third collector. A fixture pool missing this cannot
   // distinguish the cross-pool fix from its absence -- the reviewer's own proof file predated
   // the field, and its regression test could only ever fail for that reason.
-  fenceLines: new Set(bodies.flatMap((body) => extractFences(body)
-    .filter((f) => isGated(f) && !f.unterminated)
-    .flatMap((f) => rawComparableLines(f.body)))),
+  fenceLines: new Set(bodies.flatMap((body) => {
+    const lines = toLines(body);
+    return extractFences(body).flatMap((f) => [
+      // Every fence's OPENER line — they are dropped by `openLines` and so sit in no other
+      // pool, which let an exposed ```javascript line be counted as novel prose.
+      ...rawComparableLines(lines[f.line - 1] ?? ''),
+      ...(isGated(f) && !f.unterminated ? rawComparableLines(f.body) : []),
+    ]);
+  })),
 });
 
 /**
@@ -468,6 +474,77 @@ test('a stray LOCALISABLE opener is caught even though it hides nothing', () => 
     classifyTranslation({ translatedText: strayed, locale: 'de', english: pool }).reason,
     'fence-mismatch',
   );
+});
+
+test('a localisable stray is caught by the FINGERPRINT when the shape cannot help', () => {
+  // #582 F2. The shape only CATCHES when the resulting shape is absent from the pool. Gate the
+  // shape on gated fences and a stray `text` opener yields '' — which IS in the pool for any
+  // file whose history contains a gated-fence-free revision, and fences accrete, so that is the
+  // common case rather than the exotic one. There the shape is silent and `hasSwallowedOpener`
+  // is the sole catcher. That fallback was pinned by nothing: restricting the fingerprint to
+  // gated enclosing fences left the whole suite green.
+  const body = [
+    '# Ein Titel fuer die Pruefung hier',
+    'Dies ist ein Satz mit genuegend Zeichen fuer die Zaehlung.',
+    'Und hier folgt ein zweiter Satz mit genuegend Zeichen.',
+    '```yaml',
+    'name: keep-this-identifier-in-english',
+    '```',
+    'Ein dritter Satz, ebenfalls lang genug fuer die Zaehlung.',
+    '',
+  ].join('\n');
+  // An OLDER English revision with no gated fence at all, so '' is legitimately pooled.
+  const older = ['# Ein Titel fuer die Pruefung hier', 'Dies ist ein Satz mit genuegend Zeichen fuer die Zaehlung.'].join('\n');
+  const pool = poolOf(body, older);
+  assert.ok(pool.fenceShapes.has(''), "the fixture must actually pool '' or it tests the shape path");
+
+  const strayed = body.replace(
+    '# Ein Titel fuer die Pruefung hier\n',
+    '# Ein Titel fuer die Pruefung hier\n```text\n',
+  );
+  assert.ok(pool.fenceShapes.has(fenceShape(strayed)), 'and the shape check must be SILENT here');
+  assert.equal(hasSwallowedOpener(strayed), true, 'so the fingerprint is the only thing left');
+
+  const verdict = classifyTranslation({ translatedText: strayed, locale: 'de', english: pool });
+  assert.equal(verdict.reason, 'fence-mismatch');
+  assert.equal(verdict.cause, 'swallowed-opener', 'and the cause must name what actually caught it');
+});
+
+test('an exposed fence OPENER line is not novelty (#582 F1)', () => {
+  // Delimiter lines are dropped by `openLines` for every fence, so they sat in no pool. An
+  // opener long enough to compare — ```javascript is 13 chars with letters — therefore counted
+  // as NOVEL the moment a corrupted mask exposed it. A byte-identical scaffold wrapped in one
+  // ````text fence reported `has-novel-lines`: a positive claim of translation manufactured
+  // out of markdown syntax, with both fingerprints silent by construction.
+  const body = [
+    '# Ein Titel fuer die Pruefung hier',
+    'Dies ist ein Satz mit genuegend Zeichen fuer die Zaehlung.',
+    'Und hier folgt ein zweiter Satz mit genuegend Zeichen.',
+    'Ein dritter Satz, ebenfalls lang genug fuer die Zaehlung.',
+    'Ein vierter Satz, ebenfalls lang genug fuer die Zaehlung.',
+    '```javascript',
+    'const keepThisInEnglish = 1;',
+    '```',
+    '',
+  ].join('\n');
+  const older = ['# Ein Titel fuer die Pruefung hier', 'Dies ist ein Satz mit genuegend Zeichen fuer die Zaehlung.'].join('\n');
+  const pool = poolOf(body, older);
+
+  // The opener must be comparable, or the construction has nothing to exploit.
+  assert.deepEqual(rawComparableLines('```javascript'), ['```javascript']);
+  assert.ok(pool.fenceLines.has('```javascript'), 'and it must now be pooled');
+
+  const wrapped = ['````text', body.trimEnd(), '````', ''].join('\n');
+  // Both fingerprints silent, and the shape is '' which the older revision legitimately pooled.
+  assert.equal(fenceShape(wrapped), '', 'the wrap is localisable, the inner fence is content');
+  assert.ok(pool.fenceShapes.has(''));
+  assert.equal(hasSwallowedOpener(wrapped), false, 'inner run 3 < outer 4 — the documented exemption');
+  assert.equal(hidesKnownProse(wrapped, pool.lines, pool.fenceLines), false, 'the wrap is not gated');
+
+  // With nothing else to catch it, the verdict rests entirely on the novel count.
+  const verdict = classifyTranslation({ translatedText: wrapped, locale: 'de', english: pool });
+  assert.equal(verdict.novel, 0, 'a byte-identical scaffold has no novelty, delimiters included');
+  assert.equal(verdict.stub, true, 'so it is a scaffold, not a translation');
 });
 
 test('a SAME-TAG stray opener is caught, though the shape is byte-identical', () => {

--- a/scripts/test/translation-status.test.js
+++ b/scripts/test/translation-status.test.js
@@ -454,7 +454,11 @@ test('a stray LOCALISABLE opener is caught even though it hides nothing', () => 
 
   // The fixture must genuinely exhibit the evading shape, or it proves nothing.
   assert.equal(hidesLines(strayed), false, 'a localisable fence hides nothing — the old predicate passed it');
-  assert.equal(fenceShape(strayed), 'text');
+  // The shape counts GATED fences only, so the stray `text` opener contributes nothing itself.
+  // What changes the shape is that it SWALLOWS the real frozen fence, which then vanishes from
+  // the gated list — which is exactly why gating the shape costs no attack coverage.
+  assert.equal(fenceShape(body), 'yaml', 'the clean body has one frozen fence');
+  assert.equal(fenceShape(strayed), '', 'and the stray opener swallows it');
   assert.ok(
     substantiveLines(strayed).some((l) => l.startsWith('name: keep-this-identifier')),
     'the frozen body must actually be exposed as comparable prose',
@@ -1075,7 +1079,10 @@ test('buildEnglishProseHistory collects all THREE pools, and poolOf mirrors it',
     assert.ok(entry.lines.has('A localisable line that is long enough here.'),
       'a localisable body is prose, not frozen');
     assert.ok(!entry.fenceLines.has('A localisable line that is long enough here.'));
-    assert.deepEqual([...entry.fenceShapes], ['bash,text']);
+    // GATED only: the fixture's `text` fence is localisable, so it is absent from the shape.
+    // Its body is in `lines` (asserted above) because localisable content IS compared — which
+    // is precisely why it must not perturb the shape.
+    assert.deepEqual([...entry.fenceShapes], ['bash']);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }

--- a/scripts/test/translation-status.test.js
+++ b/scripts/test/translation-status.test.js
@@ -1130,8 +1130,12 @@ test('buildEnglishProseHistory collects all THREE pools, and poolOf mirrors it',
     const body = [
       '# Demo Skill Title Here',
       'A prose line that is long enough to compare.',
-      '```bash',
-      'echo "frozen content that is long enough"',
+      // A tag long enough that the OPENER LINE itself clears the 12-char comparability floor.
+      // With `bash` (7 chars) neither opener is poolable, so deleting the production collector's
+      // opener line changed nothing and the mutant survived — the fixture lacked the construct
+      // the defect needs. `javascript` makes the opener 13 chars.
+      '```javascript',
+      'const frozenContentLongEnough = 1;',
       '```',
       '```text',
       'A localisable line that is long enough here.',
@@ -1149,9 +1153,11 @@ test('buildEnglishProseHistory collects all THREE pools, and poolOf mirrors it',
     assert.deepEqual([...entry.fenceLines].sort(), [...mirror.fenceLines].sort(), 'frozen pool must mirror');
 
     // And the pools must actually be populated, or "they match" is two empty sets agreeing.
-    assert.ok(entry.fenceLines.has('echo "frozen content that is long enough"'),
+    assert.ok(entry.fenceLines.has('const frozenContentLongEnough = 1;'),
       'the GATED body belongs to the frozen pool');
-    assert.ok(!entry.lines.has('echo "frozen content that is long enough"'),
+    assert.ok(entry.fenceLines.has('```javascript'),
+      'and so does the OPENER LINE — it is in no other pool, so an exposed one reads as novelty');
+    assert.ok(!entry.lines.has('const frozenContentLongEnough = 1;'),
       'and must NOT be in the prose pool — that separation is what the whole rule rests on');
     assert.ok(entry.lines.has('A localisable line that is long enough here.'),
       'a localisable body is prose, not frozen');
@@ -1159,7 +1165,7 @@ test('buildEnglishProseHistory collects all THREE pools, and poolOf mirrors it',
     // GATED only: the fixture's `text` fence is localisable, so it is absent from the shape.
     // Its body is in `lines` (asserted above) because localisable content IS compared — which
     // is precisely why it must not perturb the shape.
-    assert.deepEqual([...entry.fenceShapes], ['bash']);
+    assert.deepEqual([...entry.fenceShapes], ['javascript']);
   } finally {
     rmSync(repo, { recursive: true, force: true });
   }


### PR DESCRIPTION
`openLines` drops only **frozen** fence bodies; a localisable fence (`text`/`markdown`/`md`) is kept and compared like any other prose. So adding or removing a well-formed localisable fence pair **cannot corrupt the measurement** — and `fenceShape` counted it anyway, costing the file its verdict.

Measured on the corpus rather than argued: **76** files mismatched on the all-fence shape, and **62** of those had a demonstrably intact frozen mask — comparing a gated-only shape against every English revision, they match. They were being removed from the coverage count for a change that provably could not affect them. That is the strict direction, which this module's header names as the expensive one.

| | before | after | delta |
|---|---|---|---|
| translated | 3395 | 3454 | **+59** |
| unjudged | 92 | 33 | −59 |
| **stubs** | 157 | 157 | **0** |

## The stubs column is the one that mattered

A file leaving `unjudged` goes to **judged**, not to "translated" — and a stub is remediated by **deleting the file**. Had those 59 resolved to stub, this fix would have *enlarged* the deletion-eligible population, which is the exact failure mode this whole line of work exists to avoid.

All 59 resolved to `translated`. Zero deletion risk added. I checked this before looking at the coverage percentage.

## It costs no attack coverage

Every construction that corrupts the mask does so with a **gated** fence, or swallows one. A stray *localisable* opener still changes this shape — it swallows the real frozen fence, which then disappears from the gated list.

Verified against every construction from four review rounds — cross-tag, same-tag, localisable-stray, split closer, moved closer, tilde wrap, depth-2 wrap, pipe forgery. All still caught; **264/264**, and the reviewers' own proof files behave identically to before the change.

## The 33 that remain, fully accounted for

By the repo's own classifier, not a reimplementation:

```
 14  fence-mismatch/shape              real frozen-mask defects
 13  fence-mismatch/swallowed-opener
  6  mask-unparsed/frontmatter         the #475 scaffolder bug
```

The shape 14 are five content items: `harden-github-repo-security` (frozen `bash` fence deleted, 4 locales), `guides/reverse-engineering-a-cli-harness` (retag plus deletions, 4), `annotate-source-files` (frozen fences reordered, 3), `audit-icon-pipeline` (`bash`→`text` retag, 2), `create-glyph` (1).

## Provenance

Found by an ultracode fan-out over the unjudged set. Its headline result — that **0 of 92** were false positives under the cause taxonomy #571 lists — was true, and also incomplete: there was a **second** false-positive class the issue did not anticipate, and it was 62 files wide.

Worth recording that the fan-out's classification phase ran zero agents (I passed `args` as a JSON string rather than an array, so the batch list was empty). The finding came from one agent that went beyond its brief. The orchestration did not earn this; the corpus measurement did.

Refs #571.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8