### PR TITLE
refactor(scripts): extract the shared English-history walker (#559)

### DIFF
--- a/scripts/lib/content-paths.js
+++ b/scripts/lib/content-paths.js
@@ -1,0 +1,63 @@
+/**
+ * content-paths.js — repo-relative English content path -> stable `<tree>/<id>` key.
+ *
+ * Split out of `fences.js` so the shared history walker (#559) can key its blobs without
+ * importing `fences.js`, which imports the walker. The cycle would in fact have *worked* —
+ * both bindings are hoisted `export function`s used only at call time — but it would have been
+ * load-bearing on that fact, and the first top-level `const` either module later needed from
+ * the other would have turned it into a `ReferenceError` a long way from the edit that caused
+ * it. `fences.js` re-exports `contentKey`, so every existing importer is unchanged.
+ */
+
+import { CONTENT_TYPES } from './content-types.js';
+
+/**
+ * Repo-relative English content path -> stable `<tree>/<id>` key, or null when
+ * the path is not translatable content.
+ *
+ * Uses the second-to-last segment for `SKILL.md` so that pre-flatten historical
+ * paths (`skills/<domain>/<id>/SKILL.md`, ~42% of the blobs in history) key to
+ * the same id as today's `skills/<id>/SKILL.md`.
+ */
+export function contentKey(relPath) {
+  const parts = relPath.split('/');
+  if (parts.length < 2 || !CONTENT_TYPES.includes(parts[0])) return null;
+  // Both branches below must agree on what an id is, and on which ids are not content.
+  // They did not: the exclusion lived only in the flat branch, so
+  // `contentKey('skills/_template/SKILL.md')` returned `skills/_template` — a key the
+  // English history index then carried, which would have made a translated `_template`
+  // a rewrite target (#519). skills/ holds most of the corpus, so the general claim that
+  // deriving both the path and the key from this function removes the need for a second
+  // exclusion list was false exactly where it mattered most.
+  if (parts[parts.length - 1] === 'SKILL.md') {
+    if (parts.length < 3) return null;
+    // Second-to-last, never parts[1]: pre-flatten paths are
+    // `skills/<domain>/<id>/SKILL.md`, and keying off parts[1] would silently key a whole
+    // domain — ~42% of the blobs in history — to the wrong id.
+    const id = parts[parts.length - 2];
+    if (isExcludedId(id)) return null;
+    return `${parts[0]}/${id}`;
+  }
+  if (parts.length === 2 && parts[1].endsWith('.md')) {
+    const id = parts[1].slice(0, -3);
+    if (isExcludedId(id)) return null;
+    return `${parts[0]}/${id}`;
+  }
+  return null;
+}
+
+/**
+ * Names that live inside a content tree without being content.
+ *
+ * Takes a RAW path segment and strips a `.md` suffix itself, so the two branches above can
+ * hand it the same kind of thing. They could not before: the flat branch stripped the
+ * extension before testing while the nested branch passed a bare directory segment, which
+ * made `contentKey('skills/README.md/SKILL.md')` return `skills/README.md` instead of null
+ * while `contentKey('skills/README.md')` correctly returned null. Unreachable today only
+ * because every caller happens to `statSync(...).isFile()` afterwards — which is the
+ * "unreachable because of ambient state" framing #519 exists to reject.
+ */
+function isExcludedId(id) {
+  const stem = id.endsWith('.md') ? id.slice(0, -3) : id;
+  return stem.startsWith('_') || stem === 'README';
+}

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -11,11 +11,15 @@
  *
  * The two copies had asymmetric COVERAGE, and the untested one is the strict-direction
  * consumer. Measured: deleting the `missing|ambiguous` skip from the translation-status copy
- * kills a test; deleting the identical line from the fences copy left the suite green. The
- * enclosing function does run during the suite (the normalizer's fixture repo drives it), so
- * it was the `missing` BRANCH that was uncovered — `git cat-file --batch` emits that header
- * only for a spec naming a path absent from its commit, i.e. a DELETION commit, and no fixture
- * repo in this suite had ever deleted a file. `english-history.test.js` now does.
+ * kills a test; deleting the identical line from the fences copy left the suite green.
+ *
+ * The asymmetry is not that the branch was unreachable in principle. It was already covered on
+ * the prose side — `translation-status.test.js`'s `'a missing blob does not shift the batch
+ * parser onto the wrong key'` builds a repo that deletes a skill, which is what makes
+ * `git cat-file --batch` emit a `missing` header at all (it does so only for a spec naming a
+ * path absent from its commit). The asymmetry is that NO fixture could drive the fences copy,
+ * covered branch or not, because `buildEnglishFenceHistory()` took no `root` (below). Sharing
+ * one walk is what gives the strict consumer the coverage the lenient one already had.
  *
  * That matters because of which way each consumer's errors point. In translation-status.js a
  * misparse shrinks a pool, so a scaffold shows novel lines and reads as translated — lenient.
@@ -49,6 +53,40 @@ import { contentKey } from './content-paths.js';
 const GIT_BUFFER = 2048 * 1024 * 1024;
 
 /**
+ * Every `<commit>:<path>` spec the walk will resolve: one per revision of each English content
+ * file, deduplicated, with non-content paths dropped by `contentKey`.
+ *
+ * Exported so a test can assert what the walk ACTUALLY looks at. Without that, a test can only
+ * rebuild the spec list itself and assert against its own copy — which proves the fixture emits
+ * a `missing` header, not that the walker's stream contains one. Those come apart the moment
+ * spec-building changes: filter deleted paths here and the `missing` branch goes dead while
+ * every test stays green, because a deleted file's earlier revisions still arrive by their own
+ * specs.
+ *
+ * @param {string} root repository root
+ * @returns {string[]} specs in `git log` order, newest commit first
+ */
+export function collectSpecs(root) {
+  const log = execFileSync(
+    'git', ['log', '--format=%x00%H', '--name-only', '--', ...CONTENT_TYPES],
+    { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER },
+  );
+
+  const specs = [];
+  const seen = new Set();
+  let commit = null;
+  for (const line of log.split('\n')) {
+    if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
+    if (!line || !commit || contentKey(line) === null) continue;
+    const spec = `${commit}:${line}`;
+    if (seen.has(spec)) continue;
+    seen.add(spec);
+    specs.push(spec);
+  }
+  return specs;
+}
+
+/**
  * Call `onBlob(key, text, meta)` for every revision of every English content file, then once
  * more per file for the working tree.
  *
@@ -63,7 +101,7 @@ const GIT_BUFFER = 2048 * 1024 * 1024;
  * `contentKey` normalises, but not for an id rename).
  *
  * Both gaps SHRINK the pool. What a shrunk pool does then depends entirely on which collector
- * is reading it, and the five differ — three tighten, two loosen:
+ * is reading it, and the five differ — two tighten, two loosen, one is untouched:
  *
  *   - **fence bodies** (`buildEnglishFenceHistory`): the pool is a *violation* basis, so a
  *     missing revision manufactures a false violation against a real translation — strict.
@@ -81,27 +119,20 @@ const GIT_BUFFER = 2048 * 1024 * 1024;
  * changed the pool by 0 lines and the verdict set by 0 files. That was measured for the prose
  * side only — re-measure all five before changing the walk.
  *
+ * There is deliberately no `trees` option. An earlier draft had one, defaulting to
+ * `CONTENT_TYPES` and used by nobody — and it could not have worked, because `contentKey`
+ * decides membership against `CONTENT_TYPES` regardless of what the option says. Passing
+ * `{trees: ['docs']}` would have narrowed the `git log` pathspec and then filtered every
+ * resulting path back out, walking nothing and reporting success. That is the guard-proxy shape
+ * CLAUDE.md's `--tree` lesson already names: scope validated against a static list rather than
+ * against what the run actually reached. An unused parameter that cannot be used correctly is
+ * worse than no parameter.
+ *
  * @param {string} root repository root
- * @param {(key: string, text: string, meta: {fromWorkingTree: boolean, path?: string}) => void} onBlob
- * @param {{trees?: readonly string[]}} [options]
+ * @param {(key: string, text: string, meta: {fromWorkingTree: boolean, path: string}) => void} onBlob
  */
-export function walkEnglishHistory(root, onBlob, { trees = CONTENT_TYPES } = {}) {
-  const log = execFileSync(
-    'git', ['log', '--format=%x00%H', '--name-only', '--', ...trees],
-    { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER },
-  );
-
-  const specs = [];
-  const seen = new Set();
-  let commit = null;
-  for (const line of log.split('\n')) {
-    if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
-    if (!line || !commit || contentKey(line) === null) continue;
-    const spec = `${commit}:${line}`;
-    if (seen.has(spec)) continue;
-    seen.add(spec);
-    specs.push(spec);
-  }
+export function walkEnglishHistory(root, onBlob) {
+  const specs = collectSpecs(root);
 
   if (specs.length) {
     const batch = spawnSync('git', ['cat-file', '--batch'], {
@@ -133,6 +164,9 @@ export function walkEnglishHistory(root, onBlob, { trees = CONTENT_TYPES } = {})
       // A missing or ambiguous object emits a header and NO body. Failing to advance `index`
       // past it shifts every later blob onto the wrong key — a silent, total corruption of the
       // pool. This is the line whose deletion the fences copy could not detect.
+      //
+      // Reached whenever history contains a DELETION: `git log --name-only` lists the deleted
+      // path under the commit that removed it, and `<that commit>:<that path>` does not exist.
       if (/ (missing|ambiguous)$/.test(header)) { index += 1; continue; }
       const size = Number.parseInt(header.split(' ')[2], 10);
       if (!Number.isFinite(size)) break;
@@ -146,7 +180,7 @@ export function walkEnglishHistory(root, onBlob, { trees = CONTENT_TYPES } = {})
     }
   }
 
-  for (const tree of trees) {
+  for (const tree of CONTENT_TYPES) {
     const base = join(root, tree);
     if (!existsSync(base)) continue;
     for (const entry of readdirSync(base)) {

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -1,0 +1,162 @@
+/**
+ * english-history.js — one walk over every revision of every English content file (#559).
+ *
+ * `buildEnglishFenceHistory` (fences.js) and `buildEnglishProseHistory` (translation-status.js)
+ * each carried a verbatim copy of this: the `git log --name-only` spec walk, the `commit:path`
+ * dedup, the `git cat-file --batch` positional parse, the `missing|ambiguous` skip, the
+ * `offset += size + 1` advance, and the working-tree pass. They differed only in variable
+ * names, the per-blob callback, and the failure policy.
+ *
+ * ## Why the duplication was worse than it looked
+ *
+ * The two copies had asymmetric COVERAGE, and the untested one is the strict-direction
+ * consumer. Measured: deleting the `missing|ambiguous` skip from the translation-status copy
+ * kills a test; deleting the identical line from the fences copy left the suite green. The
+ * enclosing function does run during the suite (the normalizer's fixture repo drives it), so
+ * it was the `missing` BRANCH that was uncovered — `git cat-file --batch` emits that header
+ * only for a spec naming a path absent from its commit, i.e. a DELETION commit, and no fixture
+ * repo in this suite had ever deleted a file. `english-history.test.js` now does.
+ *
+ * That matters because of which way each consumer's errors point. In translation-status.js a
+ * misparse shrinks a pool, so a scaffold shows novel lines and reads as translated — lenient.
+ * In fences.js the same pool is a VIOLATION basis, so a misparse manufactures false fence
+ * violations against real translations — strict. The copy that could do the more expensive
+ * damage was the one no test could reach.
+ *
+ * ## Why it was untestable, which #559 does not name
+ *
+ * `buildEnglishFenceHistory()` took no `root` argument — it closed over module-level `ROOT`.
+ * No test could point it at a fixture repo, so no test did. Taking `root` is the change that
+ * makes the coverage possible; the extraction is what makes it shared.
+ *
+ * Zero package imports, deliberately: `fences.js` sits in the import closure of tooling that
+ * runs in jobs without `npm ci`, and a walker is exactly the kind of module someone would
+ * later reach for a YAML parser inside.
+ */
+
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import { CONTENT_TYPES } from './content-types.js';
+import { contentKey } from './content-paths.js';
+
+/**
+ * Bounds `git cat-file --batch` stdout, which is the same bytes for every caller — the two
+ * copies disagreed (2 GiB vs 512 MiB) for no reason either could state. Unified upward so
+ * neither caller regresses. A truncation here silently produces a short pool, which is why
+ * the ENOBUFS case below is surfaced by name rather than left to a status check.
+ */
+const GIT_BUFFER = 2048 * 1024 * 1024;
+
+/**
+ * Call `onBlob(key, text, meta)` for every revision of every English content file, then once
+ * more per file for the working tree.
+ *
+ * The working-tree pass is last and deliberate: an uncommitted English edit is a legal basis
+ * too, so a translation matching work-in-progress English is not a violation.
+ *
+ * ## Two known gaps, and why they cannot be "fixed" from one call site
+ *
+ * `git log` lists no paths for a merge commit and applies default history simplification, so a
+ * body existing only as conflict-resolution output never enters the pool; and `--name-only`
+ * without `--follow` loses pre-rename paths (harmless for the skills flatten, which
+ * `contentKey` normalises, but not for an id rename).
+ *
+ * Both gaps SHRINK the pool. What a shrunk pool does then depends entirely on which collector
+ * is reading it, and the five differ — three tighten, two loosen:
+ *
+ *   - **fence bodies** (`buildEnglishFenceHistory`): the pool is a *violation* basis, so a
+ *     missing revision manufactures a false violation against a real translation — strict.
+ *   - **working-tree fences** (`history.current`): unaffected; that map is built from the
+ *     working-tree pass, which no history gap can reach.
+ *   - **prose lines** (`buildEnglishProseHistory.lines`): a scaffold shows novel lines and
+ *     reads as translated — lenient.
+ *   - **fence shapes** (`.fenceShapes`, #561): a legitimate shape goes missing, so a genuine
+ *     translation drops out of the count into `unjudged` — strict, and this one silently
+ *     removes real coverage rather than raising a flag someone reads.
+ *   - **frozen-fence lines** (`.fenceLines`, #561 R2): frozen lines go missing, so content the
+ *     mask later exposes reads as novel — lenient, the opposite of its neighbour.
+ *
+ * Recorded measurement (`translation-status.js`, pre-extraction): adding `--diff-merges=separate`
+ * changed the pool by 0 lines and the verdict set by 0 files. That was measured for the prose
+ * side only — re-measure all five before changing the walk.
+ *
+ * @param {string} root repository root
+ * @param {(key: string, text: string, meta: {fromWorkingTree: boolean, path?: string}) => void} onBlob
+ * @param {{trees?: readonly string[]}} [options]
+ */
+export function walkEnglishHistory(root, onBlob, { trees = CONTENT_TYPES } = {}) {
+  const log = execFileSync(
+    'git', ['log', '--format=%x00%H', '--name-only', '--', ...trees],
+    { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER },
+  );
+
+  const specs = [];
+  const seen = new Set();
+  let commit = null;
+  for (const line of log.split('\n')) {
+    if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
+    if (!line || !commit || contentKey(line) === null) continue;
+    const spec = `${commit}:${line}`;
+    if (seen.has(spec)) continue;
+    seen.add(spec);
+    specs.push(spec);
+  }
+
+  if (specs.length) {
+    const batch = spawnSync('git', ['cat-file', '--batch'], {
+      cwd: root,
+      input: Buffer.from(`${specs.join('\n')}\n`, 'utf8'),
+      maxBuffer: GIT_BUFFER,
+    });
+    // Surfaced explicitly rather than left to the status check, and THROWN rather than
+    // `process.exit`ed — the fences copy killed the process, which is wrong for a library.
+    // A maxBuffer overflow SIGTERMs the child and leaves `status` null, which `!== 0` happens
+    // to catch, but the message would then blame git for failing rather than naming the
+    // truncation. A truncated pool is the one failure here that silently reclassifies files.
+    if (batch.error) {
+      throw new Error(`git cat-file --batch did not complete (${batch.error.code ?? batch.error.message}). `
+        + `If this is ENOBUFS, GIT_BUFFER (${GIT_BUFFER}) is too small for this history.`);
+    }
+    if (batch.status !== 0) {
+      throw new Error(`git cat-file --batch failed: ${batch.stderr?.toString().slice(0, 500)}`);
+    }
+
+    const buf = batch.stdout;
+    let offset = 0;
+    let index = 0;
+    while (offset < buf.length && index < specs.length) {
+      const newline = buf.indexOf(0x0a, offset);
+      if (newline < 0) break;
+      const header = buf.slice(offset, newline).toString('utf8');
+      offset = newline + 1;
+      // A missing or ambiguous object emits a header and NO body. Failing to advance `index`
+      // past it shifts every later blob onto the wrong key — a silent, total corruption of the
+      // pool. This is the line whose deletion the fences copy could not detect.
+      if (/ (missing|ambiguous)$/.test(header)) { index += 1; continue; }
+      const size = Number.parseInt(header.split(' ')[2], 10);
+      if (!Number.isFinite(size)) break;
+      const path = specs[index].slice(specs[index].indexOf(':') + 1);
+      const key = contentKey(path);
+      if (key !== null) {
+        onBlob(key, buf.slice(offset, offset + size).toString('utf8'), { fromWorkingTree: false, path });
+      }
+      offset += size + 1;
+      index += 1;
+    }
+  }
+
+  for (const tree of trees) {
+    const base = join(root, tree);
+    if (!existsSync(base)) continue;
+    for (const entry of readdirSync(base)) {
+      if (entry.startsWith('_')) continue;
+      const path = tree === 'skills' ? join(base, entry, 'SKILL.md') : join(base, entry);
+      if (!existsSync(path) || !statSync(path).isFile()) continue;
+      const rel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
+      const key = contentKey(rel);
+      if (key === null) continue;
+      onBlob(key, readFileSync(path, 'utf8'), { fromWorkingTree: true, path: rel });
+    }
+  }
+}

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -23,14 +23,13 @@
  *    the first ``` would splice two blocks together and invent divergences.
  */
 
-import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
-import { resolve, dirname, join } from 'path';
+import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { execFileSync, spawnSync } from 'child_process';
 import { CONTENT_TYPES } from './content-types.js';
+import { contentKey } from './content-paths.js';
+import { walkEnglishHistory } from './english-history.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const GIT_BUFFER = 2048 * 1024 * 1024;
 
 /**
  * The ONLY fence info-string tags a translation may localise. Everything else
@@ -82,55 +81,13 @@ export const isGated = (fence) => !LOCALISABLE_TAGS.has(fence.lang);
 export const TREES = CONTENT_TYPES;
 
 /**
- * Repo-relative English content path -> stable `<tree>/<id>` key, or null when
- * the path is not translatable content.
- *
- * Uses the second-to-last segment for `SKILL.md` so that pre-flatten historical
- * paths (`skills/<domain>/<id>/SKILL.md`, ~42% of the blobs in history) key to
- * the same id as today's `skills/<id>/SKILL.md`.
+ * Re-exported, not re-declared: `contentKey` now lives in `content-paths.js` so the shared
+ * history walker can key blobs without importing this module, which imports the walker (#559).
+ * Six call sites import it from here, and the `import` + `export` pair below keeps every one of
+ * them working — note it is deliberately NOT a bare `export { contentKey } from ...`, which
+ * would create no local binding, the same trap already documented for `TREES` above.
  */
-export function contentKey(relPath) {
-  const parts = relPath.split('/');
-  if (parts.length < 2 || !TREES.includes(parts[0])) return null;
-  // Both branches below must agree on what an id is, and on which ids are not content.
-  // They did not: the exclusion lived only in the flat branch, so
-  // `contentKey('skills/_template/SKILL.md')` returned `skills/_template` — a key the
-  // English history index then carried, which would have made a translated `_template`
-  // a rewrite target (#519). skills/ holds most of the corpus, so the general claim that
-  // deriving both the path and the key from this function removes the need for a second
-  // exclusion list was false exactly where it mattered most.
-  if (parts[parts.length - 1] === 'SKILL.md') {
-    if (parts.length < 3) return null;
-    // Second-to-last, never parts[1]: pre-flatten paths are
-    // `skills/<domain>/<id>/SKILL.md`, and keying off parts[1] would silently key a whole
-    // domain — ~42% of the blobs in history — to the wrong id.
-    const id = parts[parts.length - 2];
-    if (isExcludedId(id)) return null;
-    return `${parts[0]}/${id}`;
-  }
-  if (parts.length === 2 && parts[1].endsWith('.md')) {
-    const id = parts[1].slice(0, -3);
-    if (isExcludedId(id)) return null;
-    return `${parts[0]}/${id}`;
-  }
-  return null;
-}
-
-/**
- * Names that live inside a content tree without being content.
- *
- * Takes a RAW path segment and strips a `.md` suffix itself, so the two branches above can
- * hand it the same kind of thing. They could not before: the flat branch stripped the
- * extension before testing while the nested branch passed a bare directory segment, which
- * made `contentKey('skills/README.md/SKILL.md')` return `skills/README.md` instead of null
- * while `contentKey('skills/README.md')` correctly returned null. Unreachable today only
- * because every caller happens to `statSync(...).isFile()` afterwards — which is the
- * "unreachable because of ambient state" framing #519 exists to reject.
- */
-function isExcludedId(id) {
-  const stem = id.endsWith('.md') ? id.slice(0, -3) : id;
-  return stem.startsWith('_') || stem === 'README';
-}
+export { contentKey };
 
 /**
  * Union of every fence body that has ever appeared in each English SKILL.md,
@@ -141,84 +98,29 @@ function isExcludedId(id) {
  * (which can only make a fence match an EARLIER revision) nor by a
  * `source_commit` bumped without retranslation (#405).
  *
- * Costs two git processes rather than one per revision.
- * @returns {Map<string, Set<string>>}
+ * Costs two git processes rather than one per revision — see `english-history.js`, which owns
+ * the walk both this and `buildEnglishProseHistory` run over.
+ *
+ * `root` defaults to the repo this file lives in, which is how every production caller uses it.
+ * It exists as a parameter because it did NOT before, and that was the reason this half of the
+ * duplicated walk had no test: nothing could point it at a fixture repo (#559).
+ *
+ * @param {string} [root] repository root
+ * @returns {Map<string, Set<string>> & {current: Map<string, import('./fences.js').Fence[]>}}
  */
-export function buildEnglishFenceHistory() {
-  const log = execFileSync(
-    'git', ['log', '--format=%x00%H', '--name-only', '--', ...TREES],
-    { cwd: ROOT, encoding: 'utf8', maxBuffer: GIT_BUFFER },
-  );
-
-  const specs = [];
-  const seen = new Set();
-  let commit = null;
-  for (const line of log.split('\n')) {
-    if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
-    if (!line || !commit || contentKey(line) === null) continue;
-    const spec = `${commit}:${line}`;
-    if (seen.has(spec)) continue;
-    seen.add(spec);
-    specs.push(spec);
-  }
-
+export function buildEnglishFenceHistory(root = ROOT) {
   const history = new Map();
-  const add = (key, text) => {
-    if (key === null) return;
+  // Kept separately, keyed the same way: the deleted-fence check needs the fences English has
+  // NOW, with their tags, not the flattened union of every body that ever existed.
+  const current = new Map();
+
+  walkEnglishHistory(root, (key, text, { fromWorkingTree }) => {
     if (!history.has(key)) history.set(key, new Set());
     const set = history.get(key);
-    for (const f of extractFences(text)) set.add(f.body);
-  };
-
-  if (specs.length) {
-    const batch = spawnSync('git', ['cat-file', '--batch'], {
-      cwd: ROOT,
-      input: Buffer.from(specs.join('\n') + '\n', 'utf8'),
-      maxBuffer: GIT_BUFFER,
-    });
-    if (batch.status !== 0) {
-      console.error('ERROR: git cat-file --batch failed');
-      console.error(batch.stderr?.toString().slice(0, 500));
-      process.exit(1);
-    }
-    const buf = batch.stdout;
-    let offset = 0;
-    let index = 0;
-    while (offset < buf.length && index < specs.length) {
-      const nl = buf.indexOf(0x0a, offset);
-      if (nl < 0) break;
-      const header = buf.slice(offset, nl).toString('utf8');
-      offset = nl + 1;
-      if (/ (missing|ambiguous)$/.test(header)) { index++; continue; }
-      const size = Number.parseInt(header.split(' ')[2], 10);
-      if (!Number.isFinite(size)) break;
-      add(contentKey(specs[index].slice(specs[index].indexOf(':') + 1)),
-        buf.slice(offset, offset + size).toString('utf8'));
-      offset += size + 1;
-      index++;
-    }
-  }
-
-  // An uncommitted English edit is a legal basis too. The working tree is also
-  // kept separately as `history.current`, keyed the same way: the deleted-fence
-  // check needs the fences English has NOW, with their tags, not the flattened
-  // union of every body that ever existed.
-  const current = new Map();
-  for (const tree of TREES) {
-    const base = join(ROOT, tree);
-    if (!existsSync(base)) continue;
-    for (const entry of readdirSync(base)) {
-      if (entry.startsWith('_')) continue;
-      const p = tree === 'skills' ? join(base, entry, 'SKILL.md') : join(base, entry);
-      if (!existsSync(p) || !statSync(p).isFile()) continue;
-      const rel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
-      const key = contentKey(rel);
-      if (key === null) continue;
-      const text = readFileSync(p, 'utf8');
-      add(key, text);
-      current.set(key, extractFences(text));
-    }
-  }
+    const fences = extractFences(text);
+    for (const f of fences) set.add(f.body);
+    if (fromWorkingTree) current.set(key, fences);
+  });
 
   history.current = current;
   return history;

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -74,18 +74,27 @@ export const isGated = (fence) => !LOCALISABLE_TAGS.has(fence.lang);
  *
  * Re-exported from the SSOT (#568), NOT re-declared. Note the shape: `import` plus
  * `export const`, never `export { CONTENT_TYPES as TREES } from './content-types.js'` — a bare
- * re-export creates no LOCAL binding, and this module reads `TREES` internally in
- * `contentKey`, in the `git log` pathspec, and in the working-tree walk. Measured: 42 of 224
- * tests fail with `ReferenceError: TREES is not defined`.
+ * re-export creates no LOCAL binding.
+ *
+ * Stated as a rule rather than as a fact about this file, because the fact expired. The
+ * original wording said this module reads `TREES` internally "in `contentKey`, in the `git log`
+ * pathspec, and in the working-tree walk" (measured then: 42 of 224 tests failing with
+ * `ReferenceError: TREES is not defined`). #559 moved all three of those out, so today nothing
+ * here reads it and a bare re-export would in fact work. Keep the shape anyway: the next line
+ * added to this module that uses `TREES` would otherwise fail at a distance from the edit, and
+ * a comment justifying a shape by a condition that can silently stop holding is worse than no
+ * comment.
  */
 export const TREES = CONTENT_TYPES;
 
 /**
  * Re-exported, not re-declared: `contentKey` now lives in `content-paths.js` so the shared
  * history walker can key blobs without importing this module, which imports the walker (#559).
- * Six call sites import it from here, and the `import` + `export` pair below keeps every one of
- * them working — note it is deliberately NOT a bare `export { contentKey } from ...`, which
- * would create no local binding, the same trap already documented for `TREES` above.
+ * Four modules import it from here — `normalize-i18n-fences.js`, `lib/translation-status.js`,
+ * `check-yaml-fences.js`, `test/fences.test.js` — and this keeps all four working unchanged.
+ *
+ * Same `import` + `export` shape as `TREES` above, for the same forward-looking reason and with
+ * the same caveat: nothing in this module reads `contentKey` internally today either.
  */
 export { contentKey };
 
@@ -106,7 +115,7 @@ export { contentKey };
  * duplicated walk had no test: nothing could point it at a fixture repo (#559).
  *
  * @param {string} [root] repository root
- * @returns {Map<string, Set<string>> & {current: Map<string, import('./fences.js').Fence[]>}}
+ * @returns {Map<string, Set<string>> & {current: Map<string, Fence[]>}}
  */
 export function buildEnglishFenceHistory(root = ROOT) {
   const history = new Map();

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -487,9 +487,10 @@ export function classifyTranslation({ translatedText, locale, english }) {
  * so an uncommitted English edit counts as English too.
  *
  * The walk itself is `walkEnglishHistory` in `english-history.js`, shared with
- * `buildEnglishFenceHistory` (#559). Its two known gaps push this module's four collectors in
- * OPPOSITE directions, so "fix the walk" cannot be decided from here — that table is at the
- * walker, which is the only place that sees all of them.
+ * `buildEnglishFenceHistory` (#559). Its two known gaps push this module's three collectors —
+ * `lines`, `fenceShapes`, `fenceLines` — in OPPOSITE directions, and the two in `fences.js`
+ * differ again, so "fix the walk" cannot be decided from here. That table is at the walker,
+ * which is the only place that sees all five.
  *
  * @param {string} root repository root
  * @returns {Map<string, {lines: Set<string>, fenceShapes: Set<string>, fenceLines: Set<string>}>}

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -60,18 +60,12 @@
  * count. `generate-translation-status.js --verdicts` prints it. A number cannot be reviewed.
  */
 
-import { readFileSync, existsSync, readdirSync, statSync } from 'fs';
-import { join } from 'path';
-import { execFileSync, spawnSync } from 'child_process';
-import { toLines, extractFences, isGated, contentKey, fenceShape, hasSwallowedOpener, TREES } from './fences.js';
+import { toLines, extractFences, isGated, contentKey, fenceShape, hasSwallowedOpener } from './fences.js';
+import { walkEnglishHistory } from './english-history.js';
 
-// Smaller than `lib/fences.js`'s 2 GiB, and the earlier justification here was wrong: the
-// buffer bounds `git cat-file --batch` stdout, which is the same bytes in both callers, so
-// what the pool later retains has nothing to do with it. The honest statement is that this
-// caller will hit ENOBUFS first as history grows, and that the failure is loud — `spawnSync`
-// sets `error` and a short `stdout`, and the parse below would silently produce a truncated
-// pool if it were not for the `status !== 0` check. Raise both together, and keep that check.
-const GIT_BUFFER = 512 * 1024 * 1024;
+// The `git cat-file --batch` buffer used to be declared here at 512 MiB against `fences.js`'s
+// 2 GiB, and there was no reason either copy could state — the buffer bounds the same bytes
+// for both. It now lives once, in `english-history.js`, at the larger of the two (#559).
 
 /**
  * Shortest line worth comparing. Below this, markdown structure dominates — `---`, `1.`,
@@ -492,26 +486,10 @@ export function classifyTranslation({ translatedText, locale, english }) {
  * `git cat-file --batch` — rather than one per file (#305). The working tree is added last
  * so an uncommitted English edit counts as English too.
  *
- * Two known gaps in the walk, shared with `buildEnglishFenceHistory` and pointing opposite
- * ways in the two consumers, which is why neither should be "fixed" without checking both:
- * `git log` lists no paths for a merge commit and applies default history simplification, so
- * a body existing only as conflict-resolution output never enters the pool; and `--name-only`
- * without `--follow` loses pre-rename paths (harmless for the skills flatten, which
- * `contentKey` normalises, but not for an id rename). The direction differs by consumer, and
- * there are now FOUR, so "fix the walk" is not a decision that can be made from one of them:
- *
- *   - **prose pool, here:** a shrunk pool means a scaffold shows novel lines and reads as
- *     translated — lenient.
- *   - **fence bodies, `fences.js`:** the same pool is a *violation* basis, so a missing
- *     revision manufactures a false violation — strict.
- *   - **fence shapes, here (#561):** a missing revision means a missing *legitimate* shape,
- *     so a genuine translation drops out of the count into `unjudged` — also strict, and this
- *     one silently removes real coverage rather than raising a flag someone reads.
- *   - **frozen-fence lines, here (#561 R2):** a missing revision means missing frozen lines, so
- *     content the mask later exposes reads as novel — lenient, the opposite of its neighbour.
- *
- * Measured on this repo: adding `--diff-merges=separate` changes the pool by 0 lines and the
- * verdict set by 0 files. Re-measure all three before changing the walk.
+ * The walk itself is `walkEnglishHistory` in `english-history.js`, shared with
+ * `buildEnglishFenceHistory` (#559). Its two known gaps push this module's four collectors in
+ * OPPOSITE directions, so "fix the walk" cannot be decided from here — that table is at the
+ * walker, which is the only place that sees all of them.
  *
  * @param {string} root repository root
  * @returns {Map<string, {lines: Set<string>, fenceShapes: Set<string>, fenceLines: Set<string>}>}
@@ -520,26 +498,8 @@ export function classifyTranslation({ translatedText, locale, english }) {
  *   feeds all three.
  */
 export function buildEnglishProseHistory(root) {
-  const log = execFileSync(
-    'git', ['log', '--format=%x00%H', '--name-only', '--', ...TREES],
-    { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER },
-  );
-
-  const specs = [];
-  const seen = new Set();
-  let commit = null;
-  for (const line of log.split('\n')) {
-    if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
-    if (!line || !commit || contentKey(line) === null) continue;
-    const spec = `${commit}:${line}`;
-    if (seen.has(spec)) continue;
-    seen.add(spec);
-    specs.push(spec);
-  }
-
   const history = new Map();
   const add = (key, text) => {
-    if (key === null) return;
     if (!history.has(key)) {
       history.set(key, { lines: new Set(), fenceShapes: new Set(), fenceLines: new Set() });
     }
@@ -579,52 +539,7 @@ export function buildEnglishProseHistory(root) {
     entry.fenceShapes.add(fenceShape(body));
   };
 
-  if (specs.length) {
-    const batch = spawnSync('git', ['cat-file', '--batch'], {
-      cwd: root,
-      input: Buffer.from(`${specs.join('\n')}\n`, 'utf8'),
-      maxBuffer: GIT_BUFFER,
-    });
-    // Surfaced explicitly, not left to the status check. A maxBuffer overflow SIGTERMs the
-    // child and leaves `status` null, which `!== 0` happens to catch — but the message would
-    // then blame git for failing rather than naming the truncation, and a truncated pool is
-    // the one failure here that silently reclassifies files.
-    if (batch.error) {
-      throw new Error(`git cat-file --batch did not complete (${batch.error.code ?? batch.error.message}). `
-        + `If this is ENOBUFS, GIT_BUFFER (${GIT_BUFFER}) is too small for this history.`);
-    }
-    if (batch.status !== 0) {
-      throw new Error(`git cat-file --batch failed: ${batch.stderr?.toString().slice(0, 500)}`);
-    }
-    const buf = batch.stdout;
-    let offset = 0;
-    let index = 0;
-    while (offset < buf.length && index < specs.length) {
-      const newline = buf.indexOf(0x0a, offset);
-      if (newline < 0) break;
-      const header = buf.slice(offset, newline).toString('utf8');
-      offset = newline + 1;
-      if (/ (missing|ambiguous)$/.test(header)) { index += 1; continue; }
-      const size = Number.parseInt(header.split(' ')[2], 10);
-      if (!Number.isFinite(size)) break;
-      const path = specs[index].slice(specs[index].indexOf(':') + 1);
-      add(contentKey(path), buf.slice(offset, offset + size).toString('utf8'));
-      offset += size + 1;
-      index += 1;
-    }
-  }
-
-  for (const tree of TREES) {
-    const base = join(root, tree);
-    if (!existsSync(base)) continue;
-    for (const entry of readdirSync(base)) {
-      if (entry.startsWith('_')) continue;
-      const path = tree === 'skills' ? join(base, entry, 'SKILL.md') : join(base, entry);
-      if (!existsSync(path) || !statSync(path).isFile()) continue;
-      const rel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
-      add(contentKey(rel), readFileSync(path, 'utf8'));
-    }
-  }
+  walkEnglishHistory(root, add);
 
   return history;
 }

--- a/scripts/test/dependency-free.test.js
+++ b/scripts/test/dependency-free.test.js
@@ -107,6 +107,36 @@ test('a package import anywhere in that closure is detected (non-vacuity control
   assert.ok(/js-yaml/.test(stderr), 'and it should name the package');
 });
 
+test('the audit-skill-sections closure resolves with no node_modules above it', () => {
+  // A SECOND pre-`npm ci` closure, and the one #559 grew. `.github/workflows/validate-skills.yml`
+  // runs `node scripts/audit-skill-sections.js --missing` at step 57, with `npm ci` not until
+  // step 123 — so everything that entry can reach must resolve against the bare tree.
+  //
+  // #559 extended that closure without extending this probe: audit-skill-sections imports
+  // `toLines` from `lib/fences.js`, which now pulls in `lib/english-history.js` and
+  // `lib/content-paths.js`. Both headers assert they take no package imports, and until this
+  // test that assertion was exactly the untested docstring guarantee the walker's own header
+  // warns about ("a walker is exactly the kind of module someone would later reach for a YAML
+  // parser inside"). The failure would be CI-only and would land on an unrelated PR.
+  const { stderr } = importFromBareTree('audit-skill-sections.js');
+  assert.ok(
+    !RESOLUTION_FAILURE.test(stderr),
+    `validate-skills.yml step 1 would die at module resolution:\n${stderr.split('\n').slice(0, 6).join('\n')}`,
+  );
+});
+
+test('the walker and its path module resolve standalone, not only via their consumer', () => {
+  // Entry-point-only probing hides a dependency that a *different* consumer would hit first.
+  // Probe each new module directly as well.
+  for (const entry of ['lib/english-history.js', 'lib/content-paths.js']) {
+    const { stderr } = importFromBareTree(entry);
+    assert.ok(
+      !RESOLUTION_FAILURE.test(stderr),
+      `${entry} acquired a package dependency:\n${stderr.split('\n').slice(0, 6).join('\n')}`,
+    );
+  }
+});
+
 test('the control also proves TRANSITIVE detection, not just direct imports', () => {
   // `generate-translation-status.js` reaches js-yaml both directly and through relative
   // modules; the point here is that a package reached along a relative edge is caught too,

--- a/scripts/test/english-history.test.js
+++ b/scripts/test/english-history.test.js
@@ -1,0 +1,165 @@
+/**
+ * The shared English-history walker (#559).
+ *
+ * #559 asks for the duplicated walk to be extracted. The reason it is worth extracting is not
+ * line count: the two copies had asymmetric COVERAGE, and the uncovered one was the copy whose
+ * errors point in the expensive direction. Deleting the `missing|ambiguous` skip from
+ * `translation-status.js` killed a test; deleting the identical line from `fences.js` killed
+ * nothing — yet in `fences.js` the pool is a *violation* basis, so corrupting it manufactures
+ * false fence violations against real translations.
+ *
+ * The branch was unreachable for a mundane reason: `git cat-file --batch` only emits a
+ * `missing` header when a spec names a path absent from that commit, which happens when a
+ * commit DELETES a file — and no fixture repo in this suite had ever deleted one. So the
+ * fixture below deletes a skill. That is not a synthetic corruption; it is what this repo does
+ * whenever a skill is removed, which is why the line was written in the first place.
+ *
+ * `buildEnglishFenceHistory` also took no `root` argument until #559, closing over the module's
+ * own repo root. Nothing could point it at a fixture, so nothing did. These tests exercise it
+ * through the parameter that made them possible.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+
+import { walkEnglishHistory } from '../lib/english-history.js';
+import { buildEnglishFenceHistory } from '../lib/fences.js';
+import { buildEnglishProseHistory } from '../lib/translation-status.js';
+
+const FENCE = (body) => ['```javascript', body, '```', ''].join('\n');
+
+/**
+ * A repo whose history contains a deletion, so `git cat-file --batch` emits a `missing`
+ * header, plus one flat-tree file so both i18n layouts (`skills/<id>/SKILL.md` and
+ * `agents/<id>.md`) go through the same walk.
+ *
+ * Bodies are distinct strings rather than counts: the two live mutations here (drop the skip,
+ * or drop its `index += 1`) differ by WHICH key each blob lands on, and a count-based
+ * assertion cannot tell those apart from a correct run.
+ */
+function makeFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'aa-history-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+
+  mkdirSync(join(dir, 'skills', 'alpha'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'alpha', 'SKILL.md'), `# Alpha\n\n${FENCE('const alphaHistoric = 1;')}`);
+  git('add', '-A');
+  git('commit', '-qm', 'add alpha');
+
+  mkdirSync(join(dir, 'skills', 'beta'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'beta', 'SKILL.md'), `# Beta\n\n${FENCE('const betaHistoric = 2;')}`);
+  mkdirSync(join(dir, 'agents'), { recursive: true });
+  writeFileSync(join(dir, 'agents', 'gamma.md'), `# Gamma\n\n${FENCE('const gammaHistoric = 4;')}`);
+  git('add', '-A');
+  git('commit', '-qm', 'add beta and gamma');
+
+  // The deletion. This is what puts a `missing` header in the batch stream.
+  git('rm', '-q', '-r', 'skills/alpha');
+  writeFileSync(join(dir, 'skills', 'beta', 'SKILL.md'), `# Beta\n\n${FENCE('const betaCurrent = 3;')}`);
+  git('add', '-A');
+  git('commit', '-qm', 'delete alpha, revise beta');
+
+  return dir;
+}
+
+const sorted = (set) => [...set].sort();
+
+test('the fixture really does produce a `missing` header — otherwise it proves nothing', () => {
+  const dir = makeFixture();
+  try {
+    const log = execFileSync('git', ['log', '--format=%x00%H', '--name-only', '--', 'skills'],
+      { cwd: dir, encoding: 'utf8' });
+    const specs = [];
+    let commit = null;
+    for (const line of log.split('\n')) {
+      if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
+      if (line && commit) specs.push(`${commit}:${line}`);
+    }
+    const batch = spawnSync('git', ['cat-file', '--batch'],
+      { cwd: dir, input: Buffer.from(`${specs.join('\n')}\n`, 'utf8') });
+    assert.match(batch.stdout.toString('utf8'), / missing\n/,
+      'no missing header in the batch stream: the branch under test is not being reached');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a missing header advances the spec index, so every later blob keeps its own key', () => {
+  const dir = makeFixture();
+  try {
+    const history = buildEnglishFenceHistory(dir);
+
+    // Reached only through the batch parse: alpha is gone from the working tree, so its one
+    // historical fence body can enter the pool by no other route. Dropping the skip breaks the
+    // parse loop outright and this key never appears.
+    assert.deepEqual(sorted(history.get('skills/alpha') ?? new Set()), ['const alphaHistoric = 1;']);
+
+    // And the blobs that follow the missing one are not shifted onto the wrong key. Dropping
+    // only the `index += 1` (keeping the `continue`) leaves the loop running but attributes
+    // beta's current body to alpha — which the assertion above would catch, and this one pins
+    // from the other side.
+    assert.deepEqual(sorted(history.get('skills/beta')),
+      ['const betaCurrent = 3;', 'const betaHistoric = 2;']);
+    assert.deepEqual(sorted(history.get('agents/gamma')), ['const gammaHistoric = 4;']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the working-tree pass runs last and is keyed like the rest', () => {
+  const dir = makeFixture();
+  try {
+    // An uncommitted English edit is a legal basis, so it must reach the pool without a commit.
+    writeFileSync(join(dir, 'skills', 'beta', 'SKILL.md'), `# Beta\n\n${FENCE('const betaUncommitted = 9;')}`);
+    const history = buildEnglishFenceHistory(dir);
+    assert.ok(history.get('skills/beta').has('const betaUncommitted = 9;'),
+      'an uncommitted English fence must count as English');
+
+    // `history.current` holds the working tree ALONE, tags intact — not the flattened union.
+    const currentBodies = history.current.get('skills/beta').map((f) => f.body);
+    assert.deepEqual(currentBodies, ['const betaUncommitted = 9;']);
+    assert.equal(history.current.has('skills/alpha'), false,
+      'a deleted skill is absent from the working tree, so absent from current');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('both builders see the same blobs, because there is now one walk', () => {
+  const dir = makeFixture();
+  try {
+    const fenceKeys = [...buildEnglishFenceHistory(dir).keys()].sort();
+    const proseKeys = [...buildEnglishProseHistory(dir).keys()].sort();
+    assert.deepEqual(proseKeys, fenceKeys);
+    // Non-vacuity: an empty pool would satisfy the equality above.
+    assert.deepEqual(fenceKeys, ['agents/gamma', 'skills/alpha', 'skills/beta']);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the walker reports whether each blob came from the working tree', () => {
+  const dir = makeFixture();
+  try {
+    const seen = [];
+    walkEnglishHistory(dir, (key, _text, meta) => seen.push([key, meta.fromWorkingTree]));
+    // Deleted skills appear only from history; surviving ones appear from both.
+    assert.equal(seen.some(([k, wt]) => k === 'skills/alpha' && !wt), true);
+    assert.equal(seen.some(([k, wt]) => k === 'skills/alpha' && wt), false);
+    assert.equal(seen.some(([k, wt]) => k === 'skills/beta' && wt), true);
+    // The working-tree pass is last, which is what makes an uncommitted edit a legal basis.
+    const lastHistoryIndex = seen.map(([, wt]) => wt).lastIndexOf(false);
+    const firstWorktreeIndex = seen.map(([, wt]) => wt).indexOf(true);
+    assert.ok(firstWorktreeIndex > lastHistoryIndex);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/test/english-history.test.js
+++ b/scripts/test/english-history.test.js
@@ -8,15 +8,17 @@
  * nothing — yet in `fences.js` the pool is a *violation* basis, so corrupting it manufactures
  * false fence violations against real translations.
  *
- * The branch was unreachable for a mundane reason: `git cat-file --batch` only emits a
- * `missing` header when a spec names a path absent from that commit, which happens when a
- * commit DELETES a file — and no fixture repo in this suite had ever deleted one. So the
- * fixture below deletes a skill. That is not a synthetic corruption; it is what this repo does
- * whenever a skill is removed, which is why the line was written in the first place.
+ * `git cat-file --batch` emits a `missing` header only for a spec naming a path absent from its
+ * commit — that is, a DELETION commit. `translation-status.test.js` already builds such a
+ * fixture (`'a missing blob does not shift the batch parser onto the wrong key'`), which is
+ * exactly why the mutation dies on that side. So the branch was never unreachable in principle;
+ * it was unreachable through `buildEnglishFenceHistory`, which until #559 took no `root`
+ * argument and closed over the module's own repo root. Nothing could point it at a fixture, so
+ * nothing did.
  *
- * `buildEnglishFenceHistory` also took no `root` argument until #559, closing over the module's
- * own repo root. Nothing could point it at a fixture, so nothing did. These tests exercise it
- * through the parameter that made them possible.
+ * These tests therefore do two things the prose-side test cannot: they exercise the walk through
+ * the fences builder, and they pin the shared walk itself, so the coverage cannot go asymmetric
+ * again by one caller quietly growing a second copy.
  */
 
 import { test } from 'node:test';
@@ -26,7 +28,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { execFileSync, spawnSync } from 'child_process';
 
-import { walkEnglishHistory } from '../lib/english-history.js';
+import { walkEnglishHistory, collectSpecs } from '../lib/english-history.js';
 import { buildEnglishFenceHistory } from '../lib/fences.js';
 import { buildEnglishProseHistory } from '../lib/translation-status.js';
 
@@ -72,17 +74,19 @@ function makeFixture() {
 
 const sorted = (set) => [...set].sort();
 
-test('the fixture really does produce a `missing` header — otherwise it proves nothing', () => {
+test("the walker's own spec list produces a `missing` header — otherwise this proves nothing", () => {
   const dir = makeFixture();
   try {
-    const log = execFileSync('git', ['log', '--format=%x00%H', '--name-only', '--', 'skills'],
-      { cwd: dir, encoding: 'utf8' });
-    const specs = [];
-    let commit = null;
-    for (const line of log.split('\n')) {
-      if (line.startsWith('\x00')) { commit = line.slice(1).trim(); continue; }
-      if (line && commit) specs.push(`${commit}:${line}`);
-    }
+    // `collectSpecs`, not a hand-rolled copy. Rebuilding the spec list inside the test would
+    // prove the FIXTURE emits a missing header while saying nothing about the stream the walker
+    // actually parses, and the two come apart the moment spec-building changes: filter deleted
+    // paths there and the branch below goes dead with every test still green, because alpha's
+    // earlier revision still arrives under its own spec.
+    const specs = collectSpecs(dir);
+    const deletionCommit = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: dir, encoding: 'utf8' }).trim();
+    assert.ok(specs.includes(`${deletionCommit}:skills/alpha/SKILL.md`),
+      'the walk must look at the deleted path under the commit that deleted it');
+
     const batch = spawnSync('git', ['cat-file', '--batch'],
       { cwd: dir, input: Buffer.from(`${specs.join('\n')}\n`, 'utf8') });
     assert.match(batch.stdout.toString('utf8'), / missing\n/,

--- a/scripts/test/fences.test.js
+++ b/scripts/test/fences.test.js
@@ -1,5 +1,11 @@
 /**
- * Unit tests for `contentKey()` in `scripts/lib/fences.js`.
+ * Unit tests for `contentKey()`, which since #559 is defined in `scripts/lib/content-paths.js`
+ * and re-exported from `scripts/lib/fences.js`.
+ *
+ * The import below deliberately keeps going through `fences.js`. That is the path four modules
+ * use, so testing it is what proves the re-export still resolves — importing from
+ * `content-paths.js` directly would test the definition while leaving every real caller's route
+ * unexercised.
  *
  * There was no test file for this module at all, and that is how #519 survived: every
  * skills path any fixture in `scripts/test/` constructs is the 3-segment


### PR DESCRIPTION
Closes #559.

## What was duplicated

`buildEnglishFenceHistory` (`lib/fences.js`) and `buildEnglishProseHistory`
(`lib/translation-status.js`) each carried a verbatim copy of the same walk: the
`git log --name-only` spec collection, the `commit:path` dedup, the
`git cat-file --batch` positional parse, the `missing|ambiguous` skip, the
`offset += size + 1` advance, and the working-tree pass. They differed only in
variable names, the per-blob callback, and the failure policy.

## Why it was worth doing, which is not line count

The two copies had **asymmetric coverage**, and the uncovered one is the
strict-direction consumer.

| mutation | translation-status copy | fences copy |
|---|---|---|
| delete the `missing\|ambiguous` skip | killed a test | **suite stayed green** |

That matters because of which way each consumer's errors point. In
`translation-status.js` a misparse shrinks a pool, so a scaffold shows novel
lines and reads as translated — lenient. In `fences.js` the same pool is a
**violation basis**, so a misparse manufactures false fence violations against
real translations — strict. The copy that could do the more expensive damage was
the one no test could reach.

## Why no test could reach it

Two reasons, and #559 names neither:

1. **`buildEnglishFenceHistory()` took no `root` argument.** It closed over the
   module's own repo root, so nothing could point it at a fixture repo, and
   nothing did. It now takes one, defaulting to the same value.
2. **`git cat-file --batch` emits a `missing` header only for a spec naming a
   path absent from its commit** — that is, a **deletion** commit. No fixture
   repo in this suite had ever deleted a file. Verified directly before writing
   the test, and the test asserts the header is present so it cannot go vacuous.

`english-history.test.js` deletes a skill, which is what this repo does whenever
a skill is removed. Not a synthetic corruption.

## Proving the gate can fail

```
--file scripts/lib/english-history.js
--delete-matching '(missing|ambiguous)$/.test(header)'   -> MUTANT KILLED by 3 tests
--replace '{ index += 1; continue; }::{ continue; }'     -> MUTANT KILLED by 1 test
```

The second is the subtler one: keeping the `continue` but dropping the advance
leaves the loop running and shifts every later blob onto the wrong key. Both
mutants parse first (so neither kill is a parse error), and the file is restored
green afterwards.

## Also unified

- **`GIT_BUFFER`** was 2 GiB in one copy and 512 MiB in the other, for no reason
  either could state — it bounds the same `git cat-file` stdout for both. Now
  declared once, at the larger value.
- **Failure policy** is now the library-correct one: throw, with the ENOBUFS case
  named, rather than `console.error` + `process.exit(1)`. A truncated pool is the
  one failure here that silently reclassifies files.
- **`contentKey`** moves to `lib/content-paths.js` so the walker can key blobs
  without importing `fences.js`, which imports the walker. The cycle would in
  fact have worked — both bindings are hoisted function declarations used only at
  call time — but it would have been load-bearing on that fact, and the first
  top-level `const` either module later needed from the other would have turned
  it into a `ReferenceError` far from the edit that caused it. `fences.js`
  re-exports it, so all six importers are unchanged.
- **The four-consumer directionality table** (which way a shrunk pool errs, and
  why "fix the walk" cannot be decided from one call site) moves to the walker,
  the only place that sees all of them. The recorded `--diff-merges=separate`
  measurement is now labelled as prose-side-only, which is what it was.

## Behaviour gate, measured on a clean tree

| check | result |
|---|---|
| `check-i18n-fence-parity.js --json --all` | exit 1, **242,748 bytes, byte-identical** before and after |
| `normalize:i18n-fences` (preview) | identical apart from the npm banner |
| `npm run test:scripts` | 275 pass, 0 fail (270 before, +5 new) |
| `npm run validate:integrity` | PASSED (2 pre-existing glyph warnings, unrelated) |
| line-endings / banned-invocations / yaml-fences / check-readmes | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8
