### PR TITLE
feat(ci): assert the shell/YAML content-type literals against the SSOT (#585)

### DIFF
--- a/.github/workflows/validate-integrity.yml
+++ b/.github/workflows/validate-integrity.yml
@@ -18,6 +18,10 @@ on:
       # step (or its own paths) must not be able to bypass the job.
       - 'README.md'
       - '.github/workflows/validate-integrity.yml'
+      # A10 asserts this workflow's `for content_type in` loops against the
+      # CONTENT_TYPES SSOT, so a PR editing only it must not bypass the check
+      # that guards it. A10 enforces this listing rather than trusting it.
+      - '.github/workflows/validate-translations.yml'
       # A8 derives its expected translation_status set from i18n/_config.yml and
       # B6 reads i18n/*/ — without this, a new-locale PR bypasses both (#362).
       - 'i18n/**'
@@ -40,6 +44,10 @@ on:
       - '.github/workflows/update-readmes.yml'
       - 'README.md'
       - '.github/workflows/validate-integrity.yml'
+      # A10 asserts this workflow's `for content_type in` loops against the
+      # CONTENT_TYPES SSOT, so a PR editing only it must not bypass the check
+      # that guards it. A10 enforces this listing rather than trusting it.
+      - '.github/workflows/validate-translations.yml'
       - 'i18n/**'
       - 'viz/R/glyphs.R'
       - 'viz/R/agent_glyphs.R'

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "guard:release": "node scripts/repo-guard.js verify --release",
     "coverage:evals": "node scripts/eval-coverage.js",
     "mutation-check": "node scripts/mutation-check.js",
+    "gate-envelope": "node scripts/gate-envelope.js",
     "translation:status": "node scripts/generate-translation-status.js",
     "translate:scaffold": "bash scripts/translate-content.sh",
     "test": "npm run validate:integrity && npm run check-readmes",

--- a/scripts/envelopes/a10-content-type-literals.mjs
+++ b/scripts/envelopes/a10-content-type-literals.mjs
@@ -8,8 +8,11 @@
  *
  *   npm run gate-envelope -- --spec scripts/envelopes/a10-content-type-literals.mjs
  *
- * Every `find` string below must match exactly one site; the runner refuses otherwise, because a
- * mutation that silently matches nothing makes the whole envelope pass while proving nothing.
+ * Every `find` string below must match exactly the number of sites the case declares (`sites`,
+ * default 1); the runner refuses otherwise, because a mutation that silently matches nothing
+ * makes the whole envelope pass while proving nothing. Two cases here needed re-anchoring after
+ * A10's own comments began quoting the commands they guard, creating a second match site — the
+ * runner caught that rather than mutating an arbitrary one.
  *
  * Note the `expect: null` case at the end. It is not a failure — it is A10's one documented
  * non-guarantee, measured rather than asserted in prose.
@@ -105,15 +108,17 @@ export const cases = [
     // inventory and by A10's first version.
     label: "B5's flat find drops a tree",
     file: 'scripts/validate-integrity.sh',
-    find: "find agents teams guides -name '*.md'",
-    replace: "find agents teams -name '*.md'",
+    // `-not` is in the command and not in A10's comment quoting it, which is what makes this
+    // unique — the comment created a second match site and the runner refused to guess.
+    find: "find agents teams guides -name '*.md' -not",
+    replace: "find agents teams -name '*.md' -not",
     expect: "B5's flat find walks",
   },
   {
     label: "B5's SKILL.md find loses the nested tree",
     file: 'scripts/validate-integrity.sh',
-    find: "find skills -name 'SKILL.md'",
-    replace: "find guides -name 'SKILL.md'",
+    find: "find skills -name 'SKILL.md' -exec",
+    replace: "find guides -name 'SKILL.md' -exec",
     expect: "B5's SKILL.md find walks",
   },
   {
@@ -122,8 +127,11 @@ export const cases = [
     // validate-integrity.yml's trigger paths, so a PR editing only it bypassed A10 entirely.
     label: 'the trigger path for a file A10 reads is removed',
     file: '.github/workflows/validate-integrity.yml',
-    find: "      - '.github/workflows/validate-translations.yml'\n  workflow_dispatch:",
-    replace: '  workflow_dispatch:',
+    // Identical in the `push` and `pull_request` blocks, hence `sites: 2`. A10d reads only the
+    // pull_request list, so removing both is a superset of the drift it guards against.
+    find: "      - '.github/workflows/validate-translations.yml'\n      - 'i18n/**'",
+    replace: "      - 'i18n/**'",
+    sites: 2,
     expect: 'does not run on changes to it',
   },
   {

--- a/scripts/envelopes/a10-content-type-literals.mjs
+++ b/scripts/envelopes/a10-content-type-literals.mjs
@@ -127,11 +127,15 @@ export const cases = [
     // validate-integrity.yml's trigger paths, so a PR editing only it bypassed A10 entirely.
     label: 'the trigger path for a file A10 reads is removed',
     file: '.github/workflows/validate-integrity.yml',
-    // Identical in the `push` and `pull_request` blocks, hence `sites: 2`. A10d reads only the
-    // pull_request list, so removing both is a superset of the drift it guards against.
+    // The two-line form matches ONCE, in the `pull_request` block: the `push` block carries the
+    // A8/#362 comment between the same two entries. An earlier version of this case claimed the
+    // blocks were "identical" and declared `sites: 2`; the count guard rejected it, which is the
+    // point of naming the number instead of accepting whatever is there.
+    //
+    // Targeting pull_request alone is also the more precise mutation, since that is the only
+    // list A10d reads.
     find: "      - '.github/workflows/validate-translations.yml'\n      - 'i18n/**'",
     replace: "      - 'i18n/**'",
-    sites: 2,
     expect: 'does not run on changes to it',
   },
   {

--- a/scripts/envelopes/a10-content-type-literals.mjs
+++ b/scripts/envelopes/a10-content-type-literals.mjs
@@ -1,0 +1,155 @@
+/**
+ * Envelope for integrity check A10 — content-type literals outside JavaScript (#585).
+ *
+ * A10 asserts eight non-JavaScript content-type lists against `scripts/lib/content-types.js`.
+ * This is the committed record of which of those assertions actually fire, produced by breaking
+ * each one and watching the gate. Run it after touching A10, `content-types.js`, `NESTING`, or
+ * any of the sites A10 reads:
+ *
+ *   npm run gate-envelope -- --spec scripts/envelopes/a10-content-type-literals.mjs
+ *
+ * Every `find` string below must match exactly one site; the runner refuses otherwise, because a
+ * mutation that silently matches nothing makes the whole envelope pass while proving nothing.
+ *
+ * Note the `expect: null` case at the end. It is not a failure — it is A10's one documented
+ * non-guarantee, measured rather than asserted in prose.
+ */
+
+export const gate = { command: ['bash', 'scripts/validate-integrity.sh'] };
+
+export const cases = [
+  {
+    label: 'a fifth tree added to the SSOT',
+    file: 'scripts/lib/content-types.js',
+    find: "Object.freeze(['skills', 'agents', 'teams', 'guides'])",
+    replace: "Object.freeze(['skills', 'agents', 'teams', 'guides', 'workflows'])",
+    expect: 'but CONTENT_TYPES is',
+  },
+  {
+    // The parse dying must FAIL, never pass quietly with an empty list — every site downstream
+    // would otherwise go unchecked while the run stayed green.
+    label: 'the SSOT parse breaks (const renamed)',
+    file: 'scripts/lib/content-types.js',
+    find: 'export const CONTENT_TYPES = Object.freeze',
+    replace: 'export const CONTENT_TYPES_RENAMED = Object.freeze',
+    expect: 'could not parse CONTENT_TYPES',
+  },
+  {
+    // NESTING parsing to something non-empty that the SSOT does not contain. `skills: 1` would
+    // instead yield an EMPTY list, caught one guard earlier by a different message — which is
+    // how this case was mis-specified on its first writing.
+    label: 'NESTING names a tree the SSOT does not have',
+    file: 'scripts/check-i18n-fence-parity.js',
+    find: 'const NESTING = { skills: true, agents: false, teams: false, guides: false };',
+    replace: 'const NESTING = { workflows: true, agents: false, teams: false, guides: false };',
+    expect: 'derived no nested trees',
+  },
+  {
+    label: 'a tree dropped from the full loop in validate-integrity.sh',
+    file: 'scripts/validate-integrity.sh',
+    find: 'for content_type in skills agents teams guides; do',
+    replace: 'for content_type in skills agents teams; do',
+    expect: 'must be full',
+  },
+  {
+    label: 'a tree dropped from the full loop in the CI workflow',
+    file: '.github/workflows/validate-translations.yml',
+    find: 'for content_type in skills agents teams guides; do',
+    replace: 'for content_type in skills agents teams; do',
+    expect: 'must be full',
+  },
+  {
+    // The case an "at least one full loop" rule let through: one loop degrades to the EXACT flat
+    // form while another full loop survives, so a >=1 counter stays satisfied. This is why the
+    // per-site rule exists.
+    label: 'one full loop degrades to the exact flat form',
+    file: '.github/workflows/validate-translations.yml',
+    find: 'for content_type in skills agents teams guides; do',
+    replace: 'for content_type in agents teams guides; do',
+    expect: 'must be full',
+  },
+  {
+    // The reverse direction, so the rule is two-sided rather than a rubber stamp that only ever
+    // demands more trees.
+    label: 'a loop keeps the full list after losing its nested branch',
+    file: '.github/workflows/validate-translations.yml',
+    find: 'if [ "$content_type" = "skills" ]; then',
+    replace: 'if [ "$content_type" = "nothing" ]; then',
+    expect: 'must be flat',
+  },
+  {
+    label: "a case arm removed from the scaffolder's accept-rule",
+    file: 'scripts/translate-content.sh',
+    find: '  guides)\n    SOURCE_FILE="$ROOT/guides/$ID.md"',
+    replace: '  guidez)\n    SOURCE_FILE="$ROOT/guides/$ID.md"',
+    expect: 'case arms (the accept-rule)',
+  },
+  {
+    label: 'the unknown-type message drifts from the accept-rule',
+    file: 'scripts/translate-content.sh',
+    find: 'Use: skills, agents, teams, guides',
+    replace: 'Use: skills, agents, teams',
+    expect: 'unknown-type message',
+  },
+  {
+    // Per-FILE, not global: a pattern still matching the other file would otherwise satisfy a
+    // global guard while this file went entirely unread.
+    label: 'the loop pattern drifts in one file so that file is unread',
+    file: 'scripts/validate-integrity.sh',
+    find: 'for content_type in skills agents teams guides; do',
+    replace: 'for ctype in skills agents teams guides; do',
+    expect: "no 'for content_type in' loop in scripts/validate-integrity.sh",
+  },
+  {
+    // B5's reference corpus: the same flat/nested split in a different shape, missed by #585's
+    // inventory and by A10's first version.
+    label: "B5's flat find drops a tree",
+    file: 'scripts/validate-integrity.sh',
+    find: "find agents teams guides -name '*.md'",
+    replace: "find agents teams -name '*.md'",
+    expect: "B5's flat find walks",
+  },
+  {
+    label: "B5's SKILL.md find loses the nested tree",
+    file: 'scripts/validate-integrity.sh',
+    find: "find skills -name 'SKILL.md'",
+    replace: "find guides -name 'SKILL.md'",
+    expect: "B5's SKILL.md find walks",
+  },
+  {
+    // A10d: the gate must be able to fire on the files it reads. Found by reading the CI job log
+    // rather than the check's green — .github/workflows/validate-translations.yml was outside
+    // validate-integrity.yml's trigger paths, so a PR editing only it bypassed A10 entirely.
+    label: 'the trigger path for a file A10 reads is removed',
+    file: '.github/workflows/validate-integrity.yml',
+    find: "      - '.github/workflows/validate-translations.yml'\n  workflow_dispatch:",
+    replace: '  workflow_dispatch:',
+    expect: 'does not run on changes to it',
+  },
+  {
+    // THE DOCUMENTED LIMIT, measured rather than asserted. Co-deletion removes the loop's nested
+    // branch AND its list entry in one edit, leaving a well-formed flat loop with no signal in
+    // the file that it ever handled the nested tree. The per-site rule cannot see it by
+    // construction; the loop-only counter catches only TOTAL degradation, and here
+    // validate-integrity.sh's full loop survives. Distinguishing "deliberately stopped handling
+    // skills" from "accidentally stopped" needs a human-declared expectation.
+    label: 'PARTIAL co-deletion of a loop branch and its tree',
+    file: '.github/workflows/validate-translations.yml',
+    find: [
+      '          for content_type in skills agents teams guides; do',
+      '            for locale_dir in i18n/*/"$content_type"/; do',
+      '              [ ! -d "$locale_dir" ] && continue',
+      '              locale=$(basename "$(dirname "$locale_dir")")',
+      '              if [ "$content_type" = "skills" ]; then',
+    ].join('\n'),
+    replace: [
+      '          for content_type in agents teams guides; do',
+      '            for locale_dir in i18n/*/"$content_type"/; do',
+      '              [ ! -d "$locale_dir" ] && continue',
+      '              locale=$(basename "$(dirname "$locale_dir")")',
+      '              if [ "$content_type" = "nope" ]; then',
+    ].join('\n'),
+    expect: null,
+    why: "A10's one non-guarantee: co-deletion erases the signal the per-site rule keys on, and one full loop still remains so the counter is satisfied.",
+  },
+];

--- a/scripts/gate-envelope.js
+++ b/scripts/gate-envelope.js
@@ -1,0 +1,273 @@
+#!/usr/bin/env node
+/**
+ * gate-envelope.js — run a SUITE of mutations against one gate command and report which the
+ * gate catches.
+ *
+ * `mutation-check.js` answers "does deleting this one line turn that one test red?". This
+ * answers "of the N properties this gate claims to enforce, which does it actually enforce?",
+ * and records the answer as a committed artifact rather than a paragraph in a commit message.
+ *
+ * It exists because the same harness was hand-written three times in one session while building
+ * integrity check A10, and each rewrite re-derived guards the previous one had already learned:
+ *
+ *   - The first version had no SIGTERM handler. A harness timeout skipped Python's `finally` and
+ *     left `check-i18n-fence-parity.js` mutated in the working tree. It was found by `git status`
+ *     minutes later, not by the harness — and every measurement taken in between would have been
+ *     a self-consistent lie.
+ *   - The first version's expectations were guesses. Three cases "survived" and two of those were
+ *     fixture errors, not gate defects. Requiring each case to name the FAIL substring it expects
+ *     is what separated them: a run that goes red for an unrelated reason is not a kill.
+ *   - Nothing recorded a KNOWN limit. A10 cannot detect partial co-deletion, by construction. An
+ *     `expect: null` case pins that as a measured fact, so the day it starts being caught, or the
+ *     day someone claims it always was, the artifact settles it.
+ *
+ * ## Differences from mutation-check.js, and when to use which
+ *
+ * Use `mutation-check` for a single line and a single test command — it is the sharper
+ * instrument and its report is easier to quote. Use this when the subject is a gate with many
+ * guarded properties, when a case must touch more than one file, when the subject is not
+ * JavaScript, or when a documented non-guarantee deserves a measurement.
+ *
+ * ## What it refuses to do
+ *
+ * It fails closed, like its sibling. It refuses to run without a green baseline; it refuses a
+ * mutation matching zero or several sites (silently matching nothing is how an envelope passes
+ * vacuously while looking thorough); it refuses to start with a stale backup present; and it
+ * reports INVALID rather than a kill when a mutant fails to parse, because "the file no longer
+ * loads" is not evidence that the gate understood anything.
+ *
+ * Usage:
+ *   node scripts/gate-envelope.js --spec scripts/envelopes/<name>.mjs
+ *   node scripts/gate-envelope.js --spec <file> --only 'substring of a label'
+ *   node scripts/gate-envelope.js --spec <file> --list
+ *   node scripts/gate-envelope.js --spec <file> --root <dir>   # run against a fixture tree
+ *
+ * Spec shape (an ES module):
+ *   export const gate = { command: ['bash', 'scripts/validate-integrity.sh'] };
+ *   export const cases = [
+ *     { label: '...', file: 'scripts/x.sh', find: '...', replace: '...', expect: 'FAIL substring' },
+ *     { label: '...', file: '...', find: '...', replace: '...', expect: null, why: 'documented limit' },
+ *   ];
+ */
+
+import { readFileSync, writeFileSync, existsSync, unlinkSync, mkdtempSync, rmSync } from 'fs';
+import { resolve, dirname, extname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { spawnSync } from 'child_process';
+import { tmpdir } from 'os';
+
+const BACKUP_SUFFIX = '.gate-envelope.bak';
+
+function fail(message) {
+  console.error(`ERROR: ${message}`);
+  process.exit(2);
+}
+
+function flagValue(name, fallback) {
+  const i = process.argv.indexOf(name);
+  if (i < 0) return fallback;
+  const v = process.argv[i + 1];
+  // A bare `--only` would otherwise become `undefined`, match nothing, and print a clean-looking
+  // "0 cases, all passed" — the vacuous report this tool exists to make impossible.
+  if (v === undefined || v.startsWith('--')) fail(`${name} requires a value`);
+  return v;
+}
+
+/**
+ * Syntax-check a mutant in the language it is actually written in.
+ *
+ * `node --check` on a `.sh` file is not a weaker check, it is a meaningless one — it would
+ * either reject valid shell or accept anything, and either way the answer says nothing. Files
+ * with no cheap dependency-free validator are reported as unchecked rather than silently
+ * treated as valid, because "we did not verify this parses" and "this parses" must not look the
+ * same in the output.
+ *
+ * @returns {{ok: boolean, checked: boolean, detail: string}}
+ */
+function syntaxCheck(absPath, text) {
+  const ext = extname(absPath);
+  if (ext === '.sh' || ext === '.bash') {
+    const dir = mkdtempSync(join(tmpdir(), 'gate-env-'));
+    try {
+      const probe = join(dir, `probe${ext}`);
+      writeFileSync(probe, text);
+      const r = spawnSync('bash', ['-n', probe], { encoding: 'utf8' });
+      return { ok: r.status === 0, checked: true, detail: (r.stderr || '').trim().slice(0, 300) };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
+    // Through a temp file whose extension matches, because `node --check` parses a bare `.js`
+    // as CommonJS and would reject every ESM file in this package — the same trap
+    // mutation-check.js documents.
+    const dir = mkdtempSync(join(tmpdir(), 'gate-env-'));
+    try {
+      const probe = join(dir, `probe${ext === '.js' ? '.mjs' : ext}`);
+      writeFileSync(probe, text);
+      const r = spawnSync(process.execPath, ['--check', probe], { encoding: 'utf8' });
+      return { ok: r.status === 0, checked: true, detail: (r.stderr || '').trim().slice(0, 300) };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  return { ok: true, checked: false, detail: `no dependency-free parser for ${ext || 'extensionless'}` };
+}
+
+function runGate(command) {
+  const [bin, ...args] = command;
+  const r = spawnSync(bin, args, { cwd: ROOT, encoding: 'utf8' });
+  return { status: r.status, output: `${r.stdout || ''}${r.stderr || ''}` };
+}
+
+/**
+ * The tree the gate runs in and every `file` is resolved against. Defaults to this repo, which
+ * is how every real invocation uses it.
+ *
+ * It exists as a flag because the tool is otherwise untestable — the exact defect #559 was
+ * about, where `buildEnglishFenceHistory()` closed over its module's repo root so no fixture
+ * could reach it, and so nothing tested it. A verification tool with no tests of its own is
+ * worse than most code without tests: it is trusted precisely when it is wrong.
+ */
+const ROOT = resolve(flagValue('--root', dirname(fileURLToPath(import.meta.url)) + '/..'));
+
+const specArg = flagValue('--spec', null);
+if (!specArg) fail('--spec <file> is required');
+const specPath = resolve(ROOT, specArg);
+if (!existsSync(specPath)) fail(`spec not found: ${specPath}`);
+
+const spec = await import(pathToFileURL(specPath).href);
+const command = spec.gate?.command;
+if (!Array.isArray(command) || command.length === 0) {
+  fail(`${specArg} must export \`gate.command\` as a non-empty argv array`);
+}
+if (!Array.isArray(spec.cases) || spec.cases.length === 0) {
+  fail(`${specArg} must export a non-empty \`cases\` array`);
+}
+
+const only = flagValue('--only', null);
+const cases = only ? spec.cases.filter((c) => c.label.includes(only)) : spec.cases;
+if (only && cases.length === 0) fail(`--only '${only}' matched no case label`);
+
+if (process.argv.includes('--list')) {
+  for (const c of spec.cases) {
+    console.log(`${c.expect === null ? '[expected-survivor] ' : ''}${c.label}  (${c.file})`);
+  }
+  process.exit(0);
+}
+
+// Refuse to start with a stale backup: it means a previous run died hard, and the file on disk
+// may already be a mutant. Restoring from THIS run's in-memory buffer would then bake that
+// mutation in permanently while reporting success.
+for (const c of spec.cases) {
+  const bak = resolve(ROOT, c.file) + BACKUP_SUFFIX;
+  if (existsSync(bak)) fail(`stale backup present: ${bak}\nA previous run died mid-mutation. Compare it with the file and remove it by hand.`);
+}
+
+console.log(`gate-envelope: ${specArg}`);
+console.log(`  gate:  ${command.join(' ')}`);
+console.log(`  cases: ${cases.length}${only ? ` (filtered from ${spec.cases.length})` : ''}\n`);
+
+console.log('baseline (expect green) ...');
+const baseline = runGate(command);
+if (baseline.status !== 0) {
+  fail(`baseline is not green (exit ${baseline.status}). Fix that before measuring anything.`);
+}
+console.log('      green.\n');
+
+/** Files currently mutated, so a signal can put them all back. */
+const inFlight = new Map();
+
+function restoreAll() {
+  for (const [abs, text] of inFlight) {
+    writeFileSync(abs, text);
+    const bak = abs + BACKUP_SUFFIX;
+    if (existsSync(bak)) unlinkSync(bak);
+  }
+  inFlight.clear();
+}
+
+// The handler that the first hand-written version lacked. A harness timeout sends SIGTERM, which
+// by default terminates without unwinding — leaving a mutated file in the working tree.
+for (const sig of ['SIGTERM', 'SIGINT', 'SIGHUP']) {
+  process.on(sig, () => {
+    console.error(`\n${sig} received — restoring ${inFlight.size} mutated file(s) before exit.`);
+    restoreAll();
+    process.exit(130);
+  });
+}
+
+let killed = 0;
+let survived = 0;
+let asDocumented = 0;
+let problems = 0;
+
+for (const c of cases) {
+  const abs = resolve(ROOT, c.file);
+  if (!existsSync(abs)) {
+    console.log(`[MISSING]  ${c.label} — ${c.file} does not exist`);
+    problems += 1;
+    continue;
+  }
+  const before = readFileSync(abs, 'utf8');
+  const sites = before.split(c.find).length - 1;
+  if (sites !== 1) {
+    // Zero is the dangerous one: the case would "pass" having changed nothing.
+    console.log(`[INCONCLUSIVE] ${c.label} — ${sites} match site(s) for the \`find\` text, expected exactly 1`);
+    problems += 1;
+    continue;
+  }
+  const mutant = before.replace(c.find, c.replace);
+  const syntax = syntaxCheck(abs, mutant);
+  if (!syntax.ok) {
+    console.log(`[INVALID]  ${c.label} — the mutant does not parse, so any red is meaningless\n           ${syntax.detail}`);
+    problems += 1;
+    continue;
+  }
+
+  writeFileSync(abs + BACKUP_SUFFIX, before);
+  inFlight.set(abs, before);
+  writeFileSync(abs, mutant);
+  try {
+    const { status, output } = runGate(command);
+    if (c.expect === null) {
+      if (status === 0) {
+        console.log(`[SURVIVED as documented] ${c.label}${c.why ? `\n           ${c.why}` : ''}`);
+        asDocumented += 1;
+      } else {
+        console.log(`[UNEXPECTED KILL] ${c.label} — the documented limit may be narrower than claimed; re-read it`);
+        problems += 1;
+      }
+    } else {
+      const hit = output.split('\n').find((l) => l.includes('FAIL') && l.includes(c.expect));
+      if (status !== 0 && hit) {
+        console.log(`[KILLED]   ${c.label}\n           ${hit.trim().slice(0, 160)}`);
+        killed += 1;
+      } else if (status !== 0) {
+        // Red, but not for the reason claimed — the case proves nothing about this property.
+        console.log(`[WRONG-RED] ${c.label} — gate failed but no FAIL line contained ${JSON.stringify(c.expect)}`);
+        problems += 1;
+      } else {
+        console.log(`[SURVIVED] ${c.label} — gate stayed green; this property is NOT enforced`);
+        survived += 1;
+      }
+    }
+  } finally {
+    restoreAll();
+  }
+}
+
+console.log('\nverifying the tree is back where it started ...');
+const after = runGate(command);
+if (after.status !== 0) {
+  fail('the gate is red after restore — the working tree was NOT restored cleanly. Inspect it before doing anything else.');
+}
+console.log('      green.\n');
+
+const parts = [`${killed} killed`];
+if (asDocumented) parts.push(`${asDocumented} survived as documented`);
+if (survived) parts.push(`${survived} SURVIVED`);
+if (problems) parts.push(`${problems} inconclusive/invalid`);
+console.log(`gate-envelope: ${parts.join(', ')} of ${cases.length} case(s).`);
+
+process.exit(survived > 0 || problems > 0 ? 1 : 0);

--- a/scripts/gate-envelope.js
+++ b/scripts/gate-envelope.js
@@ -47,6 +47,7 @@
  *   export const cases = [
  *     { label: '...', file: 'scripts/x.sh', find: '...', replace: '...', expect: 'FAIL substring' },
  *     { label: '...', file: '...', find: '...', replace: '...', expect: null, why: 'documented limit' },
+ *     { label: '...', file: '...', find: '...', replace: '...', expect: '...', sites: 2 },
  *   ];
  */
 
@@ -210,14 +211,20 @@ for (const c of cases) {
     continue;
   }
   const before = readFileSync(abs, 'utf8');
+  // `sites` defaults to 1 and is an explicit COUNT, not an `allowMultiple` boolean. A boolean
+  // says "however many there are is fine", which is the same silence as no check: a find string
+  // that starts matching a third site after an unrelated edit would still pass. Naming the
+  // number turns that into a failure. Two real cases here match twice because A10's own comment
+  // quotes the command it guards.
+  const wanted = c.sites ?? 1;
   const sites = before.split(c.find).length - 1;
-  if (sites !== 1) {
+  if (sites !== wanted) {
     // Zero is the dangerous one: the case would "pass" having changed nothing.
-    console.log(`[INCONCLUSIVE] ${c.label} — ${sites} match site(s) for the \`find\` text, expected exactly 1`);
+    console.log(`[INCONCLUSIVE] ${c.label} — ${sites} match site(s) for the \`find\` text, expected exactly ${wanted}`);
     problems += 1;
     continue;
   }
-  const mutant = before.replace(c.find, c.replace);
+  const mutant = before.split(c.find).join(c.replace);
   const syntax = syntaxCheck(abs, mutant);
   if (!syntax.ok) {
     console.log(`[INVALID]  ${c.label} — the mutant does not parse, so any red is meaningless\n           ${syntax.detail}`);

--- a/scripts/measure-tag-sequence-parity.js
+++ b/scripts/measure-tag-sequence-parity.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * measure-tag-sequence-parity.js — what would tag-sequence parity cost, before building it?
+ *
+ * #481 proposes closing the retag escape (a frozen ```yaml fence retagged ```text leaves the
+ * parity gate entirely) by comparing the ordered info-string sequence between a translation and
+ * its English basis. #583 records that the status detector carried an accidental tripwire for
+ * the same escape and lost it in #582, leaving #481 the only thing standing between a retag and
+ * both gates.
+ *
+ * #583's acceptance criteria require the false-positive cost to be measured on the corpus
+ * BEFORE shipping, "because the last check in this area cost 62 files, and that was only
+ * discovered by measuring the corpus rather than reasoning about it". This is that measurement.
+ * It writes nothing and enforces nothing.
+ *
+ * ## The design being measured
+ *
+ * Staleness is the confound that kills the naive version. 2,549 translations are stale, so
+ * comparing a translation's tags against HEAD's tags reports drift that nobody introduced. The
+ * gate's existing answer is to accept a match against ANY English revision, and the same answer
+ * applies here: a translation is clean when its folded tag sequence equals that of SOME revision
+ * of its English source.
+ *
+ * Two foldings are load-bearing, both lifted from `normalize-i18n-fences.js`, which already
+ * makes this exact judgement to decide whether ordinal mapping is sound:
+ *
+ *   - An untagged fence folds to `text`. `normalize-content-style.js --mode fences` retro-tagged
+ *     untagged blocks as `text` on the newer side only, so that pairing is an artifact of a
+ *     known repo tool rather than a translator action.
+ *   - Alignment must NOT be expressed as `isGated(a) !== isGated(b)`. Under default-deny an
+ *     untagged fence is gated while `text` is not, so that formulation makes every one of those
+ *     benign pairings a misalignment — it stranded 169 repairable fences across 73 files when it
+ *     was tried.
+ *
+ * ## What the buckets mean
+ *
+ *   clean       the folded sequence appears in some English revision — no finding
+ *   unalignable no English revision has the same fence COUNT, so no positional claim can be
+ *               made at all. These must report as unjudged, never as violations: a translation
+ *               that legitimately predates a fence English later gained lands here, and calling
+ *               that a violation reintroduces the staleness confound the gate exists to avoid.
+ *   retag       some revision has a matching count, but a tag differs at a position. This is the
+ *               signal #481 wants and the FALSE-POSITIVE RISK at once — the report lists every
+ *               one so they can be read rather than counted.
+ *
+ * Usage:
+ *   node scripts/measure-tag-sequence-parity.js
+ *   node scripts/measure-tag-sequence-parity.js --locale de
+ *   node scripts/measure-tag-sequence-parity.js --json
+ *   node scripts/measure-tag-sequence-parity.js --list-retags   # every retag position, verbatim
+ */
+
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { extractFences } from './lib/fences.js';
+import { walkEnglishHistory } from './lib/english-history.js';
+import { collectTargets } from './check-i18n-fence-parity.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+function flagValue(name, fallback) {
+  const i = process.argv.indexOf(name);
+  if (i < 0) return fallback;
+  const v = process.argv[i + 1];
+  if (v === undefined || v.startsWith('--')) {
+    console.error(`ERROR: ${name} requires a value`);
+    process.exit(2);
+  }
+  return v;
+}
+
+const AS_JSON = process.argv.includes('--json');
+const LIST_RETAGS = process.argv.includes('--list-retags');
+const ONLY_LOCALE = flagValue('--locale', null);
+
+/** Untagged folds to `text`; see the header for why this is not optional. */
+const alignmentTag = (fence) => (fence.lang === '' ? 'text' : fence.lang);
+const sequenceOf = (text) => extractFences(text).map(alignmentTag);
+
+// Pool every folded tag sequence each English source has ever carried, keyed by `<tree>/<id>`.
+// Sequences are stored joined; the per-count index lets a mismatch be classified as unalignable
+// (no revision of that length) rather than as a retag.
+const english = new Map();
+walkEnglishHistory(ROOT, (key, text) => {
+  if (!english.has(key)) english.set(key, { sequences: new Set(), byCount: new Map() });
+  const entry = english.get(key);
+  const seq = sequenceOf(text);
+  entry.sequences.add(seq.join(','));
+  if (!entry.byCount.has(seq.length)) entry.byCount.set(seq.length, new Set());
+  entry.byCount.get(seq.length).add(seq.join(','));
+});
+
+const totals = { clean: 0, unalignable: 0, retag: 0, orphan: 0 };
+const byLocale = new Map();
+const retags = [];
+
+for (const target of collectTargets()) {
+  if (ONLY_LOCALE && target.locale !== ONLY_LOCALE) continue;
+  const entry = english.get(`${target.tree}/${target.id}`);
+  if (!entry) { totals.orphan += 1; continue; }
+
+  const seq = sequenceOf(readFileSync(target.absPath, 'utf8'));
+  const joined = seq.join(',');
+  let bucket;
+  if (entry.sequences.has(joined)) {
+    bucket = 'clean';
+  } else if (!entry.byCount.has(seq.length)) {
+    bucket = 'unalignable';
+  } else {
+    bucket = 'retag';
+    // Report against the count-matched revision that differs in the FEWEST positions — the
+    // nearest legal basis. Reporting against an arbitrary one would inflate the diff and make a
+    // single retag look like wholesale divergence.
+    let best = null;
+    for (const candidate of entry.byCount.get(seq.length)) {
+      const other = candidate.split(',');
+      const positions = seq.map((t, i) => [i, t, other[i]]).filter(([, a, b]) => a !== b);
+      if (!best || positions.length < best.positions.length) best = { positions, other };
+    }
+    retags.push({
+      file: target.relPath,
+      locale: target.locale,
+      tree: target.tree,
+      id: target.id,
+      positions: best.positions.map(([i, a, b]) => ({ index: i + 1, translated: a, english: b })),
+    });
+  }
+  totals[bucket] += 1;
+  if (!byLocale.has(target.locale)) byLocale.set(target.locale, { clean: 0, unalignable: 0, retag: 0 });
+  byLocale.get(target.locale)[bucket] += 1;
+}
+
+if (AS_JSON) {
+  console.log(JSON.stringify({ totals, byLocale: Object.fromEntries(byLocale), retags }, null, 2));
+  process.exit(0);
+}
+
+const judged = totals.clean + totals.retag;
+console.log('tag-sequence parity, measured (writes nothing, enforces nothing)\n');
+console.log(`  clean        ${totals.clean}\t folded tag sequence appears in some English revision`);
+console.log(`  retag        ${totals.retag}\t count-matched revision exists but a tag differs — the proposed finding`);
+console.log(`  unalignable  ${totals.unalignable}\t no English revision has that fence count — must report unjudged, not violation`);
+console.log(`  orphan       ${totals.orphan}\t no English source at all (check-i18n-frontmatter-parity.js owns these)`);
+console.log(`\n  judged (clean + retag): ${judged}`);
+if (judged > 0) {
+  console.log(`  finding rate on judged pairs: ${((totals.retag / judged) * 100).toFixed(2)}%`);
+}
+
+console.log('\nby locale (clean / retag / unalignable):');
+for (const [locale, counts] of [...byLocale.entries()].sort((a, b) => b[1].retag - a[1].retag)) {
+  console.log(`  ${locale.padEnd(14)} ${String(counts.clean).padStart(4)} / ${String(counts.retag).padStart(4)} / ${String(counts.unalignable).padStart(4)}`);
+}
+
+if (retags.length) {
+  console.log(`\n${retags.length} file(s) would be newly flagged. Read them before believing the count:`);
+  const shown = LIST_RETAGS ? retags : retags.slice(0, 25);
+  for (const r of shown) {
+    const where = r.positions.map((p) => `#${p.index} ${p.english}->${p.translated}`).join(', ');
+    console.log(`  ${r.file}\n      ${where}`);
+  }
+  if (!LIST_RETAGS && retags.length > shown.length) {
+    console.log(`  ... ${retags.length - shown.length} more (--list-retags for all, or --json)`);
+  }
+
+  // The distribution that decides whether this is a gate or a backlog: a retag TO a localisable
+  // tag is the #481 escape; anything else is ordinary tag drift and a likely false positive.
+  const escapes = retags.filter((r) => r.positions.some(
+    (p) => ['text', 'markdown', 'md'].includes(p.translated) && !['text', 'markdown', 'md'].includes(p.english),
+  ));
+  console.log(`\nof those, ${escapes.length} involve a frozen tag becoming localisable — the #481 escape proper.`);
+  console.log(`the remaining ${retags.length - escapes.length} are other tag drift, and are the false-positive risk.`);
+}

--- a/scripts/test/gate-envelope.test.js
+++ b/scripts/test/gate-envelope.test.js
@@ -179,6 +179,67 @@ test('a mutant that does not parse is INVALID, not a kill', () => {
   }
 });
 
+test('a case may declare N sites, and a drift from N is still refused', () => {
+  // `sites` is a count, not an `allowMultiple` boolean. A boolean says "however many there are
+  // is fine", which is the same silence as no check — a find string that starts matching a third
+  // site after an unrelated edit would still pass. Naming the number turns that into a failure.
+  const dir = makeTree([{
+    label: 'both markers removed',
+    file: 'subject.sh',
+    find: 'GUARDED',
+    replace: 'gone',
+    sites: 1,
+  }]);
+  try {
+    // The fixture has one GUARDED; declaring 1 is right, so this must run and kill.
+    const { out } = runTool(dir);
+    assert.match(out, /\[KILLED\]|\[WRONG-RED\]/, 'a correct site count must not be refused');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  const dir2 = makeTree([{
+    label: 'declares two sites but there is one',
+    file: 'subject.sh',
+    find: 'GUARDED',
+    replace: 'gone',
+    expect: 'the GUARDED marker is gone',
+    sites: 2,
+  }]);
+  try {
+    const { status, out } = runTool(dir2);
+    assert.match(out, /\[INCONCLUSIVE\].*1 match site\(s\).*expected exactly 2/s);
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir2, { recursive: true, force: true });
+  }
+});
+
+test('every site is mutated when a case declares more than one', () => {
+  // `String.replace` with a string pattern replaces only the FIRST occurrence — a trap that
+  // would leave a `sites: 2` case half-mutated, and the gate might well stay green on the
+  // survivor, scoring the property as unenforced when it is merely half-broken.
+  const dir = mkdtempSync(join(tmpdir(), 'aa-envelope-multi-'));
+  try {
+    writeFileSync(join(dir, 'subject.sh'), '#!/usr/bin/env bash\n# GUARDED a\n# GUARDED b\necho hi\n');
+    writeFileSync(join(dir, 'check.sh'),
+      '#!/usr/bin/env bash\n'
+      + 'n=$(grep -c GUARDED subject.sh)\n'
+      + 'if [ "$n" = "2" ]; then echo "OK: both markers present"; exit 0; fi\n'
+      + 'echo "FAIL: expected 2 markers, found $n"\nexit 1\n');
+    writeFileSync(join(dir, 'spec.mjs'),
+      "export const gate = { command: ['bash', 'check.sh'] };\n"
+      + 'export const cases = [{ label: "both", file: "subject.sh", find: "# GUARDED",'
+      + ' replace: "# gone", expect: "expected 2 markers, found 0", sites: 2 }];\n');
+    const { status, out } = runTool(dir);
+    assert.match(out, /\[KILLED\]/);
+    assert.match(out, /found 0/, 'both sites must be mutated, not just the first');
+    assert.equal(status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('a non-green baseline refuses to measure anything', () => {
   const dir = makeTree([KILLABLE]);
   try {

--- a/scripts/test/gate-envelope.test.js
+++ b/scripts/test/gate-envelope.test.js
@@ -1,0 +1,223 @@
+/**
+ * Tests for `scripts/gate-envelope.js`.
+ *
+ * A verification tool with no tests of its own is worse than most untested code: it is trusted
+ * exactly when it is wrong, and everything measured through it inherits the error silently. The
+ * three failures below are the ones that make an envelope LOOK thorough while proving nothing —
+ * a case whose `find` matches no site, a survivor reported as a pass, and a mutated file left
+ * behind so every later measurement is a self-consistent lie.
+ *
+ * Each test builds a throwaway tree and points the tool at it with `--root`, so the real repo is
+ * never mutated by the suite.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { spawnSync } from 'child_process';
+
+const TOOL = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'gate-envelope.js');
+
+/**
+ * A tree with a trivial gate: `check.sh` exits 1 and prints a FAIL line when `subject.sh` no
+ * longer contains the token `GUARDED`.
+ */
+function makeTree(cases) {
+  const dir = mkdtempSync(join(tmpdir(), 'aa-envelope-'));
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  writeFileSync(join(dir, 'subject.sh'), '#!/usr/bin/env bash\n# GUARDED marker\necho hello\n');
+  writeFileSync(join(dir, 'check.sh'),
+    '#!/usr/bin/env bash\n'
+    + 'if grep -q GUARDED subject.sh; then echo "OK: marker present"; exit 0; fi\n'
+    + 'echo "FAIL: the GUARDED marker is gone"\nexit 1\n');
+  writeFileSync(join(dir, 'spec.mjs'),
+    "export const gate = { command: ['bash', 'check.sh'] };\n"
+    + `export const cases = ${JSON.stringify(cases, null, 2)};\n`);
+  return dir;
+}
+
+function runTool(dir, extra = []) {
+  const r = spawnSync(process.execPath, [TOOL, '--root', dir, '--spec', 'spec.mjs', ...extra],
+    { encoding: 'utf8', cwd: dir });
+  return { status: r.status, out: `${r.stdout || ''}${r.stderr || ''}` };
+}
+
+const KILLABLE = {
+  label: 'the marker is removed',
+  file: 'subject.sh',
+  find: '# GUARDED marker',
+  replace: '# nothing here',
+  expect: 'the GUARDED marker is gone',
+};
+
+test('a mutation the gate catches is reported KILLED, and exits 0', () => {
+  const dir = makeTree([KILLABLE]);
+  try {
+    const { status, out } = runTool(dir);
+    assert.match(out, /\[KILLED\]/);
+    assert.equal(status, 0);
+    // The subject is back exactly as it was — the property everything else depends on.
+    assert.match(readFileSync(join(dir, 'subject.sh'), 'utf8'), /# GUARDED marker/);
+    assert.equal(existsSync(join(dir, 'subject.sh.gate-envelope.bak')), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a mutation the gate MISSES is reported SURVIVED, and exits non-zero', () => {
+  // The whole point of an envelope. A tool that reported this as a pass would certify an
+  // unenforced property as enforced.
+  const dir = makeTree([{
+    label: 'an unguarded line is changed',
+    file: 'subject.sh',
+    find: 'echo hello',
+    replace: 'echo goodbye',
+    expect: 'the GUARDED marker is gone',
+  }]);
+  try {
+    const { status, out } = runTool(dir);
+    assert.match(out, /\[SURVIVED\]/);
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a `find` matching no site is INCONCLUSIVE, never a pass', () => {
+  // The silent-vacuity case: the mutation changes nothing, the gate stays green, and a naive
+  // runner records a pass. Two of this session's hand-written cases were mis-specified this way.
+  const dir = makeTree([{
+    label: 'a typo in the find string',
+    file: 'subject.sh',
+    find: '# GUARDED marekr',
+    replace: 'x',
+    expect: 'the GUARDED marker is gone',
+  }]);
+  try {
+    const { status, out } = runTool(dir);
+    assert.match(out, /\[INCONCLUSIVE\].*0 match site/s);
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a red run that does not carry the expected message is WRONG-RED, not a kill', () => {
+  // The distinction that separated real defects from fixture errors: a gate can go red for a
+  // reason unrelated to the property under test, and counting that as a kill overstates coverage.
+  const dir = makeTree([{
+    label: 'right break, wrong expectation',
+    file: 'subject.sh',
+    find: '# GUARDED marker',
+    replace: '# nothing here',
+    expect: 'some message this gate never prints',
+  }]);
+  try {
+    const { status, out } = runTool(dir);
+    assert.match(out, /\[WRONG-RED\]/);
+    assert.equal(status, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('an expected-survivor case passes when it survives and flags an unexpected kill', () => {
+  const dir = makeTree([{
+    label: 'a documented non-guarantee',
+    file: 'subject.sh',
+    find: 'echo hello',
+    replace: 'echo goodbye',
+    expect: null,
+    why: 'this gate deliberately does not look at that line',
+  }]);
+  try {
+    const { status, out } = runTool(dir);
+    assert.match(out, /\[SURVIVED as documented\]/);
+    assert.equal(status, 0, 'a documented limit that holds is not a failure');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+
+  const dir2 = makeTree([{
+    label: 'a limit that is no longer real',
+    file: 'subject.sh',
+    find: '# GUARDED marker',
+    replace: '# nothing here',
+    expect: null,
+  }]);
+  try {
+    const { status, out } = runTool(dir2);
+    assert.match(out, /\[UNEXPECTED KILL\]/);
+    assert.equal(status, 1, 'a documented limit that stopped being real must be re-read');
+  } finally {
+    rmSync(dir2, { recursive: true, force: true });
+  }
+});
+
+test('a mutant that does not parse is INVALID, not a kill', () => {
+  // Breaking the file so it cannot load makes the gate red for a reason that says nothing about
+  // what the gate understands. mutation-check.js documents this trap; the same one applies here,
+  // and for shell it needs `bash -n` rather than `node --check`.
+  const dir = makeTree([{
+    label: 'the mutant is not valid shell',
+    file: 'subject.sh',
+    find: 'echo hello',
+    replace: 'if [ ; then',
+    expect: 'the GUARDED marker is gone',
+  }]);
+  try {
+    const { status, out } = runTool(dir);
+    assert.match(out, /\[INVALID\]/);
+    assert.equal(status, 1);
+    assert.match(readFileSync(join(dir, 'subject.sh'), 'utf8'), /echo hello/,
+      'an INVALID mutant must never be left on disk');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a non-green baseline refuses to measure anything', () => {
+  const dir = makeTree([KILLABLE]);
+  try {
+    // Break the subject up front: the gate is already red, so every "kill" below would be one.
+    writeFileSync(join(dir, 'subject.sh'), '#!/usr/bin/env bash\necho hello\n');
+    const { status, out } = runTool(dir);
+    assert.match(out, /baseline is not green/);
+    assert.equal(status, 2, 'refusal must be distinguishable from a measured failure');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a stale backup halts the run rather than overwriting it', () => {
+  // A previous run died hard, so the file on disk may already be a mutant. Restoring from THIS
+  // run's buffer would bake that mutation in permanently while reporting success.
+  const dir = makeTree([KILLABLE]);
+  try {
+    writeFileSync(join(dir, 'subject.sh.gate-envelope.bak'), 'whatever');
+    const { status, out } = runTool(dir);
+    assert.match(out, /stale backup present/);
+    assert.equal(status, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the a10 envelope spec is well formed and every case is distinct', async () => {
+  // Guards the committed artifact itself: a duplicated label makes `--only` ambiguous, and a
+  // missing field would surface only as an INCONCLUSIVE mid-run.
+  const spec = await import('../envelopes/a10-content-type-literals.mjs');
+  assert.ok(Array.isArray(spec.gate.command) && spec.gate.command.length > 0);
+  assert.ok(spec.cases.length >= 10, 'the A10 envelope should stay comprehensive');
+  const labels = spec.cases.map((c) => c.label);
+  assert.equal(new Set(labels).size, labels.length, 'labels must be unique');
+  for (const c of spec.cases) {
+    assert.ok(c.file && c.find && c.replace !== undefined, `case '${c.label}' is missing a field`);
+    assert.notEqual(c.find, c.replace, `case '${c.label}' mutates nothing`);
+    assert.ok(c.expect === null || typeof c.expect === 'string');
+    if (c.expect === null) assert.ok(c.why, `expected-survivor '${c.label}' must say why`);
+  }
+});

--- a/scripts/test/readme-sections.test.js
+++ b/scripts/test/readme-sections.test.js
@@ -133,6 +133,20 @@ test('replaceSection touches only the named section', () => {
 // ── renderTranslationsTable ─────────────────────────────────────────────────
 
 const SOURCE = { skills: 369, agents: 75, teams: 22, guides: 34, total: 500 };
+
+/**
+ * A four-tree literal, and it is CORRECT to keep — do not "fix" it to `CONTENT_TYPES` (#585).
+ *
+ * #578 routed the production consumers through the SSOT and A10 now asserts the shell and YAML
+ * ones against it, so a literal here looks like the one that got away. It is the opposite: a
+ * fixture that derived its expectation from the SSOT could not detect SSOT corruption. Reorder
+ * or truncate `CONTENT_TYPES` and every assertion below would move with it, agreeing with the
+ * broken value and reporting green.
+ *
+ * The rule that separates the two cases: derive when the literal is an INPUT the code acts on,
+ * hardcode when it is the EXPECTATION the code is measured against. A test that shares its
+ * subject's source of truth is measuring the subject against itself.
+ */
 const TYPES = ['skills', 'agents', 'teams', 'guides'];
 
 const coverageOf = (translated, stubs, unjudged) => ({

--- a/scripts/test/readme-sections.test.js
+++ b/scripts/test/readme-sections.test.js
@@ -138,14 +138,24 @@ const SOURCE = { skills: 369, agents: 75, teams: 22, guides: 34, total: 500 };
  * A four-tree literal, and it is CORRECT to keep — do not "fix" it to `CONTENT_TYPES` (#585).
  *
  * #578 routed the production consumers through the SSOT and A10 now asserts the shell and YAML
- * ones against it, so a literal here looks like the one that got away. It is the opposite: a
- * fixture that derived its expectation from the SSOT could not detect SSOT corruption. Reorder
- * or truncate `CONTENT_TYPES` and every assertion below would move with it, agreeing with the
- * broken value and reporting green.
+ * ones against it, so a literal here looks like the one that got away. It is not.
  *
- * The rule that separates the two cases: derive when the literal is an INPUT the code acts on,
- * hardcode when it is the EXPECTATION the code is measured against. A test that shares its
- * subject's source of truth is measuring the subject against itself.
+ * `TYPES` is the third ARGUMENT of `renderTranslationsTable`, which production fills with
+ * `CONTENT_TYPES` at `generate-readmes.js:638`. These are unit tests of a pure renderer, and
+ * pinning its input locally is what keeps them unit tests: derive it, and a legitimate fifth
+ * tree turns this file red for a reason that has nothing to do with the renderer. That is
+ * noise, not detection.
+ *
+ * Note what does NOT justify keeping it — an earlier version of this comment claimed a derived
+ * `TYPES` would make the assertions "move with it, agreeing with the broken value and reporting
+ * green". That is backwards. The assertions below are hardcoded regexes over rendered rows
+ * (`| 328/369 | 3/75 | 1/22 | 2/34 |`), so a truncated or reordered SSOT would drop or move a
+ * column and they would go RED. They anchor the table's shape regardless of what is injected,
+ * which is exactly why injecting a literal costs nothing here.
+ *
+ * SSOT corruption is caught elsewhere and does not need catching here: A10 goes red when the
+ * SSOT disagrees with any of the eight shell/YAML sites, and `content-types-propagation.test.js`
+ * pins the JS consumers.
  */
 const TYPES = ['skills', 'agents', 'teams', 'guides'];
 

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -488,6 +488,43 @@ else
     done <<< "$a10_hits"
   done
 
+  # A10d: this job must actually RUN when one of the files A10 reads changes.
+  #
+  # A check that cannot fire on the file it guards is not a gate. `validate-integrity.yml`
+  # already self-lists its own path for that reason, and A8c enforces the same property for the
+  # staleness gate's outputs -- but nothing covered A10's INPUTS, and one of them
+  # (.github/workflows/validate-translations.yml) was outside the trigger. A PR editing only that
+  # file dropped a tree from its loop with A10 never running. Found by checking the CI log
+  # rather than the check's own green.
+  #
+  # The source list below is hardcoded and inherently so: it is the set of files A10 opens, which
+  # only A10 knows. Adding a read without adding it here is the one drift this cannot see.
+  a10_paths=$(sed -n '/^  pull_request:/,/^  workflow_dispatch:/p' .github/workflows/validate-integrity.yml \
+    | grep -E '^      - ' | sed -E "s/^      - //; s/^['\"]//; s/['\"]\$//" || true)
+  a10_covered() { # <repo-relative path> -> 0 when some pull_request path entry matches it
+    while IFS= read -r a10_pat; do
+      [ -z "$a10_pat" ] && continue
+      case "$a10_pat" in
+        */\*\*) [ "${1#${a10_pat%/\*\*}/}" != "$1" ] && return 0 ;;
+        *) [ "$a10_pat" = "$1" ] && return 0 ;;
+      esac
+    done <<< "$a10_paths"
+    return 1
+  }
+  if [ -z "$a10_paths" ]; then
+    echo "FAIL: A10 could not read validate-integrity.yml's pull_request paths -- trigger coverage UNCHECKED"
+    failed=1; a10_fail=1
+  else
+    for a10_src in scripts/lib/content-types.js scripts/check-i18n-fence-parity.js \
+                   scripts/validate-integrity.sh scripts/translate-content.sh \
+                   .github/workflows/validate-translations.yml; do
+      if ! a10_covered "$a10_src"; then
+        echo "FAIL: A10 reads $a10_src, but .github/workflows/validate-integrity.yml does not run on changes to it -- editing that file alone bypasses this check entirely"
+        failed=1; a10_fail=1
+      fi
+    done
+  fi
+
   # translate-content.sh. The `case` arms are the ACCEPT-RULE -- what the scaffolder will and
   # will not act on. The other two describe that rule to a human, and a description that
   # disagrees with the rule is a lie someone reads while debugging.

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -406,10 +406,19 @@ a10_flat=""
 # Counted separately, because they mean different things: `a10_full` is surfaces required to
 # carry every tree, `a10_flatsites` is surfaces legitimately carrying only the non-nested ones.
 # Reported rather than asserted -- the assertion is per site, against the form that site's own
-# behaviour requires. An earlier version asserted on the COUNT instead, which passed while a
-# full loop degraded to flat.
+# behaviour requires.
+#
+# `a10_loops_full` is asserted, and is LOOP-ONLY on purpose. The per-site rule and a count rule
+# catch different drifts, so this repo now carries both. The per-site rule misses CO-DELETION:
+# remove a loop's `= "skills"` branch AND drop `skills` from its list in one edit and it is a
+# well-formed flat loop, silently. Do that to both full loops and no loop iterates the nested
+# tree anywhere. Counting only loops is what makes that visible -- `a10_full` cannot, because
+# translate-content.sh's three surfaces always count full and would report `3 full` on a corpus
+# with zero full loops.
 a10_full=0
 a10_flatsites=0
+a10_loops_full=0
+a10_checked_find=0
 
 a10_all=$(sed -n 's/^export const CONTENT_TYPES = Object.freeze(\[\(.*\)\]);$/\1/p' scripts/lib/content-types.js \
   | tr -d "'\"" | tr ',' ' ' | tr -s ' ' '\n' | sed '/^$/d' | sort || true)
@@ -474,19 +483,60 @@ else
       # The branch sits 4 lines into both real cases; 10 is margin. A restructure that moves it
       # further reads here as "flat loop with a full list" and FAILS -- loud and worth reading,
       # which is the right direction for a heuristic window.
+      # F5: `[a-z ]+` above admits no hyphen. A hyphenated tree name would make its loop line
+      # unmatchable while the SSOT parse handled it fine -- widen both together if that day comes.
       if sed -n "${a10_line},$((a10_line + 10))p" "$a10_file" | grep -qE "= \"($a10_nested_re)\""; then
-        a10_want="$a10_all"; a10_form="full (it branches on a nested tree)"
+        a10_want="$a10_all"; a10_form="full: a \`= \"<nested tree>\"\` branch appears within 10 lines"
       else
-        a10_want="$a10_flat"; a10_form="flat (it never branches on a nested tree)"
+        a10_want="$a10_flat"; a10_form="flat: no \`= \"<nested tree>\"\` branch within 10 lines (a branch written as \`case\`, \`[[ == ]]\`, or with single quotes reads as absent here)"
       fi
       if [ "$a10_list" = "$a10_want" ]; then
-        if [ "$a10_want" = "$a10_all" ]; then a10_full=$((a10_full + 1)); else a10_flatsites=$((a10_flatsites + 1)); fi
+        if [ "$a10_want" = "$a10_all" ]; then
+          a10_full=$((a10_full + 1)); a10_loops_full=$((a10_loops_full + 1))
+        else
+          a10_flatsites=$((a10_flatsites + 1))
+        fi
       else
         echo "FAIL: $a10_file:$a10_line iterates [$(printf '%s' "$a10_list" | tr '\n' ' ')] but must be $a10_form: [$(printf '%s' "$a10_want" | tr '\n' ' ')]"
         failed=1; a10_fail=1
       fi
     done <<< "$a10_hits"
   done
+
+  # Catches TOTAL degradation. It does not catch PARTIAL co-deletion -- one loop losing both its
+  # branch and its list entry while another full loop survives -- and nothing here can, because
+  # co-deletion removes every signal in the file that the loop ever handled the nested tree.
+  # Distinguishing "deliberately stopped handling skills" from "accidentally stopped" needs a
+  # human-declared expectation, i.e. the per-file inventory this check exists to avoid. Tracked
+  # rather than papered over.
+  if [ "$a10_loops_full" -eq 0 ]; then
+    echo "FAIL: A10 found no loop iterating the FULL content-type list -- nested trees are walked nowhere. If that is deliberate, this line is the place to say so."
+    failed=1; a10_fail=1
+  fi
+
+  # B5's reference corpus, a SEVENTH site and the same flat/nested split in a different shape:
+  # two `find` pathspecs whose union must be the SSOT -- `find agents teams guides -name '*.md'`
+  # plus `find skills -name 'SKILL.md'`. Invisible to the loop pattern above, and missed by both
+  # #585's inventory and the first version of this check. Add a fifth mirrored tree and B5's
+  # reference corpus silently omits it, so skills referenced only from that tree read as orphans.
+  a10_find_flat=$(grep -oE "^find [a-z ]+ -name '\*\.md'" scripts/validate-integrity.sh \
+    | sed -E "s/^find //; s/ -name '\*\.md'\$//" | tr -s ' ' '\n' | sed '/^$/d' | sort || true)
+  a10_find_nested=$(grep -oE "^find [a-z ]+ -name 'SKILL\.md'" scripts/validate-integrity.sh \
+    | sed -E "s/^find //; s/ -name 'SKILL\.md'\$//" | tr -s ' ' '\n' | sed '/^$/d' | sort || true)
+  if [ -z "$a10_find_flat" ] || [ -z "$a10_find_nested" ]; then
+    echo "FAIL: A10 could not extract B5's find pathspecs -- that site is UNCHECKED"
+    failed=1; a10_fail=1
+  else
+    a10_checked_find=1
+    if [ "$a10_find_flat" != "$a10_flat" ]; then
+      echo "FAIL: B5's flat find walks [$(printf '%s' "$a10_find_flat" | tr '\n' ' ')] but the non-nested trees are [$(printf '%s' "$a10_flat" | tr '\n' ' ')]"
+      failed=1; a10_fail=1
+    fi
+    if [ "$a10_find_nested" != "$a10_nested" ]; then
+      echo "FAIL: B5's SKILL.md find walks [$(printf '%s' "$a10_find_nested" | tr '\n' ' ')] but the nested trees are [$(printf '%s' "$a10_nested" | tr '\n' ' ')]"
+      failed=1; a10_fail=1
+    fi
+  fi
 
   # A10d: this job must actually RUN when one of the files A10 reads changes.
   #
@@ -539,7 +589,7 @@ else
       | sed -E 's/^Use: //' | tr ',' ' ' | tr -s ' ' '\n' | sed '/^$/d' | sort || true)"
 fi
 
-[ "$a10_fail" -eq 0 ] && echo "OK: $((a10_full + a10_flatsites)) shell/YAML content-type list(s) agree with CONTENT_TYPES ($a10_full full, $a10_flatsites flat)"
+[ "$a10_fail" -eq 0 ] && echo "OK: $((a10_full + a10_flatsites + a10_checked_find * 2)) shell/YAML content-type list(s) agree with CONTENT_TYPES ($a10_loops_full full loop(s), $a10_flatsites flat loop(s), $((a10_full - a10_loops_full)) full surface(s), $((a10_checked_find * 2)) find pathspec(s))"
 
 echo ""
 echo "=== Category B: Structural Integrity ==="

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -378,6 +378,132 @@ while IFS= read -r f; do
 done <<< "$a9_hits"
 [ "$a9_warned" -eq 0 ] && echo "OK: no invocation-phrase/allowed-tools drift (anchored pattern, warn-only)"
 
+# A10: Content-type literals outside JavaScript (#585)
+#
+# #578 routed every JS consumer through `scripts/lib/content-types.js`. Three consumers are not
+# JavaScript and cannot import it: two shell loops and one shell `case`. #584's PR body asserted
+# the remaining literals "survive only inside a comment" -- true of A8's `case` arms, false of
+# the repo, generalised from one site.
+#
+# So this ASSERTS rather than shares. A check beats a share when the languages differ, and it
+# is the only option available here: this job runs `setup-node` with deliberately NO `npm ci`
+# (the constraint A8 documents), and a shell script cannot import an ESM binding regardless.
+# The SSOT is therefore read the way A8 reads MANAGED -- a static `sed` parse of the JS source.
+#
+# Two legal derivations, not one. `validate-translations.yml:59` iterates `agents teams guides`
+# and is CORRECT to: it globs `"$locale_dir"*.md`, which finds nothing under the nested
+# `skills/<id>/SKILL.md` layout. A rule demanding every loop equal CONTENT_TYPES would fire on
+# it. So the flat form is derived too, from the `NESTING` record in check-i18n-fence-parity.js
+# -- the same record that throws there on an unclassified tree, which makes it the cross-language
+# source for the nesting fact rather than a second literal invented here.
+#
+# Every extraction below fails CLOSED. A pattern that drifts and matches nothing reports FAIL,
+# never OK: a silent zero is the vacuous pass this whole check exists to prevent, and it is the
+# same shape #578's first `NESTED.has(dir)` predicate had.
+echo "--- A10: Content-type literals outside JavaScript ---"
+a10_fail=0
+a10_flat=""
+# Counted separately, because they mean different things: `a10_full` is surfaces required to
+# carry every tree, `a10_flatsites` is surfaces legitimately carrying only the non-nested ones.
+# Reported rather than asserted -- the assertion is per site, against the form that site's own
+# behaviour requires. An earlier version asserted on the COUNT instead, which passed while a
+# full loop degraded to flat.
+a10_full=0
+a10_flatsites=0
+
+a10_all=$(sed -n 's/^export const CONTENT_TYPES = Object.freeze(\[\(.*\)\]);$/\1/p' scripts/lib/content-types.js \
+  | tr -d "'\"" | tr ',' ' ' | tr -s ' ' '\n' | sed '/^$/d' | sort || true)
+a10_nested=$(sed -n 's/^const NESTING = {\(.*\)};$/\1/p' scripts/check-i18n-fence-parity.js \
+  | tr ',' '\n' | grep -E ':[[:space:]]*true' | sed -E 's/^[[:space:]]*//; s/[[:space:]]*:.*//' | sed '/^$/d' | sort || true)
+
+# Compare one extracted list against the full SSOT. Order is ignored -- these are loop and case
+# arms, where order carries no meaning -- but duplicates are not, hence `sort` and not `sort -u`.
+a10_expect_all() { # <label> <sorted-newline-list>
+  a10_full=$((a10_full + 1))
+  if [ -z "$2" ]; then
+    echo "FAIL: A10 extracted no content types from $1 -- the pattern drifted, so that site is UNCHECKED"
+    failed=1; a10_fail=1
+  elif [ "$2" != "$a10_all" ]; then
+    echo "FAIL: $1 lists [$(printf '%s' "$2" | tr '\n' ' ')] but CONTENT_TYPES is [$(printf '%s' "$a10_all" | tr '\n' ' ')]"
+    failed=1; a10_fail=1
+  fi
+}
+
+if [ -z "$a10_all" ] || [ -z "$a10_nested" ]; then
+  echo "FAIL: A10 could not parse CONTENT_TYPES and/or NESTING -- every site below would go UNCHECKED"
+  failed=1; a10_fail=1
+else
+  a10_flat=$(printf '%s\n' "$a10_all" | grep -vxF -f <(printf '%s\n' "$a10_nested") || true)
+  if [ "$a10_flat" = "$a10_all" ]; then
+    echo "FAIL: A10 derived no nested trees from NESTING, so the flat form cannot be told from the full one"
+    failed=1; a10_fail=1
+  fi
+
+  # Every `for content_type in` loop in both files, matched by pattern rather than by line
+  # number so a THIRD loop added later is checked too, instead of being invisible to a
+  # hardcoded inventory.
+  #
+  # Which form a loop SHOULD take is derived from what the loop does, not from a list kept
+  # here. A loop that branches on a nested tree (`[ "$content_type" = "skills" ]`) must iterate
+  # the full list, because that branch is dead otherwise. A loop that does not branch --
+  # validate-translations.yml:59, which globs `"$locale_dir"*.md` -- must iterate the flat
+  # subset, because the nested layout puts nothing where that glob looks.
+  #
+  # The weaker rule this replaces ("at least one loop iterates the full list") let a full loop
+  # silently degrade to the flat form whenever another full loop survived. Measured: dropping
+  # `skills` from validate-translations.yml:81 left A10 reporting OK at exit 0, while CI stopped
+  # checking every skill mirror for an orphaned source.
+  a10_nested_re=$(printf '%s' "$a10_nested" | paste -sd'|' - || true)
+  for a10_file in scripts/validate-integrity.sh .github/workflows/validate-translations.yml; do
+    a10_hits=$(grep -nE 'for content_type in [a-z ]+; do' "$a10_file" 2>/dev/null || true)
+    # Per FILE, not once overall. A pattern that still matches the other file would otherwise
+    # satisfy a global check while this file went entirely unread -- measured: renaming the
+    # loop variable in validate-integrity.sh left the old global guard silent.
+    if [ -z "$a10_hits" ]; then
+      echo "FAIL: A10 found no 'for content_type in' loop in $a10_file -- the pattern drifted, so that file is UNCHECKED"
+      failed=1; a10_fail=1
+      continue
+    fi
+    # Herestring, not a pipe: a `while` on the right of a pipe runs in a subshell, where
+    # `failed=1` would be discarded and the whole check would report OK while finding violations.
+    while IFS= read -r a10_hit; do
+      [ -z "$a10_hit" ] && continue
+      a10_line=${a10_hit%%:*}
+      a10_list=$(printf '%s' "$a10_hit" | grep -oE 'for content_type in [a-z ]+; do' \
+        | sed -E 's/^for content_type in //; s/; do$//' | tr -s ' ' '\n' | sed '/^$/d' | sort || true)
+      # The branch sits 4 lines into both real cases; 10 is margin. A restructure that moves it
+      # further reads here as "flat loop with a full list" and FAILS -- loud and worth reading,
+      # which is the right direction for a heuristic window.
+      if sed -n "${a10_line},$((a10_line + 10))p" "$a10_file" | grep -qE "= \"($a10_nested_re)\""; then
+        a10_want="$a10_all"; a10_form="full (it branches on a nested tree)"
+      else
+        a10_want="$a10_flat"; a10_form="flat (it never branches on a nested tree)"
+      fi
+      if [ "$a10_list" = "$a10_want" ]; then
+        if [ "$a10_want" = "$a10_all" ]; then a10_full=$((a10_full + 1)); else a10_flatsites=$((a10_flatsites + 1)); fi
+      else
+        echo "FAIL: $a10_file:$a10_line iterates [$(printf '%s' "$a10_list" | tr '\n' ' ')] but must be $a10_form: [$(printf '%s' "$a10_want" | tr '\n' ' ')]"
+        failed=1; a10_fail=1
+      fi
+    done <<< "$a10_hits"
+  done
+
+  # translate-content.sh. The `case` arms are the ACCEPT-RULE -- what the scaffolder will and
+  # will not act on. The other two describe that rule to a human, and a description that
+  # disagrees with the rule is a lie someone reads while debugging.
+  a10_expect_all "scripts/translate-content.sh case arms (the accept-rule)" \
+    "$(sed -n '/^case "\$CONTENT_TYPE" in$/,/^esac$/p' scripts/translate-content.sh \
+      | grep -oE '^  [a-z]+\)$' | tr -d ' )' | sort || true)"
+  a10_expect_all "scripts/translate-content.sh usage line" \
+    "$(grep -oE 'content-type: [a-z |]+' scripts/translate-content.sh \
+      | sed -E 's/^content-type: //' | tr '|' ' ' | tr -s ' ' '\n' | sed '/^$/d' | sort || true)"
+  a10_expect_all "scripts/translate-content.sh unknown-type message" \
+    "$(grep -oE 'Use: [a-z, ]+' scripts/translate-content.sh \
+      | sed -E 's/^Use: //' | tr ',' ' ' | tr -s ' ' '\n' | sed '/^$/d' | sort || true)"
+fi
+
+[ "$a10_fail" -eq 0 ] && echo "OK: $((a10_full + a10_flatsites)) shell/YAML content-type list(s) agree with CONTENT_TYPES ($a10_full full, $a10_flatsites flat)"
+
 echo ""
 echo "=== Category B: Structural Integrity ==="
 


### PR DESCRIPTION
Closes #585.

Adds integrity check **A10**, which asserts the six non-JavaScript content-type
lists against `scripts/lib/content-types.js` rather than sharing it — a shell
script cannot import an ESM binding, and `validate-integrity.yml` runs with
`setup-node` and deliberately **no `npm ci`** (the constraint A8 documents). The
SSOT is read the way A8 reads `MANAGED`: a static `sed` parse of the JS source.

## The issue's inventory was incomplete in two ways

**Six sites, not three.** `ripgrep` skips dot-directories without `--hidden`,
which is how `.github/workflows/validate-translations.yml` nearly went
unexamined — the sweep returning the shape of its own boundary rather than the
shape of the repo.

| site | form |
|---|---|
| `scripts/validate-integrity.sh:626` (B6) | full |
| `.github/workflows/validate-translations.yml:81` | full |
| `.github/workflows/validate-translations.yml:59` | **flat** |
| `scripts/translate-content.sh` case arms | full (the accept-rule) |
| `scripts/translate-content.sh` usage line | full |
| `scripts/translate-content.sh` unknown-type message | full |

**Not every loop should carry every tree.** `validate-translations.yml:59`
iterates `agents teams guides` and is *correct* to: it globs
`"$locale_dir"*.md`, which finds nothing under the nested `skills/<id>/SKILL.md`
layout. A rule demanding every loop equal `CONTENT_TYPES` would have shipped a
false positive straight into CI.

So A10 derives **two** legal forms. The flat one comes from the `NESTING` record
in `check-i18n-fence-parity.js` — the same record that throws there on an
unclassified tree — making it the cross-language source for the nesting fact
rather than a second literal invented in shell.

## The count-based rule was the defect

The first version asserted "at least one loop iterates the full list". Measured,
that let a full loop degrade to the **exact** flat form whenever another full
loop survived: dropping `skills` from `validate-translations.yml:81` left A10
reporting **OK at exit 0**, while CI stopped checking every skill mirror for an
orphaned source.

Replaced with a per-site rule read off the loop's own body — the consumer's
accept-rule, not a proxy for it:

- branches on a nested tree (`[ "$content_type" = "skills" ]`) → **must** iterate the full list, because that branch is dead otherwise
- never branches → **must** iterate the flat subset, because the nested layout puts nothing where its glob looks

Both real full loops carry that branch four lines in; the flat one does not.

Sites are matched by pattern, not line number, so a third loop added later is
checked rather than invisible to a hardcoded inventory. The "found nothing"
guard is per **file**, not global — a pattern still matching the other file
would otherwise satisfy a global check while this one went entirely unread.
Every extraction fails **closed**: a drifted pattern reports FAIL, never OK.

## Proving it can fail

Ten mutations, each applied to the real file and run against the real
`bash scripts/validate-integrity.sh` — the command CI runs, not an extracted
copy — then restored from an in-memory buffer. Each names the A10 message it
expects, so a run that merely goes red for another reason is not counted as a
kill.

```
baseline (expect green) ... green.

[KILLED] fifth tree added to the SSOT
[KILLED] SSOT parse broken (const renamed)
[KILLED] NESTING names a tree the SSOT does not have
[KILLED] a tree dropped from the full loop in validate-integrity.sh
[KILLED] a tree dropped from the full loop in the CI workflow
[KILLED] one full loop degrades to the exact flat form
[KILLED] a loop keeps the full list after losing its nested branch
[KILLED] a case arm removed from the scaffolder's accept-rule
[KILLED] the unknown-type message drifts from the accept-rule
[KILLED] the loop pattern drifts in one file so that file is unread

restored; baseline re-run exit=0
```

Three of those started as **SURVIVORS**. Two were fixture errors — `skills: 1`
empties the nesting list and is caught one guard earlier by a different message,
and the "both loops" case only degraded one of them. The third was the real
defect above.

The reverse-direction case is deliberate: a loop that *loses* its nested branch
but keeps the full list must also fail, so the rule is two-sided rather than a
rubber stamp that only ever demands more trees.

## Left alone deliberately

`scripts/test/readme-sections.test.js`'s four-tree literal now carries a comment
saying why it must **not** be routed through the SSOT. A fixture deriving its
expectation from the subject cannot detect the subject's corruption — reorder
`CONTENT_TYPES` and every assertion would move with it and report green. Derive
when the literal is an *input*; hardcode when it is the *expectation*.

## Checks

| check | result |
|---|---|
| `bash scripts/validate-integrity.sh` | PASSED — `OK: 6 shell/YAML content-type list(s) agree with CONTENT_TYPES (5 full, 1 flat)` |
| negative envelope | 10/10 killed, baseline green before and after |
| `npm run test:scripts` | 277 pass, 0 fail |
| `npm run validate:line-endings` | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8
