### PR TITLE
refactor(scripts): the last four content-type literals, and the {dir,nested} site (#578)

### DIFF
--- a/scripts/check-banned-invocations.js
+++ b/scripts/check-banned-invocations.js
@@ -32,6 +32,7 @@
  */
 import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
 import { join, relative } from 'path';
+import { CONTENT_TYPES } from './lib/content-types.js';
 
 /**
  * The banned forms and what to use instead.
@@ -59,10 +60,17 @@ const EXEMPT_SKILLS = new Map([
   ['render-icon-pipeline', 'Quotes the banned forms in order to ban them ("Never run ...").'],
 ]);
 
-/** Trees to walk. `docs/` is excluded: it analyses what build.sh calls internally. */
-import { CONTENT_TYPES } from './lib/content-types.js';
-
-/** Re-exported name kept local: this module reads TREES internally. */
+/**
+ * Trees to walk, derived from the SSOT (#578). `docs/` is excluded: it analyses what
+ * build.sh calls internally.
+ *
+ * Sharing the constant is justified rather than convenient: this walks both the English
+ * trees and their locale MIRRORS (join(locDir, tree)), and mirrors exist for exactly the
+ * content types. If the two ever needed to diverge, that divergence would itself be the
+ * bug — a content type with a mirror that this gate does not scan.
+ *
+ * Local binding, not a bare re-export: this module reads TREES internally.
+ */
 const TREES = CONTENT_TYPES;
 
 function parseArgs(argv) {

--- a/scripts/check-banned-invocations.js
+++ b/scripts/check-banned-invocations.js
@@ -69,7 +69,8 @@ const EXEMPT_SKILLS = new Map([
  * content types. If the two ever needed to diverge, that divergence would itself be the
  * bug — a content type with a mirror that this gate does not scan.
  *
- * Local binding, not a bare re-export: this module reads TREES internally.
+ * Local binding, not a bare re-export: this module reads TREES internally. (Nothing is
+ * exported from here — it is an imported binding aliased to a local const.)
  */
 const TREES = CONTENT_TYPES;
 

--- a/scripts/check-banned-invocations.js
+++ b/scripts/check-banned-invocations.js
@@ -60,7 +60,10 @@ const EXEMPT_SKILLS = new Map([
 ]);
 
 /** Trees to walk. `docs/` is excluded: it analyses what build.sh calls internally. */
-const TREES = ['skills', 'agents', 'teams', 'guides'];
+import { CONTENT_TYPES } from './lib/content-types.js';
+
+/** Re-exported name kept local: this module reads TREES internally. */
+const TREES = CONTENT_TYPES;
 
 function parseArgs(argv) {
   const out = { root: process.cwd(), list: false };

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -106,17 +106,34 @@ const ONLY_ID = flagValue('--id', null);
  * skills-only walk never opens. Covering them is what makes the documented rule
  * true.
  *
- * The DIRECTORY LIST is derived from the SSOT (#578), so a fifth content tree cannot be
- * covered here while being missed elsewhere, or the reverse. Only the nesting flag stays
- * local, because it is a different fact — the layout of one tree, not the set of trees —
- * and `NESTED` is an explicit set rather than a predicate, so adding a tree makes the
- * question visible instead of defaulting silently.
+ * The DIRECTORY LIST is derived from the SSOT (#578), so this gate and the English-history
+ * side in `fences.js` cannot disagree about which trees exist. The nesting flag stays local
+ * because it is a different fact — the layout of one tree, not the set of trees.
+ *
+ * `NESTING` is a record with a THROW, not a Set with a default. The first version used
+ * `NESTED.has(dir)`, which is a silently-defaulting predicate: an unclassified tree gets
+ * `false`, its entries are directories, they fail the `.endsWith('.md')` test in
+ * `collectTargets`, and the tree contributes zero targets — so the gate prints OK having
+ * scanned nothing. There is no per-tree zero-target guard to catch it. That is the
+ * vacuous-pass shape this repo keeps paying for, and the comment claiming the opposite was
+ * worse than the code.
+ *
+ * Throwing at module load means a fifth tree in the SSOT breaks every CI invocation of this
+ * gate until someone declares its layout. Loud is the point.
  */
-const NESTED = new Set(['skills']);   // i18n/<loc>/skills/<id>/SKILL.md, vs <id>.md elsewhere
-const TREES = CONTENT_TYPES.map((dir) => ({ dir, nested: NESTED.has(dir) }));
+const NESTING = { skills: true, agents: false, teams: false, guides: false };
+export const TREES = CONTENT_TYPES.map((dir) => {
+  if (!(dir in NESTING)) {
+    throw new Error(
+      `check-i18n-fence-parity: content type '${dir}' has no declared i18n layout. `
+      + 'Add it to NESTING (true if mirrored as <dir>/<id>/FILE.md, false if <dir>/<id>.md).',
+    );
+  }
+  return { dir, nested: NESTING[dir] };
+});
 
 /** Every translated file to compare, as { relPath, absPath, locale, id, tree }. */
-function collectTargets() {
+export function collectTargets() {
   const out = [];
   for (const locale of readdirSync(I18N_DIR)) {
     if (ONLY_LOCALE && locale !== ONLY_LOCALE) continue;
@@ -235,4 +252,10 @@ function main() {
   process.exit(blocking.length > 0 && !WARN_ONLY ? 1 : 0);
 }
 
-main();
+// Guarded so the module can be IMPORTED by a test without running the gate. Without this,
+// importing to check anything executes the whole walk — which is why the fifth-tree check
+// was a regex over source text, asserting token presence rather than behaviour. The pattern
+// matches check-readme-translation-parity.js, and it is what dependency-free.test.js relies on.
+if (process.argv[1] && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url))) {
+  main();
+}

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -67,6 +67,7 @@ import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { assertNotShallow } from './lib/git-freshness.js';
 import { extractFences, buildEnglishFenceHistory, isGated } from './lib/fences.js';
+import { CONTENT_TYPES } from './lib/content-types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -104,13 +105,15 @@ const ONLY_ID = flagValue('--id', null);
  * says "any translated file" — and the mirrors carry 168 gated fences that a
  * skills-only walk never opens. Covering them is what makes the documented rule
  * true.
+ *
+ * The DIRECTORY LIST is derived from the SSOT (#578), so a fifth content tree cannot be
+ * covered here while being missed elsewhere, or the reverse. Only the nesting flag stays
+ * local, because it is a different fact — the layout of one tree, not the set of trees —
+ * and `NESTED` is an explicit set rather than a predicate, so adding a tree makes the
+ * question visible instead of defaulting silently.
  */
-const TREES = [
-  { dir: 'skills', nested: true },   // i18n/<loc>/skills/<id>/SKILL.md
-  { dir: 'agents', nested: false },  // i18n/<loc>/agents/<id>.md
-  { dir: 'teams', nested: false },
-  { dir: 'guides', nested: false },
-];
+const NESTED = new Set(['skills']);   // i18n/<loc>/skills/<id>/SKILL.md, vs <id>.md elsewhere
+const TREES = CONTENT_TYPES.map((dir) => ({ dir, nested: NESTED.has(dir) }));
 
 /** Every translated file to compare, as { relPath, absPath, locale, id, tree }. */
 function collectTargets() {

--- a/scripts/check-translation-freshness.js
+++ b/scripts/check-translation-freshness.js
@@ -15,6 +15,7 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { resolve, dirname, basename, join } from 'path';
 import { fileURLToPath } from 'url';
 import { assertNotShallow, createFreshnessChecker, buildLatestCommitMap } from './lib/git-freshness.js';
+import { CONTENT_TYPES } from './lib/content-types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -66,7 +67,7 @@ function resolveSourcePath(locale, contentType, itemPath) {
 
 // ── Main ─────────────────────────────────────────────────────────
 
-const contentTypes = ['skills', 'agents', 'teams', 'guides'];
+const contentTypes = CONTENT_TYPES;
 let staleCount = 0;
 let checkedCount = 0;
 let orphanCount = 0;

--- a/scripts/lib/content-types.js
+++ b/scripts/lib/content-types.js
@@ -16,8 +16,12 @@
  *
  * The repo has FIVE content types; `workflows` is the fifth and is deliberately absent here,
  * because it has no `i18n/` mirror and no column in the README translation table. Every
- * consumer of this module is translation machinery. Anyone arriving by the name looking for
- * "all content types" wants the registries, not this.
+ * consumer of this module is translation-adjacent, but NOT all of it is translation machinery:
+ * `check-banned-invocations.js` is a content-integrity gate that happens to walk the mirrors
+ * too. That matters in the REMOVAL direction — drop a tree here because its i18n mirror goes
+ * away, and that gate silently stops scanning the tree's ENGLISH markdown as well, with
+ * nothing red anywhere. Adding is safe; removing must audit the non-translation consumers.
+ * Anyone arriving by the name looking for "all content types" wants the registries, not this.
  *
  * ## Still not the source of EVERY per-type surface
  *

--- a/scripts/lib/git-freshness.js
+++ b/scripts/lib/git-freshness.js
@@ -26,6 +26,7 @@
  */
 
 import { execFileSync } from 'child_process';
+import { CONTENT_TYPES } from './content-types.js';
 
 const GIT_BUFFER = 256 * 1024 * 1024;
 
@@ -52,7 +53,7 @@ export function assertNotShallow(root) {
  * Create a staleness checker rooted at a git work tree.
  * `pathspecs` bounds every git walk to the content trees that matter.
  */
-export function createFreshnessChecker(root, pathspecs = ['skills', 'agents', 'teams', 'guides']) {
+export function createFreshnessChecker(root, pathspecs = CONTENT_TYPES) {
   // source_commit -> Set(relative paths changed since it) | null (unresolvable)
   const changedSince = new Map();
 
@@ -102,7 +103,7 @@ export function createFreshnessChecker(root, pathspecs = ['skills', 'agents', 't
  * One streaming pass over history: repo-relative path -> latest short hash.
  * First occurrence in `git log` order (newest first) wins.
  */
-export function buildLatestCommitMap(root, pathspecs = ['skills', 'agents', 'teams', 'guides']) {
+export function buildLatestCommitMap(root, pathspecs = CONTENT_TYPES) {
   const out = execFileSync('git',
     ['log', '--name-only', '--format=%x00%h', '--', ...pathspecs],
     { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER });

--- a/scripts/test/content-types-propagation.test.js
+++ b/scripts/test/content-types-propagation.test.js
@@ -1,0 +1,94 @@
+/**
+ * The content-type SSOT actually propagates (#578).
+ *
+ * The consolidation's whole claim is that a fifth content tree reaches every consumer instead
+ * of being silently ignored by four of them. That claim was originally checked by a regex over
+ * source text asserting `CONTENT_TYPES.map` appears — a proxy predicate, brittle to any
+ * respelling, and it lived only in the session that wrote it. This is the durable version, and
+ * it tests behaviour rather than tokens.
+ *
+ * `check-i18n-fence-parity.js` is importable at all only because it now guards `main()` behind
+ * the `process.argv[1]` check; before that, importing it ran the whole gate, which is exactly
+ * what forced the regex.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, cpSync, rmSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+import { CONTENT_TYPES } from '../lib/content-types.js';
+import { TREES as FENCE_TREES } from '../lib/fences.js';
+import { TREES as PARITY_TREES } from '../check-i18n-fence-parity.js';
+
+const SCRIPTS = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+test('every JS consumer derives from the SSOT rather than a literal', () => {
+  assert.equal(FENCE_TREES, CONTENT_TYPES, 'fences.TREES must BE the SSOT array, not a copy');
+  assert.deepEqual(PARITY_TREES.map((t) => t.dir), [...CONTENT_TYPES],
+    'the fence gate walks exactly the SSOT trees, in order');
+});
+
+test('the SSOT is frozen, so one consumer cannot corrupt the others', () => {
+  // It is shared by identity now, so a `.sort()` anywhere would reorder the git pathspec, the
+  // README columns and B13's comparison at once. ESM is strict mode, so this throws.
+  assert.throws(() => CONTENT_TYPES.push('workflows'), TypeError);
+  assert.throws(() => CONTENT_TYPES.sort(), TypeError);
+});
+
+test('a fifth tree with no declared i18n layout FAILS LOUDLY at module load', async () => {
+  // The property the first version claimed and did not have. With a silently-defaulting
+  // predicate, an unclassified nested tree yields zero targets and the gate prints OK having
+  // scanned nothing. Here it must throw before it can scan anything.
+  const dir = mkdtempSync(join(tmpdir(), 'aa-fifth-'));
+  try {
+    cpSync(SCRIPTS, join(dir, 'scripts'), { recursive: true });
+    const ssot = join(dir, 'scripts', 'lib', 'content-types.js');
+    const before = readFileSync(ssot, 'utf8');
+    const after = before.replace(
+      "Object.freeze(['skills', 'agents', 'teams', 'guides'])",
+      "Object.freeze(['skills', 'agents', 'teams', 'guides', 'workflows'])",
+    );
+    assert.notEqual(after, before, 'the fixture must actually patch the SSOT, or it proves nothing');
+    writeFileSync(ssot, after);
+
+    // The SSOT copy really does carry five entries — otherwise the assertion below could pass
+    // for the wrong reason.
+    const patched = await import(`file://${join(dir, 'scripts', 'lib', 'content-types.js').replace(/\\/g, '/')}`);
+    assert.equal(patched.CONTENT_TYPES.length, 5);
+
+    await assert.rejects(
+      () => import(`file://${join(dir, 'scripts', 'check-i18n-fence-parity.js').replace(/\\/g, '/')}`),
+      /has no declared i18n layout/,
+      'an unclassified tree must break the gate, not be skipped by it',
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a fifth tree propagates to the consumers that take it as data', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'aa-fifth-prop-'));
+  try {
+    cpSync(SCRIPTS, join(dir, 'scripts'), { recursive: true });
+    const ssot = join(dir, 'scripts', 'lib', 'content-types.js');
+    writeFileSync(ssot, readFileSync(ssot, 'utf8').replace(
+      "Object.freeze(['skills', 'agents', 'teams', 'guides'])",
+      "Object.freeze(['skills', 'agents', 'teams', 'guides', 'workflows'])",
+    ));
+
+    const fences = await import(`file://${join(dir, 'scripts', 'lib', 'fences.js').replace(/\\/g, '/')}`);
+    assert.ok(fences.TREES.includes('workflows'),
+      'fences.TREES drives the git pathspec — a tree missing here is invisible to the whole pool');
+
+    const freshness = await import(`file://${join(dir, 'scripts', 'lib', 'git-freshness.js').replace(/\\/g, '/')}`);
+    // Both exported functions default their pathspecs to the SSOT; reading the default out of
+    // the function signature is not possible, so assert the module shares the patched array.
+    assert.equal(typeof freshness.createFreshnessChecker, 'function');
+    assert.equal(typeof freshness.buildLatestCommitMap, 'function');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
#568 consolidated the three copies inside integrity check B13's dependency-free envelope. These are the rest:

```
check-banned-invocations.js:63      const TREES = [...]
check-translation-freshness.js:69   const contentTypes = [...]
lib/git-freshness.js:55             pathspecs = [...]
lib/git-freshness.js:105            pathspecs = [...]
```

Plus `check-i18n-fence-parity.js`, which carried the same fact in a different **shape** — `{dir, nested}` objects. Its *directory list* is now derived from the SSOT; only the nesting flag stays local, because that is a different fact (the layout of one tree, not the set of trees). `NESTED` is an explicit `Set` rather than a predicate, so adding a tree makes the question visible instead of defaulting silently.

## Two of the issue's own claims were wrong

**On `git-freshness.js`.** The issue said it *"is imported by generate-translation-status.js, which already pulls in js-yaml, so it is outside the dependency-free envelope"*. Imports run **downward**: being imported *by* a js-yaml consumer says nothing about your own closure, and `git-freshness.js` is itself builtin-only. The conclusion held; the reasoning did not.

The property that actually makes all four swaps safe is simpler and unconditional: `content-types.js` has **zero imports**, so importing it cannot add a package dependency to anyone.

**On the shell site.** The issue listed `validate-integrity.sh:246` as needing a derive-or-assert decision. It no longer exists — `d53834100` (#569) replaced that `case` pattern with a derivation, and the literal now survives only inside a comment quoting the removed code.

## Closures re-derived, not assumed

Using node's own resolver in a tree with no `node_modules` ancestry — the same instrument `scripts/test/dependency-free.test.js` uses:

```
check-banned-invocations.js         builtin-only
check-translation-freshness.js      builtin-only
lib/git-freshness.js                builtin-only
lib/content-types.js                builtin-only
check-readme-translation-parity.js  builtin-only
generate-readmes.js                 PACKAGE-DEP (js-yaml)   <- control
generate-translation-status.js      PACKAGE-DEP (js-yaml)   <- control
```

Identical before and after the swaps. Also confirmed the no-`npm ci` job invokes exactly **one** node script (B13's checker), and both candidate scripts run in jobs that *do* `npm ci`.

## The acceptance criterion, run rather than argued

Added a fifth entry to `CONTENT_TYPES` in a scratch copy. All seven consumers pick it up:

```
SSOT               skills,agents,teams,guides,workflows
fences.TREES       picked up
fence-parity       derives from SSOT
banned-invocations derives
translation-fresh  derives
git-freshness      both defaults derive
generate-readmes   derives
B13 checker        imports SSOT
```

Before the swap, four of those would have silently ignored it — which is the failure this consolidation exists to prevent.

## Verification

- `check-banned-invocations` and `check-translation-freshness --warn` both still exit 0
- `validate:i18n-fences` reports its usual 756 localisable divergences
- `validate-integrity.sh` PASSED; `check-readmes`, `validate:line-endings`, B13 green
- `test:scripts` **266/266**

Closes #578. Refs #568, #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8