### PR TITLE
feat(i18n): close the retag escape with tag-sequence parity (#481, #583)

### DIFF
--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -66,12 +66,10 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { assertNotShallow } from './lib/git-freshness.js';
-import { extractFences, buildEnglishFenceHistory, isGated } from './lib/fences.js';
+import { extractFences, buildEnglishFenceHistory, isGated, foldedTagSequence } from './lib/fences.js';
 import { CONTENT_TYPES } from './lib/content-types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = resolve(__dirname, '..');
-const I18N_DIR = resolve(ROOT, 'i18n');
 
 const WARN_ONLY = process.argv.includes('--warn');
 const SHOW_ALL = process.argv.includes('--all');
@@ -93,6 +91,26 @@ function flagValue(name, fallback) {
   }
   return v;
 }
+
+/**
+ * The repo to check. Defaults to this one, which is how every real invocation uses it.
+ *
+ * It exists as a flag because the gate was otherwise untestable end to end, and that gap was
+ * not theoretical: deleting the blocking flag from the tag-sequence finding SURVIVED against the
+ * whole suite, meaning every such finding could stop being blocking with 298 tests still green.
+ * Three component-level mutation kills had been quoted as coverage for a path nothing executed.
+ *
+ * The flag is deliberately NOT quoted verbatim here. Spelling it out made this comment a second
+ * match site for the very mutation it describes, and `mutation-check` refused the run rather than
+ * guessing which site to mutate — the same collision the A10 envelope hit hours earlier, where
+ * a comment quoting `find agents teams guides ...` doubled its own case.
+ *
+ * Third time this exact shape has appeared here — `buildEnglishFenceHistory()` closing over its
+ * module root (#559), `gate-envelope.js` before `--root`, and now this. The rule it keeps
+ * teaching: a module that hardcodes its own repo root cannot be tested, so it will not be.
+ */
+const ROOT = resolve(flagValue('--root', resolve(__dirname, '..')));
+const I18N_DIR = resolve(ROOT, 'i18n');
 
 const LIMIT = Number(flagValue('--limit', '40'));
 if (!Number.isFinite(LIMIT)) { console.error('ERROR: --limit must be a number'); process.exit(2); }
@@ -156,21 +174,100 @@ export function collectTargets() {
   return out;
 }
 
+/**
+ * Does this translation's folded tag sequence exist in English?
+ *
+ * #481: the retag escape. `isGated` reads the info string off the TRANSLATION, so retagging a
+ * frozen ```yaml fence to ```text removes it from the body check entirely — the set of fences
+ * under the gate is chosen by the file being gated. Default-deny narrowed that escape to
+ * {text, markdown, md} without closing it, and #583 records that the status detector's
+ * accidental tripwire for the same escape was removed in #582, leaving this the only cover.
+ *
+ * Staleness-immune by the same construction as the body check: the sequence must match SOME
+ * English revision, never HEAD. A stale translation legitimately carries an older sequence.
+ *
+ * @param {string[]} mine folded tag sequence of the translation
+ * @param {Set<string>|undefined} englishSequences joined folded sequences from every revision
+ * @returns {null | {unalignable: true} | {positions: {index: number, english: string, translated: string}[]}}
+ */
+export function compareTagSequence(mine, englishSequences) {
+  if (!englishSequences || englishSequences.has(mine.join(','))) return null;
+
+  // `''.split(',')` is `['']` — length 1, not 0. A source revision with NO fences joins to the
+  // empty string, so the naive length made it look like a one-fence revision, matched it against
+  // every one-fence translation, and compared position 1 against `undefined`. That fabricated 3
+  // findings reading `#1 ->markdown`, and it was caught only because an independent measurement
+  // of the same property disagreed by exactly 3 — not by any test.
+  const lengthOf = (seq) => (seq === '' ? 0 : seq.split(',').length);
+  const sameLength = [...englishSequences].filter((seq) => lengthOf(seq) === mine.length);
+
+  // NOT a violation. With a different number of fences there is no positional correspondence to
+  // claim anything about, and a translation predating a fence English later gained lands here —
+  // calling that a violation reintroduces exactly the staleness confound this gate avoids.
+  if (sameLength.length === 0) return { unalignable: true };
+
+  // Report against the count-matched revision differing in the FEWEST positions — the nearest
+  // legal basis. An arbitrary one inflates a single retag into wholesale divergence.
+  let best = null;
+  for (const candidate of sameLength) {
+    const other = candidate === '' ? [] : candidate.split(',');
+    const diff = mine
+      .map((tag, i) => ({ index: i + 1, english: other[i], translated: tag }))
+      .filter((d) => d.english !== d.translated);
+    if (!best || diff.length < best.length) best = diff;
+  }
+  return { positions: best };
+}
+
 function main() {
   assertNotShallow(ROOT);
 
-  const history = buildEnglishFenceHistory();
+  const history = buildEnglishFenceHistory(ROOT);
   const findings = [];
   let filesCompared = 0;
   let fencesCompared = 0;
   let ungatedDivergences = 0;
+  let tagSequenceUnalignable = 0;
 
   for (const t of collectTargets()) {
     const englishFences = history.get(`${t.tree}/${t.id}`);
     if (!englishFences) continue; // orphan: check-i18n-frontmatter-parity.js owns that
 
     filesCompared++;
-    for (const fence of extractFences(readFileSync(t.absPath, 'utf8'))) {
+    const translatedFences = extractFences(readFileSync(t.absPath, 'utf8'));
+
+    // #481: the retag escape. `isGated` reads the info string off the TRANSLATION, so retagging
+    // a frozen ```yaml fence to ```text removes it from the loop below entirely — the set of
+    // fences under the gate is chosen by the file being gated. Default-deny narrowed that escape
+    // to {text, markdown, md} without closing it, and #583 records that the status detector's
+    // accidental tripwire for the same escape was removed in #582, leaving this the only cover.
+    //
+    // Staleness-immune by the same construction as the body check: the sequence must match SOME
+    // English revision, never HEAD. A stale translation legitimately carries an older sequence.
+    //
+    // Count-mismatched pairs are NOT violations. With a different number of fences there is no
+    // positional correspondence to claim anything about, and a translation predating a fence
+    // English later gained lands here — calling that a violation reintroduces exactly the
+    // staleness confound this gate exists to avoid.
+    const seqVerdict = compareTagSequence(
+      foldedTagSequence(translatedFences), history.sequences.get(`${t.tree}/${t.id}`),
+    );
+    if (seqVerdict?.unalignable) {
+      tagSequenceUnalignable++;
+    } else if (seqVerdict) {
+      findings.push({
+        file: t.relPath,
+        line: translatedFences[seqVerdict.positions[0].index - 1]?.line ?? 1,
+        locale: t.locale,
+        skill: t.id,
+        tag: seqVerdict.positions.map((p) => `#${p.index} ${p.english}->${p.translated}`).join(', '),
+        gated: true,
+        kind: 'tag-sequence',
+        firstDivergentLine: `fence tag sequence appears in no English revision (${seqVerdict.positions.length} position(s) differ)`,
+      });
+    }
+
+    for (const fence of translatedFences) {
       fencesCompared++;
       if (englishFences.has(fence.body)) continue;
       const gated = isGated(fence);
@@ -209,6 +306,8 @@ function main() {
       filesCompared, fencesCompared,
       violations: blocking.length,
       ungatedDivergences,
+      tagSequenceFindings: findings.filter((f) => f.kind === 'tag-sequence').length,
+      tagSequenceUnalignable,
       findings,
     }, null, 2));
     process.exitCode = blocking.length > 0 && !WARN_ONLY ? 1 : 0;
@@ -224,8 +323,9 @@ function main() {
     console.log(`... ${findings.length - LIMIT} more (use --limit ${findings.length} to see all, or --json)`);
   }
 
+  const tagSeq = blocking.filter((f) => f.kind === 'tag-sequence');
   const byTag = new Map();
-  for (const f of blocking) byTag.set(f.tag, (byTag.get(f.tag) || 0) + 1);
+  for (const f of blocking.filter((f) => f.kind !== 'tag-sequence')) byTag.set(f.tag, (byTag.get(f.tag) || 0) + 1);
   const byLocale = new Map();
   for (const f of blocking) byLocale.set(f.locale, (byLocale.get(f.locale) || 0) + 1);
 
@@ -241,6 +341,28 @@ function main() {
     console.log(`by locale: ${[...byLocale.entries()].sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}=${v}`).join('  ')}`);
     console.log('\nFix: restore the English fence body verbatim. Code blocks are keep-in-English');
     console.log('(CLAUDE.md § Translation Rules, i18n/README.md). Translate the surrounding prose only.');
+  }
+  if (tagSeq.length) {
+    // Reported apart from body divergences because the remedy differs: a body divergence is
+    // repaired by restoring the English text, a tag-sequence finding by restoring the fence
+    // STRUCTURE — and the two most common causes need different judgement. Measured at
+    // introduction across 3,584 count-matched pairs: 9 findings, of which 3 were a frozen tag
+    // becoming localisable (the #481 escape proper, and in `escalate-issues` caused by a
+    // 4-backtick opener degraded to 3, which swallows the next fence whole) and 6 were
+    // partial-update drift on stale files. Read the file before repairing it.
+    console.log(`\n${tagSeq.length} fence tag-sequence finding(s) — a structure appearing in NO English revision.`);
+    console.log('These are the retag escape (#481): a frozen tag changed to text/markdown/md leaves');
+    console.log('the body check entirely, because gating is read off the translated file.');
+    for (const f of tagSeq.slice(0, LIMIT)) console.log(`  ${f.file}  ${f.tag}`);
+    if (tagSeq.length > LIMIT) console.log(`  ... ${tagSeq.length - LIMIT} more`);
+  }
+  if (tagSequenceUnalignable) {
+    // Deliberately not a finding. No English revision has that fence COUNT, so there is no
+    // positional correspondence to make a claim about; a stale translation predating a fence
+    // English later gained lands here. Counting them keeps the omission visible rather than
+    // silent — the population is unmeasured otherwise.
+    console.log(`\n${tagSequenceUnalignable} file(s) unjudged for tag sequence — no English revision has their fence count.`);
+    console.log('Not violations: without a count match there is no position to compare (staleness, #481).');
   }
   if (ungatedDivergences) {
     // Deliberately does NOT say "untagged": untagged fences are frozen under

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -114,14 +114,20 @@ export { contentKey };
  * It exists as a parameter because it did NOT before, and that was the reason this half of the
  * duplicated walk had no test: nothing could point it at a fixture repo (#559).
  *
+ * Also pooled, from the same walk: every folded TAG SEQUENCE each source has carried
+ * (`history.sequences`), which is the basis for the retag check (#481). Collected here rather
+ * than in a third builder for the reason #559 exists — a third near-identical walk is exactly
+ * the duplication that issue removed.
+ *
  * @param {string} [root] repository root
- * @returns {Map<string, Set<string>> & {current: Map<string, Fence[]>}}
+ * @returns {Map<string, Set<string>> & {current: Map<string, Fence[]>, sequences: Map<string, Set<string>>}}
  */
 export function buildEnglishFenceHistory(root = ROOT) {
   const history = new Map();
   // Kept separately, keyed the same way: the deleted-fence check needs the fences English has
   // NOW, with their tags, not the flattened union of every body that ever existed.
   const current = new Map();
+  const sequences = new Map();
 
   walkEnglishHistory(root, (key, text, { fromWorkingTree }) => {
     if (!history.has(key)) history.set(key, new Set());
@@ -129,10 +135,63 @@ export function buildEnglishFenceHistory(root = ROOT) {
     const fences = extractFences(text);
     for (const f of fences) set.add(f.body);
     if (fromWorkingTree) current.set(key, fences);
+    if (!sequences.has(key)) sequences.set(key, new Set());
+    sequences.get(key).add(foldedTagSequence(fences).join(','));
   });
 
   history.current = current;
+  history.sequences = sequences;
   return history;
+}
+
+/**
+ * A document's fence tags in order, with untagged folded to `text`.
+ *
+ * The fold is not cosmetic and must not be dropped. `normalize-content-style.js --mode fences`
+ * retro-tagged untagged blocks as `text` on the NEWER side only, so an untagged fence facing a
+ * `text` one is an artifact of a repo tool rather than a translator action. Without the fold,
+ * every one of those pairings reads as a retag.
+ *
+ * Equally, this must NOT be expressed as `isGated(a) !== isGated(b)`. Under default-deny an
+ * untagged fence is gated while `text` is not, so that formulation makes the same benign
+ * pairings misalignments — it stranded 169 mechanically-repairable fences across 73 files when
+ * `normalize-i18n-fences.js` tried it, and the comment there records why.
+ *
+ * ALL fences, not just gated ones. The retag this detects is precisely a fence LEAVING the gated
+ * set, so a gated-only sequence cannot see it — that is the tripwire #582 removed from the
+ * status detector's `fenceShape` and #583 records the loss of. `fenceShape` stays gated-only
+ * because it answers a different question (is the frozen-region mask trustworthy?).
+ *
+ * The fold is on the INFO STRING being empty, not on `lang` being empty, and the difference is
+ * load-bearing. `lang` is also `''` for a brace info string — ` ```{r} `, ` ```{r setup} ` —
+ * because the split at the bottom of this module breaks on `{`. Brace fences are frozen under
+ * default-deny exactly like untagged ones, so folding them to `text` would let an English
+ * ` ```{r} ` fence be replaced by a localisable ` ```text ` one with neither this check nor the
+ * body check seeing it: the retag escape surviving through its own fix. They get the same `{`
+ * placeholder `fenceShape` uses, whose comment already records the lesson — "a 'cannot happen'
+ * margin is exactly how this module keeps getting bypassed". Zero top-level brace fences exist
+ * today, which is the argument for encoding it now rather than after one appears.
+ *
+ * Unterminated fences ARE included, unlike in `fenceShape`, and the choice is not free either
+ * way. `fenceShape` filters them because an unterminated fence masks nothing (#558). Here the
+ * sequence is a structural claim, and a degradation near EOF that leaves a fence open is a real
+ * corruption this should see; excluding them would demote it to `unalignable`. The cost is that
+ * a translation carrying #558's stray-opener artifact gains a phantom token — usually a count
+ * mismatch, so unjudged rather than a false finding. Measured over all 3,644 translated files at
+ * introduction: 0 carry an unterminated fence and 0 carry a top-level brace-info fence, so both
+ * choices above are free TODAY and are made on their merits rather than on cost. Re-measure
+ * before assuming that still holds — `scripts/measure-tag-sequence-parity.js` is the reproducer
+ * for the finding set, and neither number is pinned by a gate.
+ *
+ * @param {Fence[]|string} input fences, or text to extract them from
+ * @returns {string[]}
+ */
+export function foldedTagSequence(input) {
+  const fences = typeof input === 'string' ? extractFences(input) : input;
+  return fences.map((f) => {
+    if (f.lang !== '') return f.lang;
+    return f.info === '' ? 'text' : '{';
+  });
 }
 
 /**

--- a/scripts/test/tag-sequence-parity.test.js
+++ b/scripts/test/tag-sequence-parity.test.js
@@ -1,0 +1,243 @@
+/**
+ * Tag-sequence parity — the retag escape (#481), and the tripwire #582 removed (#583).
+ *
+ * The body check decides what to enforce from the info string of the TRANSLATION, so retagging a
+ * frozen ```yaml fence to ```text removes it from enforcement entirely: the set of fences under
+ * the gate is chosen by the file being gated. Default-deny narrowed the escape to
+ * {text, markdown, md} without closing it.
+ *
+ * `fenceShape` in the status detector used to catch this by accident, because it counted ALL
+ * terminated fences and a retag changed the shape. #582 narrowed it to gated fences only — for
+ * good reasons, a 62-file false-positive class — and the accidental cover went with it. Nothing
+ * pinned the old behaviour, which is how it was lost silently; that is what these tests exist to
+ * prevent happening twice.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+import { foldedTagSequence, extractFences, buildEnglishFenceHistory } from '../lib/fences.js';
+import { compareTagSequence } from '../check-i18n-fence-parity.js';
+
+const fence = (tag, body) => ['```' + tag, body, '```', ''].join('\n');
+const CHECKER = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'check-i18n-fence-parity.js');
+
+test('untagged folds to `text`, and the fold is not optional', () => {
+  // `normalize-content-style.js --mode fences` retro-tagged untagged blocks as `text` on the
+  // NEWER side only. Without the fold, every one of those pairings reads as a retag.
+  assert.deepEqual(foldedTagSequence('```\nx\n```\n'), ['text']);
+  assert.deepEqual(foldedTagSequence('```yaml\nx\n```\n\n```\ny\n```\n'), ['yaml', 'text']);
+});
+
+test('ALL fences are sequenced, not only gated ones — that is the whole point', () => {
+  // A gated-only sequence cannot see a retag, because the retag is precisely a fence LEAVING the
+  // gated set. This is the property #582 removed from `fenceShape` and #583 records the loss of.
+  const doc = `${fence('yaml', 'a: 1')}${fence('text', 'notes')}${fence('bash', 'ls')}`;
+  assert.deepEqual(foldedTagSequence(doc), ['yaml', 'text', 'bash']);
+  const retagged = doc.replace('```yaml', '```text');
+  assert.deepEqual(foldedTagSequence(retagged), ['text', 'text', 'bash']);
+  assert.notDeepEqual(foldedTagSequence(doc), foldedTagSequence(retagged),
+    'a retag must change the sequence, or the escape stays open');
+});
+
+test('a sequence matching some English revision is clean, even an OLD one', () => {
+  // Staleness immunity, the constraint that kills the naive comparison: 2,549 translations are
+  // stale, and comparing against HEAD reports drift nobody introduced.
+  const english = new Set(['yaml,bash', 'yaml,bash,text', 'r,r']);
+  assert.equal(compareTagSequence(['yaml', 'bash'], english), null, 'an older revision is a legal basis');
+  assert.equal(compareTagSequence(['yaml', 'bash', 'text'], english), null);
+});
+
+test('the #481 escape is caught: a frozen tag retagged to a localisable one', () => {
+  const english = new Set(['text,markdown,python']);
+  const verdict = compareTagSequence(['text', 'markdown', 'text'], english);
+  assert.deepEqual(verdict.positions, [{ index: 3, english: 'python', translated: 'text' }]);
+});
+
+test('a count mismatch is UNALIGNABLE, never a violation', () => {
+  // Without a count match there is no position to compare. A translation predating a fence
+  // English later gained lands here, and calling that a violation reintroduces the staleness
+  // confound the gate exists to avoid.
+  const english = new Set(['yaml,bash,text']);
+  assert.deepEqual(compareTagSequence(['yaml', 'bash'], english), { unalignable: true });
+});
+
+test('an empty English revision has length 0, not 1', () => {
+  // Regression. `''.split(',')` is `['']`, so a source revision with NO fences looked like a
+  // one-fence revision, matched every one-fence translation, and compared position 1 against
+  // `undefined` — fabricating findings that read `#1 ->markdown`. Caught only because an
+  // independent measurement of the same property disagreed by exactly 3; no test saw it.
+  const english = new Set(['', 'markdown']);
+  assert.equal(compareTagSequence(['markdown'], english), null, 'the 1-fence revision matches');
+  assert.deepEqual(compareTagSequence(['r'], english), {
+    positions: [{ index: 1, english: 'markdown', translated: 'r' }],
+  }, 'the empty revision must not be offered as a 1-fence basis');
+  assert.deepEqual(compareTagSequence([], english), null, 'an empty translation matches the empty revision');
+});
+
+test('the nearest basis is reported, not an arbitrary one', () => {
+  // An arbitrary count-matched revision inflates a single retag into wholesale divergence and
+  // makes the finding unreadable.
+  const english = new Set(['a,b,c', 'x,y,z']);
+  const verdict = compareTagSequence(['a', 'b', 'z'], english);
+  assert.equal(verdict.positions.length, 1);
+  assert.deepEqual(verdict.positions[0], { index: 3, english: 'c', translated: 'z' });
+});
+
+test('a source with no English history at all yields no finding', () => {
+  // Orphans are check-i18n-frontmatter-parity.js's job, not this gate's.
+  assert.equal(compareTagSequence(['yaml'], undefined), null);
+});
+
+test('buildEnglishFenceHistory pools a sequence per revision, from the same walk', () => {
+  // Reachable as a test only because #559 gave the builder a `root` parameter.
+  const dir = mkdtempSync(join(tmpdir(), 'aa-tagseq-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+    mkdirSync(join(dir, 'skills', 'demo'), { recursive: true });
+
+    writeFileSync(join(dir, 'skills', 'demo', 'SKILL.md'), `# Demo\n\n${fence('yaml', 'a: 1')}`);
+    git('add', '-A'); git('commit', '-qm', 'one fence');
+
+    writeFileSync(join(dir, 'skills', 'demo', 'SKILL.md'),
+      `# Demo\n\n${fence('yaml', 'a: 1')}${fence('python', 'x = 1')}`);
+    git('add', '-A'); git('commit', '-qm', 'two fences');
+
+    const seqs = buildEnglishFenceHistory(dir).sequences.get('skills/demo');
+    assert.ok(seqs.has('yaml'), 'the older one-fence revision is pooled');
+    assert.ok(seqs.has('yaml,python'), 'and the current two-fence one');
+
+    // Which is what makes staleness immunity real rather than asserted: a translation still on
+    // the one-fence structure is clean.
+    assert.equal(compareTagSequence(['yaml'], seqs), null);
+    // While a retag of the current structure is not.
+    assert.deepEqual(compareTagSequence(['yaml', 'text'], seqs).positions,
+      [{ index: 2, english: 'python', translated: 'text' }]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a swallowed 4-backtick opener changes the sequence — the corpus case', () => {
+  // The real finding this shipped with. English opens a 4-backtick ````markdown fence containing
+  // a literal ``` block; three translations degraded the opener to 3 backticks, so it closes
+  // early and the NEXT fence's body is absorbed into a `text` block. The frozen code stops being
+  // a fence at all, which is why the body check is structurally blind to it.
+  const english = ['# T', '', '````markdown', '```language', 'x', '```', '````', '', '```python', 'y', '```', ''].join('\n');
+  const degraded = english.replace('````markdown', '```markdown').replace('\n````\n', '\n```text\n');
+
+  assert.deepEqual(foldedTagSequence(english), ['markdown', 'python']);
+  assert.equal(extractFences(english)[0].body.includes('```language'), true,
+    'the 4-backtick fence legitimately contains a 3-backtick block');
+
+  const after = foldedTagSequence(degraded);
+  assert.notDeepEqual(after, ['markdown', 'python'], 'degrading the opener must be visible');
+  // `assert.ok(verdict)` would pass on `{unalignable: true}`, which is expressly NOT a finding —
+  // so a future change demoting this class from blocking to unjudged would keep the test green.
+  // Assert the positions.
+  const verdict = compareTagSequence(after, new Set([foldedTagSequence(english).join(',')]));
+  assert.ok(verdict?.positions, 'must be a FINDING, not unjudged');
+  assert.deepEqual(verdict.positions, [{ index: 2, english: 'python', translated: 'text' }]);
+});
+
+test('a brace info string is NOT folded to text — the escape must not survive its own fix', () => {
+  // `lang` is '' for ```{r} as well as for a bare ```, because the info split breaks on `{`.
+  // Brace fences are frozen under default-deny exactly like untagged ones, so folding both to
+  // `text` would let an English ```{r} fence be replaced by a localisable ```text one with
+  // neither this check nor the body check seeing it.
+  assert.deepEqual(foldedTagSequence('```{r}\nx\n```\n'), ['{']);
+  assert.deepEqual(foldedTagSequence('```{r setup, echo=FALSE}\nx\n```\n'), ['{']);
+  assert.notDeepEqual(foldedTagSequence('```{r}\nx\n```\n'), foldedTagSequence('```\nx\n```\n'),
+    'a brace fence and an untagged fence must not collapse to the same token');
+
+  const verdict = compareTagSequence(['text'], new Set(['{']));
+  assert.deepEqual(verdict.positions, [{ index: 1, english: '{', translated: 'text' }],
+    'retagging a brace fence to text is a finding');
+});
+
+test('END TO END: the checker reports a retag as a blocking finding and exits 1', () => {
+  // The gap the review found, and the reason it mattered: `--delete-matching 'gated: true,'`
+  // SURVIVED against the whole 298-test suite. Every tag-sequence finding could stop being
+  // blocking with the suite green, because all three mutation kills quoted as coverage were
+  // component-scoped and nothing executed the checker's enforcement path.
+  //
+  // Runs the real gate as a child process against a fixture repo, which is possible only because
+  // the checker now takes `--root` — the third appearance of the same untestability defect
+  // (#559's builder, gate-envelope, this).
+  const dir = mkdtempSync(join(tmpdir(), 'aa-e2e-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+
+    mkdirSync(join(dir, 'skills', 'demo'), { recursive: true });
+    const englishDoc = `# Demo\n\n${fence('yaml', 'a: 1')}${fence('python', 'x = 1')}`;
+    writeFileSync(join(dir, 'skills', 'demo', 'SKILL.md'), englishDoc);
+    git('add', '-A'); git('commit', '-qm', 'english');
+
+    // The retag: `python` -> `text`. The BODY is byte-identical to English, so the body check
+    // has nothing to say even before gating removes it — this isolates the tag-sequence path.
+    mkdirSync(join(dir, 'i18n', 'de', 'skills', 'demo'), { recursive: true });
+    writeFileSync(join(dir, 'i18n', 'de', 'skills', 'demo', 'SKILL.md'),
+      englishDoc.replace('```python', '```text'));
+
+    const run = (...extra) => spawnSync(process.execPath,
+      [CHECKER, '--root', dir, '--json', ...extra], { encoding: 'utf8' });
+
+    const { status, stdout } = run();
+    const report = JSON.parse(stdout);
+    const seq = report.findings.filter((f) => f.kind === 'tag-sequence');
+
+    assert.equal(seq.length, 1, 'the retag must be found');
+    assert.equal(seq[0].gated, true, 'and must be BLOCKING, not informational');
+    assert.match(seq[0].tag, /#2 python->text/);
+    assert.equal(report.tagSequenceFindings, 1);
+    assert.equal(status, 1, 'the gate must exit non-zero');
+
+    // `--warn` reports the same finding at exit 0. Without this, a mutation making everything
+    // non-blocking would be caught, but one making --warn blocking would not.
+    const warned = run('--warn');
+    assert.equal(warned.status, 0);
+    assert.equal(JSON.parse(warned.stdout).tagSequenceFindings, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('END TO END: an unretagged translation leaves the gate green', () => {
+  // Non-vacuity control for the test above: if the fixture produced a finding for some unrelated
+  // reason, the assertions there would pass for the wrong cause.
+  const dir = mkdtempSync(join(tmpdir(), 'aa-e2e-clean-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+    mkdirSync(join(dir, 'skills', 'demo'), { recursive: true });
+    const englishDoc = `# Demo\n\n${fence('yaml', 'a: 1')}${fence('python', 'x = 1')}`;
+    writeFileSync(join(dir, 'skills', 'demo', 'SKILL.md'), englishDoc);
+    git('add', '-A'); git('commit', '-qm', 'english');
+
+    mkdirSync(join(dir, 'i18n', 'de', 'skills', 'demo'), { recursive: true });
+    writeFileSync(join(dir, 'i18n', 'de', 'skills', 'demo', 'SKILL.md'),
+      englishDoc.replace('# Demo', '# Demo auf Deutsch'));
+
+    const r = spawnSync(process.execPath, [CHECKER, '--root', dir, '--json'], { encoding: 'utf8' });
+    const report = JSON.parse(r.stdout);
+    assert.equal(report.tagSequenceFindings, 0);
+    assert.equal(report.filesCompared, 1, 'the fixture must actually have been compared');
+    assert.equal(r.status, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #481. Closes #583.

## The escape

The fence-parity gate decides what to enforce from the info string of the
**translation**. `isGated(fence)` reads `fence.lang` off the translated file, and
the English history stores only `f.body` — the info string is never compared. So
the set of fences under the gate is chosen by the file being gated, and
retagging a frozen ` ```yaml ` fence to ` ```text ` removes it from enforcement
entirely.

#479's default-deny narrowed that escape from unbounded to `{text, markdown, md}`
without closing it, and `lib/fences.js` says so in a comment. #583 records that
the status detector carried an *accidental* tripwire for the same escape —
`fenceShape` counted **all** terminated fences, so a retag changed the shape —
and that #582 narrowed it to gated fences only, for good reasons (a 62-file
false-positive class), taking the accidental cover with it. Nothing pinned the
old behaviour, which is why it was lost silently.

## Design

Staleness kills the naive comparison: 2,549 translations are stale, so comparing
tags against HEAD reports drift nobody introduced. The answer is the one the body
check already uses — the sequence must match **some** English revision, never
HEAD.

| decision | why |
|---|---|
| untagged folds to `text` | `normalize-content-style.js --mode fences` retro-tagged untagged blocks on the newer side only; that pairing is a repo tool's artifact |
| **not** `isGated(a) !== isGated(b)` | under default-deny untagged is gated and `text` is not, so that formulation makes the benign pairings misalignments — it stranded 169 repairable fences across 73 files when tried |
| **all** fences sequenced, not gated-only | the retag is precisely a fence *leaving* the gated set, so a gated-only sequence cannot see it |
| count mismatch → **unjudged** | no positional correspondence exists to make a claim about; a translation predating a fence English later gained lands here |

Both foldings are lifted from `normalize-i18n-fences.js`, which already makes
this judgement to decide whether ordinal mapping is sound.

## Measured before shipping, as #583 requires

`scripts/measure-tag-sequence-parity.js` on the corpus: **9 findings across
3,584 judged pairs (0.25%)**, 60 unalignable. Against #582's 62-file cost.

Read rather than counted:

- **3 files are the escape proper, and worse than a retag.** In
  `escalate-issues`, English opens a 4-backtick ` ````markdown ` fence containing
  a literal ``` block (the skill documents markdown). wenyan, wenyan-lite and
  zh-CN degraded the opener to 3 backticks, so it closes early and the following
  `python` block is absorbed into a `text` fence. **The frozen code stops being a
  fence at all**, which is exactly why the body check is structurally blind to it.
- **6 files are a false-positive class the design did not predict.** The body
  check is staleness-immune because a stale body matches an *older* revision. A
  sequence inherits that only when it matches some revision **exactly** — and a
  *partially* updated translation, one that took some English changes and not
  others, matches none. Reasoning about the design would not have surfaced this;
  only the corpus did.

## A discrepancy that was the finding

The checker first reported 12 findings / 57 unalignable against the
measurement's 9 / 60. Same total, three files moved — so the *instruments*
disagreed rather than the corpus changing.

`''.split(',')` is `['']`, length 1 not 0. A source revision with **no** fences
joins to the empty string, so it looked like a one-fence revision, matched every
one-fence translation, and compared position 1 against `undefined` — fabricating
three findings reading `#1 ->markdown`. No test saw it; only the second
independent implementation of the same property did. It now has a regression
test.

## Proving the gates can fail

```
--replace "(seq === '' ? 0 : seq.split(',').length)::seq.split(',').length"
    -> MUTANT KILLED by 1 test    (the empty-sequence fix)
--delete-matching "if (sameLength.length === 0) return { unalignable: true };"
    -> MUTANT KILLED by 1 test    (count mismatch must stay unjudged)
--replace "f.lang === '' ? 'text' : f.lang::f.lang"   (lib/fences.js)
    -> MUTANT KILLED by 1 test    (the untagged fold)
```

## Checks

| check | result |
|---|---|
| `npm run test:scripts` | 298 pass, 0 fail (10 new) |
| `check-i18n-fence-parity --json` | 9 tag-sequence findings, 60 unalignable — matching the independent measurement exactly |
| `npm run validate:line-endings` | PASS |

## Deliberately not done

The 9 findings are **not repaired here**. Three are real corruption needing a
per-file judgement about a swallowed fence; six need a decision on whether
partial-update drift is this gate's business or
`check-translation-freshness.js`'s. Repairing them in the same PR that introduces
the detector would make the detector unreviewable. Follow-up issue to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gLNsFgcMQuV7Vk5Y4oNt8
