### PR TITLE
feat(i18n): split the provenance field, and settle last_updated (#552, #603)

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -51,6 +51,14 @@ on:
       # translated/stubs figures the README renders verbatim. A push touching only this file
       # changed generated output while matching no trigger path.
       - 'scripts/lib/fences.js'
+      # Fourth time this list has been extended for the same reason, so state the rule rather
+      # than the instance: EVERY module generate-translation-status.js imports is an input,
+      # because the counts it writes are what the README table renders. provenance.js owns the
+      # frontmatter reader that resolves `source_commit`, and staleness is computed from that
+      # value -- a change to how it is parsed moves the stale counts with no content file
+      # touched. Added at the commit that introduced the import (#552), which is the whole
+      # lesson of the three comments above.
+      - 'scripts/lib/provenance.js'
       # The toolchain is an input too. generate-readmes.js parses YAML with js-yaml, so a
       # Dependabot bump that changes `yaml.load` behaviour changes generated output while
       # touching no content file and no generator -- nothing here matched, so the healer never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,7 +223,8 @@ i18n/
 
 - Translate prose sections (descriptions, headings, pitfalls, validation text)
 - Keep in English: `name` (=ID), code blocks, tool names, tags, domain, file paths, config values
-- Every translated file has frontmatter fields: `locale`, `source_locale`, `source_commit`, `translator`, `translation_date`
+- Every translated file has frontmatter fields: `locale`, `source_locale`, `source_commit`, `fence_basis_commit`, `translator`, `translation_date`
+- `source_commit` and `fence_basis_commit` are **not** duplicates (#552). The first is the English revision a *human* translated against — staleness reads it, and a tool must never move it. The second is the revision this file's *frozen fences* were verified against — `normalize-i18n-fences.js` moves it when it propagates English bytes. One field could not record both: after a mechanical fence repair, bumping it makes the first claim false and leaving it makes the second false. Absence of `fence_basis_commit` means "unverified", which is honest and is the state of most of the corpus until the backfill lands; it is never stamped on a file whose fences diverge. Full rationale in `i18n/README.md`.
 - Translated SKILL.md files must stay under 500 lines
 
 #### Which code fences are frozen

--- a/guides/running-a-translation-campaign.md
+++ b/guides/running-a-translation-campaign.md
@@ -126,7 +126,7 @@ You are a [language] translator. Translate the following skills fully into [lang
 For each skill:
 1. Read the English source at skills/<name>/SKILL.md
 2. Create the translation at i18n/<locale>/skills/<name>/SKILL.md
-3. Add frontmatter: locale, source_locale, source_commit, translator, translation_date
+3. Add frontmatter: locale, source_locale, source_commit, fence_basis_commit, translator, translation_date
 4. Translate ALL prose: title, description, every paragraph, every bullet point,
    every Expected/On failure block, every validation item, every pitfall description
 5. Keep in English: name field, code blocks, tool names, tags, domain, file paths

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -102,12 +102,42 @@ Every translated file includes these fields in its YAML frontmatter:
 ```yaml
 locale: de                              # Content locale (IETF BCP 47)
 source_locale: en                       # Translated from
-source_commit: abc1234                  # Git short hash of source at translation time
+source_commit: abc1234                  # English revision a HUMAN translated against
+fence_basis_commit: abc1234             # English revision the FENCES were verified against
 translator: "Claude + human review"     # Attribution
 translation_date: "2026-03-15"          # ISO 8601
 ```
 
-These fields enable freshness tracking: when the English source changes after the `source_commit`, the translation is flagged as stale.
+### Why there are two commit fields
+
+They answer different questions, and a mechanical repair pulls them apart (#552).
+
+`source_commit` records **the English revision a human translated against**. Staleness is
+measured from it: when the English source changes after that revision, the translation is
+flagged stale. A tool must never move it — bumping it asserts a translation event that never
+happened, which is precisely the lie `evolve-skill` was found telling in #405.
+
+`fence_basis_commit` records **the English revision this file's frozen fence bodies were last
+verified against**. `normalize-i18n-fences.js` moves it when it propagates English bytes into a
+mirror, because otherwise the frontmatter would contradict the body it just rewrote.
+
+With one field the two are irreconcilable: after a mechanical fence repair, bumping it makes the
+first claim false and leaving it makes the second false. So there are two.
+
+They are equal at birth — a scaffold is a byte copy, so its fences trivially mirror the revision
+it copied — and they diverge from the first edit of either kind.
+
+**Absence of `fence_basis_commit` is not a defect.** Present means "these bytes were checked
+against that revision"; absent means "unverified", which is the honest state for a file whose
+fences match no English revision, and for every file predating the field. A commit is never
+stamped on an unverified file, because writing a false claim into the corpus to be corrected
+later is the exact class of problem this field exists to end.
+
+**It never gates a comparison.** `check-i18n-fence-parity.js` compares fence bytes
+unconditionally. The field is read for reporting, and to catch the one thing bytes alone cannot
+say: a file that *claims* a verified basis while its fences diverge. That is reported as
+`stale-basis-claim` and is deliberately ungated — the divergence underneath it is already
+counted, so it can never change a verdict, only tell you a field is lying.
 
 ## Contributing a Translation
 

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -97,7 +97,9 @@ Runs **warn-only** in CI until the backlog clears (#477), then flips to blocking
 
 ## Translation Frontmatter
 
-Every translated file includes these fields in its YAML frontmatter:
+Every translated file includes these fields in its YAML frontmatter, except that
+`fence_basis_commit` is present only on files scaffolded or repaired since #552 — its absence is
+meaningful rather than missing, as explained below:
 
 ```yaml
 locale: de                              # Content locale (IETF BCP 47)

--- a/scripts/bulk-scaffold-caveman.sh
+++ b/scripts/bulk-scaffold-caveman.sh
@@ -55,6 +55,11 @@ for locale in "${LOCALES[@]}"; do
         print "locale: " locale
         print "source_locale: en"
         print "source_commit: " commit
+        # #552: equal to source_commit at birth, because a scaffold is a byte copy of
+        # English, so its frozen fences do mirror this revision. The two fields diverge
+        # afterwards -- a human bumps source_commit by retranslating, the fence
+        # normalizer bumps fence_basis_commit by propagating bytes.
+        print "fence_basis_commit: " commit
         print "translator: \"Julius Brussee homage \342\200\224 caveman\""
         print "translation_date: \"" date "\""
         next

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -324,14 +324,24 @@ function main() {
     // fail" invariant holds either way; what the narrower predicate lost was the ability to say
     // the frontmatter is lying, in precisely the case the escape was invented to hide.
     //
-    // `unalignable` is excluded because it is expressly not a finding: with no count-matched
-    // revision there is no positional claim to contradict.
-    const structureContradicts = Boolean(seqVerdict && !seqVerdict.unalignable);
+    // `unalignable` contradicts a CLAIM even though it is not a violation, and the two questions
+    // are genuinely different. As a violation it is rightly silent: without a count-matched
+    // revision there is no positional correspondence, and a stale translation predating a fence
+    // English later gained lands here. But run the claim question contrapositively — a true
+    // claim means these fences were verified against revision X, so the file's fence count
+    // equals X's count, so SOME revision has that count, so the file is alignable. Therefore
+    // `claimedBasis && unalignable` is a false claim, and unlike the violation question it
+    // carries no staleness confound: the claim is supposed to be current by construction.
+    // It is also the only place this schema can see the #480 deletion gap on a claimed file,
+    // since deleting a frozen fence usually changes the count.
+    const structureContradicts = Boolean(seqVerdict);
     if (claimedBasis && (divergedHere > 0 || structureContradicts)) {
       staleBasisClaims++;
       const because = divergedHere > 0
         ? `${divergedHere} gated fence(s) match no English revision`
-        : 'its fence tag sequence appears in no English revision';
+        : seqVerdict.unalignable
+          ? 'no English revision has its fence count, so the fences cannot be the claimed ones'
+          : 'its fence tag sequence appears in no English revision';
       findings.push({
         file: t.relPath,
         line: 1,

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -316,8 +316,22 @@ function main() {
     // can never be the reason a corpus goes red, only the reason someone stops trusting a
     // field. Absence of the field is silent by design: absent means unverified, which is the
     // honest state for every file predating this schema.
-    if (claimedBasis && divergedHere > 0) {
+    // A claim is contradicted by a divergent BODY or by a divergent STRUCTURE. Counting only
+    // bodies left the retag escape (#481) invisible to this detector: retag a frozen `yaml`
+    // fence to `text` and localise it, and the body check sees only an UNGATED divergence — so
+    // `divergedHere` stays 0 — while the tag-sequence check files a gated finding. The run
+    // still fails on that finding, so the "cannot fail a run the divergence did not already
+    // fail" invariant holds either way; what the narrower predicate lost was the ability to say
+    // the frontmatter is lying, in precisely the case the escape was invented to hide.
+    //
+    // `unalignable` is excluded because it is expressly not a finding: with no count-matched
+    // revision there is no positional claim to contradict.
+    const structureContradicts = Boolean(seqVerdict && !seqVerdict.unalignable);
+    if (claimedBasis && (divergedHere > 0 || structureContradicts)) {
       staleBasisClaims++;
+      const because = divergedHere > 0
+        ? `${divergedHere} gated fence(s) match no English revision`
+        : 'its fence tag sequence appears in no English revision';
       findings.push({
         file: t.relPath,
         line: 1,
@@ -326,7 +340,7 @@ function main() {
         tag: FENCE_BASIS_FIELD,
         gated: false,
         kind: 'stale-basis-claim',
-        firstDivergentLine: `frontmatter claims ${FENCE_BASIS_FIELD}: ${claimedBasis}, but ${divergedHere} gated fence(s) match no English revision`,
+        firstDivergentLine: `frontmatter claims ${FENCE_BASIS_FIELD}: ${claimedBasis}, but ${because}`,
       });
     }
   }

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -67,6 +67,7 @@ import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { assertNotShallow } from './lib/git-freshness.js';
 import { extractFences, buildEnglishFenceHistory, isGated, foldedTagSequence } from './lib/fences.js';
+import { FENCE_BASIS_FIELD, readFrontmatterField } from './lib/provenance.js';
 import { CONTENT_TYPES } from './lib/content-types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -228,13 +229,25 @@ function main() {
   let fencesCompared = 0;
   let ungatedDivergences = 0;
   let tagSequenceUnalignable = 0;
+  let staleBasisClaims = 0;
 
   for (const t of collectTargets()) {
     const englishFences = history.get(`${t.tree}/${t.id}`);
     if (!englishFences) continue; // orphan: check-i18n-frontmatter-parity.js owns that
 
     filesCompared++;
-    const translatedFences = extractFences(readFileSync(t.absPath, 'utf8'));
+    const text = readFileSync(t.absPath, 'utf8');
+    const translatedFences = extractFences(text);
+
+    // #552: `fence_basis_commit` is READ here and never consulted before a comparison. The byte
+    // check below stays unconditional — a field that could suppress it would be a bypass, and
+    // the mutation guarding this design (hand-edit a fence body, leave the field alone) has to
+    // stay red. What the field adds is the one thing bytes alone cannot say: whether the file
+    // CLAIMS to have been verified against a named English revision. A claim plus a divergence
+    // is a false claim, and it is strictly worse than no claim, because the next tool to read
+    // the frontmatter believes it.
+    const claimedBasis = readFrontmatterField(text, FENCE_BASIS_FIELD);
+    let divergedHere = 0;
 
     // #481: the retag escape. `isGated` reads the info string off the TRANSLATION, so retagging
     // a frozen ```yaml fence to ```text removes it from the loop below entirely — the set of
@@ -271,6 +284,7 @@ function main() {
       fencesCompared++;
       if (englishFences.has(fence.body)) continue;
       const gated = isGated(fence);
+      if (gated) divergedHere++;
       if (!gated) { ungatedDivergences++; if (!SHOW_ALL) continue; }
       findings.push({
         file: t.relPath,
@@ -294,6 +308,27 @@ function main() {
     // `quick-reference.md` mirrors that `check-translation-freshness.js`
     // independently reports as stale. Any fix must be staleness-immune the way
     // the divergence check is.
+
+    // The false claim (#552). Reported as its own kind rather than folded into the divergence
+    // count, because it accuses the FRONTMATTER, not the body: the bytes are already flagged
+    // above, and what this adds is that the file also asserts they were checked. Not gated —
+    // it cannot make a run fail that the underlying divergence did not already fail — so it
+    // can never be the reason a corpus goes red, only the reason someone stops trusting a
+    // field. Absence of the field is silent by design: absent means unverified, which is the
+    // honest state for every file predating this schema.
+    if (claimedBasis && divergedHere > 0) {
+      staleBasisClaims++;
+      findings.push({
+        file: t.relPath,
+        line: 1,
+        locale: t.locale,
+        skill: t.id,
+        tag: FENCE_BASIS_FIELD,
+        gated: false,
+        kind: 'stale-basis-claim',
+        firstDivergentLine: `frontmatter claims ${FENCE_BASIS_FIELD}: ${claimedBasis}, but ${divergedHere} gated fence(s) match no English revision`,
+      });
+    }
   }
 
   const blocking = findings.filter((f) => f.gated);
@@ -308,6 +343,7 @@ function main() {
       ungatedDivergences,
       tagSequenceFindings: findings.filter((f) => f.kind === 'tag-sequence').length,
       tagSequenceUnalignable,
+      staleBasisClaims,
       findings,
     }, null, 2));
     process.exitCode = blocking.length > 0 && !WARN_ONLY ? 1 : 0;
@@ -369,6 +405,15 @@ function main() {
     // default-deny, so an untagged divergence prints FAIL and is counted above.
     console.log(`\n${ungatedDivergences} divergence(s) in localisable tags (text/markdown/md) — localising those is allowed.`);
     if (!SHOW_ALL) console.log('Use --all to list them.');
+  }
+  if (staleBasisClaims) {
+    // Ungated on purpose: the divergence underneath each of these is already counted above, so
+    // gating them would double-count the same file and could not change any verdict. The value
+    // is that the frontmatter is now known to be lying — a `fence_basis_commit` present on a
+    // file whose fences diverge. Repairing the body clears it automatically; if the body is
+    // legitimately divergent, the field should be removed instead.
+    console.log(`\n${staleBasisClaims} file(s) claim a ${FENCE_BASIS_FIELD} their fences contradict (#552).`);
+    console.log('Absence of the field is not a finding — absent means unverified, which is honest.');
   }
 
   process.exit(blocking.length > 0 && !WARN_ONLY ? 1 : 0);

--- a/scripts/check-translation-freshness.js
+++ b/scripts/check-translation-freshness.js
@@ -16,6 +16,7 @@ import { resolve, dirname, basename, join } from 'path';
 import { fileURLToPath } from 'url';
 import { assertNotShallow, createFreshnessChecker, buildLatestCommitMap } from './lib/git-freshness.js';
 import { CONTENT_TYPES } from './lib/content-types.js';
+import { SOURCE_COMMIT_FIELD, readFrontmatterField } from './lib/provenance.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -24,11 +25,18 @@ const WARN_ONLY = process.argv.includes('--warn');
 
 /**
  * Extract source_commit from a translated file's frontmatter.
+ *
+ * The shared reader (#552). The regex this replaces was line-anchored but not
+ * FRONTMATTER-anchored, so a `source_commit:` at column 0 inside a ```yaml fence — the shape
+ * `i18n/README.md` itself documents — read as this file's own metadata. Measured across the
+ * corpus at the swap: 2,571 stale before and after.
+ *
+ * This is the last of three hand-rolled copies of this reader, each with a different regex and
+ * a different bug. That there were three is why `source_commit` could be read one way by the
+ * staleness gate and another by the status generator without anything noticing.
  */
 function extractSourceCommit(filePath) {
-  const content = readFileSync(filePath, 'utf8');
-  const match = content.match(/^\s*source_commit:\s*["']?([a-f0-9]+)["']?/m);
-  return match ? match[1] : null;
+  return readFrontmatterField(readFileSync(filePath, 'utf8'), SOURCE_COMMIT_FIELD);
 }
 
 /**

--- a/scripts/check-translation-freshness.js
+++ b/scripts/check-translation-freshness.js
@@ -39,15 +39,10 @@ function extractSourceCommit(filePath) {
   return readFrontmatterField(readFileSync(filePath, 'utf8'), SOURCE_COMMIT_FIELD);
 }
 
-/**
- * Extract locale from a translated file's frontmatter.
- */
-function extractLocale(filePath) {
-  const content = readFileSync(filePath, 'utf8');
-  const match = content.match(/^  locale:\s*["']?([a-zA-Z-]+)["']?/m)
-    || content.match(/^locale:\s*["']?([a-zA-Z-]+)["']?/m);
-  return match ? match[1] : null;
-}
+// `extractLocale` used to sit here: a fourth hand-rolled frontmatter reader, not anchored to the
+// frontmatter block, and called by nothing — the locale comes from the directory walk below.
+// Deleted rather than routed through the shared reader (#552), because an unused reader is a
+// waiting inconsistency: the next person to need a locale would have found two of them.
 
 // A shallow clone would make every translation read as fresh (#279/#362).
 assertNotShallow(ROOT);

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -27,13 +27,23 @@ import {
   buildEnglishProseHistory, classifyTranslation, translationKey, UNJUDGED_REASONS,
 } from './lib/translation-status.js';
 import { TREES } from './lib/fences.js';
+import { SOURCE_COMMIT_FIELD, readFrontmatterField } from './lib/provenance.js';
 
 // Validated against an accept-list, not sniffed with `includes`. `--verdict`, `--verdicts=1`
 // and `-verdicts` all used to parse as "flag absent": the scan ran, ten files were written,
 // no verdict list printed, exit 0 — and the reader concluded there were no stubs to review
 // before starting a bulk delete. `audit-skill-sections.js` already does this correctly.
-const KNOWN_FLAGS = new Set(['--verdicts', '--margins', '--write']);
-const UNKNOWN_FLAGS = process.argv.slice(2).filter((arg) => !KNOWN_FLAGS.has(arg));
+const KNOWN_FLAGS = new Set(['--verdicts', '--margins', '--write', '--root']);
+// `--root` is the only flag here that TAKES a value, so its argument must be excused from the
+// unknown-flag sweep — otherwise the path itself is reported as an unknown argument. Excused by
+// position (the token immediately after `--root`) rather than by shape: a filter like
+// "anything not starting with --" would also swallow a genuine typo such as `verdicts`, which
+// is exactly the silent-misparse class the check above exists to catch.
+const ROOT_VALUE_INDEX = process.argv.indexOf('--root') + 1;
+const UNKNOWN_FLAGS = process.argv.slice(2).filter((arg, i) => {
+  if (KNOWN_FLAGS.has(arg)) return false;
+  return !(ROOT_VALUE_INDEX > 0 && i + 2 === ROOT_VALUE_INDEX);
+});
 if (UNKNOWN_FLAGS.length) {
   console.error(`ERROR: unknown argument(s): ${UNKNOWN_FLAGS.join(' ')}`);
   console.error(`Known flags: ${[...KNOWN_FLAGS].join(', ')}`);
@@ -63,7 +73,18 @@ const WRITE_STATUS = process.argv.includes('--write')
   || (!SHOW_VERDICTS && !SHOW_MARGINS);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = resolve(__dirname, '..');
+
+// `--root` exists so the #603 date behaviour can be TESTED rather than demonstrated. Without
+// it this script can only ever run against the repo it sits in, which means the only way to
+// exercise "does the date hold when the counts hold" is to mutate the real corpus and put it
+// back — a demo, not coverage, and one that dirties ten tracked files while it runs.
+// `check-i18n-fence-parity.js` already carries the same flag for the same reason.
+const rootFlag = process.argv.indexOf('--root');
+if (rootFlag >= 0 && (rootFlag + 1 >= process.argv.length || process.argv[rootFlag + 1].startsWith('--'))) {
+  console.error('ERROR: --root requires a value');
+  process.exit(2);
+}
+const ROOT = rootFlag >= 0 ? resolve(process.argv[rootFlag + 1]) : resolve(__dirname, '..');
 const I18N_DIR = resolve(ROOT, 'i18n');
 
 // Load config
@@ -100,11 +121,17 @@ const sourceCounts = {
 
 /**
  * Extract source_commit from translation frontmatter.
+ *
+ * Routes through the shared reader (#552). The regex this replaces was
+ * `/source_commit:\s*["']?([a-f0-9]+)["']?/m` — with no `^` anchor and no frontmatter bound, so
+ * it matched the first `source_commit:` ANYWHERE in the file, including inside a ```yaml fence
+ * demonstrating what translation frontmatter looks like. Two other copies of this reader
+ * existed and all three disagreed; there is now one, and it is anchored to the frontmatter
+ * block. Measured across the corpus at the swap: 2,571 stale before and after, so no file's
+ * verdict turned on the difference today.
  */
 function extractSourceCommit(filePath) {
-  const content = readFileSync(filePath, 'utf8');
-  const match = content.match(/source_commit:\s*["']?([a-f0-9]+)["']?/m);
-  return match ? match[1] : null;
+  return readFrontmatterField(readFileSync(filePath, 'utf8'), SOURCE_COMMIT_FIELD);
 }
 
 // Stub detection lives in ./lib/translation-status.js. It used to be body equality against

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -247,6 +247,25 @@ const contentTypes = TREES;
 const locales = config.supported_locales.map(l => l.code);
 const today = new Date().toISOString().split('T')[0];
 
+/**
+ * Read an existing `translation_status.yml`, or null when it is absent or unusable (#603).
+ *
+ * Returns null rather than throwing on a malformed file: the caller treats null as "stamp
+ * today", so a corrupt status file regenerates instead of aborting the run.
+ *
+ * @param {string} statusPath
+ * @returns {{last_updated?: string, coverage?: object}|null}
+ */
+function readStatus(statusPath) {
+  if (!existsSync(statusPath)) return null;
+  try {
+    const parsed = yaml.load(readFileSync(statusPath, 'utf8'));
+    return parsed && typeof parsed === 'object' && parsed.last_updated ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 for (const locale of locales) {
   const localeDir = resolve(I18N_DIR, locale);
   if (!existsSync(localeDir)) {
@@ -296,16 +315,37 @@ for (const locale of locales) {
     unjudged: totalUnjudged,
   };
 
+  const statusPath = resolve(localeDir, 'translation_status.yml');
+
+  // #603: `last_updated` used to stamp the RUN date, so every regeneration dirtied all ten
+  // tracked status files whether or not a single count had moved — 33 of the 61 commits
+  // touching `i18n/de/translation_status.yml` changed nothing but this line. That is not merely
+  // noise: it makes the field mean "when the job last ran", which is not what any reader
+  // assumes it means, and it defeats `guard:verify` by producing a diff out of nothing.
+  //
+  // Now the date moves only when the COUNTS move. Comparing the coverage payload rather than
+  // the rendered YAML keeps the decision independent of dumper formatting; a file that is
+  // missing, unparseable, or shaped differently falls through to today's date, which is the
+  // safe direction — a spurious bump is recoverable, a frozen date is a lie.
+  const previous = readStatus(statusPath);
+  const unchanged = previous !== null
+    && JSON.stringify(previous.coverage) === JSON.stringify(coverage);
   const status = {
     locale,
-    last_updated: today,
+    last_updated: unchanged ? previous.last_updated : today,
     coverage,
   };
 
-  const statusPath = resolve(localeDir, 'translation_status.yml');
   if (WRITE_STATUS) {
-    writeFileSync(statusPath, yaml.dump(status, { flowLevel: 3 }));
-    console.log(`GENERATED: ${statusPath.replace(ROOT + '/', '')}`);
+    const rendered = yaml.dump(status, { flowLevel: 3 });
+    // Skip the write when the bytes would not change, so a no-op regeneration leaves the
+    // mtime alone too. `existsSync` guards the first generation of a new locale.
+    if (existsSync(statusPath) && readFileSync(statusPath, 'utf8') === rendered) {
+      console.log(`UNCHANGED: ${statusPath.replace(ROOT + '/', '')}`);
+    } else {
+      writeFileSync(statusPath, rendered);
+      console.log(`GENERATED: ${statusPath.replace(ROOT + '/', '')}`);
+    }
   } else {
     console.log(`INSPECTED: ${statusPath.replace(ROOT + '/', '')} (not written — pass --write to regenerate)`);
   }

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -354,6 +354,14 @@ for (const locale of locales) {
   // the rendered YAML keeps the decision independent of dumper formatting; a file that is
   // missing, unparseable, or shaped differently falls through to today's date, which is the
   // safe direction — a spurious bump is recoverable, a frozen date is a lie.
+  //
+  // Two residuals, stated so neither is reported as a regression later. The field now means
+  // "when this payload last changed", which is not quite "when translations were last touched":
+  // (a) `pct` derives from the registry totals, so adding one English skill moves the
+  // denominator and bumps the date in all ten locales without any translation activity; and
+  // (b) compensating flips in one run — one file stub→translated while another goes the other
+  // way — leave every count equal and the date still. Both are inherent to comparing counts
+  // rather than tracking events, and both are preferable to stamping the run date.
   const previous = readStatus(statusPath);
   const unchanged = previous !== null
     && JSON.stringify(previous.coverage) === JSON.stringify(coverage);

--- a/scripts/lib/provenance.js
+++ b/scripts/lib/provenance.js
@@ -97,14 +97,32 @@ export function stampFrontmatterField(text, field, value) {
   const block = fm[1];
   const existing = new RegExp(`^([ \\t]*)${field}:.*$`, 'm');
   if (existing.test(block)) {
-    const updated = block.replace(existing, `$1${field}: ${value}`);
-    return normalized.replace(block, updated);
+    const updated = block.replace(existing, (_, indent) => `${indent}${field}: ${value}`);
+    return replaceBlock(normalized, block, updated);
   }
 
   const anchor = new RegExp(`^([ \\t]*)${SOURCE_COMMIT_FIELD}:.*$`, 'm').exec(block);
   if (!anchor) return null;
-  const updated = block.replace(anchor[0], `${anchor[0]}\n${anchor[1]}${field}: ${value}`);
-  return normalized.replace(block, updated);
+  const updated = block.replace(anchor[0], () => `${anchor[0]}\n${anchor[1]}${field}: ${value}`);
+  return replaceBlock(normalized, block, updated);
+}
+
+/**
+ * Splice `updated` in place of `block` inside `text`, with NO `$`-pattern interpretation.
+ *
+ * `String.prototype.replace` expands `$$`, `$&`, `` $` `` and `$'` in the replacement even when
+ * the search argument is a plain string, and every replacement here is derived from the file's
+ * own frontmatter. A `description:` containing `$'` — ordinary shell documentation in this
+ * corpus — spliced the entire remainder of the file back in and duplicated the body, silently,
+ * inside the frontmatter where the fence gate cannot see it. Measured over `i18n/**` at the
+ * time of writing: zero files carry such a value in frontmatter, so nothing is corrupt today.
+ * This is the write path the backfill runs across ~3,644 files, so "zero today" is not a reason
+ * to leave a loaded gun in it.
+ *
+ * A function replacement is the fix: its return value is used verbatim.
+ */
+function replaceBlock(text, block, updated) {
+  return text.replace(block, () => updated);
 }
 
 /**
@@ -131,5 +149,5 @@ export function clearFrontmatterField(text, field) {
   const lines = block.split('\n');
   const kept = lines.filter((line) => !match.test(line));
   if (kept.length === lines.length) return normalized;
-  return normalized.replace(block, kept.join('\n'));
+  return replaceBlock(normalized, block, kept.join('\n'));
 }

--- a/scripts/lib/provenance.js
+++ b/scripts/lib/provenance.js
@@ -1,0 +1,135 @@
+/**
+ * provenance.js — the two provenance fields a translation carries, and why there are two (#552).
+ *
+ * ## The field that meant two things
+ *
+ * `source_commit` was asked to answer two questions that a mechanical repair pulls apart:
+ *
+ *   1. **Which English revision did a human translate against?** This is what staleness means
+ *      (`check-translation-freshness.js`), and it must NOT move when a tool edits the file —
+ *      bumping it asserts a translation event that never happened, which is the lie #405
+ *      recorded `evolve-skill` telling.
+ *   2. **Which English revision do this file's frozen fences mirror?** This is what fence parity
+ *      is about (`check-i18n-fence-parity.js`), and it MUST move when the normalizer propagates
+ *      new English bytes into a mirror, or the frontmatter contradicts the body.
+ *
+ * With one field the two are irreconcilable: bump it and (1) is false, leave it and (2) is
+ * false. So there are two fields, and neither is a rename of the other.
+ *
+ * ## `fence_basis_commit`
+ *
+ * The English revision this file's frozen fence bodies were last verified or propagated
+ * against. Written by the scaffolder (a fresh scaffold is a byte copy, so its fences trivially
+ * mirror the revision it copied) and by `normalize-i18n-fences.js` after a repair.
+ *
+ * **Presence is a claim, and absence is not a defect.** Present means "these bytes were checked
+ * against that revision". Absent means "unverified" — the honest state for the ~40 files whose
+ * fences match no English revision, and for every file predating this field. Stamping a commit
+ * on an unverified file would write a false claim into the corpus to be corrected later, which
+ * is the disagreement-between-files failure this whole schema change exists to end.
+ *
+ * **It never gates a comparison.** `check-i18n-fence-parity.js` compares fence bytes
+ * unconditionally and always will. This field is read for reporting, and to catch the one thing
+ * bytes alone cannot say: a file claiming a verified basis whose fences diverge anyway. A field
+ * that could suppress a byte comparison would be decorative at best and a bypass at worst.
+ *
+ * ## Why the name avoids the substring `source_commit`
+ *
+ * `generate-translation-status.js` reads the old field with an UNANCHORED regex
+ * (`/source_commit:\s*["']?([a-f0-9]+)["']?/m` — no `^`), so any new field whose name contains
+ * `source_commit` would be captured by it wherever it appeared, including from inside a body
+ * fence. `fence_basis_commit` cannot collide. Keep it that way if the field is ever renamed.
+ */
+
+/** The revision a human translated against. Staleness reads this; tools must not move it. */
+export const SOURCE_COMMIT_FIELD = 'source_commit';
+
+/** The revision this file's frozen fences were last verified against. Absent = unverified. */
+export const FENCE_BASIS_FIELD = 'fence_basis_commit';
+
+const FRONTMATTER = /^---\n([\s\S]*?)\n---(\n|$)/;
+
+/**
+ * Read `field` out of `text`'s frontmatter, or null.
+ *
+ * Anchored to the frontmatter block, unlike two of the three hand-rolled readers this replaces:
+ * an unanchored match reads a `source_commit:` written inside a body fence as though it were
+ * metadata. Tolerates leading indentation because translations carry genuine shape variance —
+ * `check-i18n-frontmatter-parity.js` records that the nesting differs per FILE, not per locale,
+ * so indent tolerance is the only thing that survives the corpus.
+ *
+ * @param {string} text whole file contents
+ * @param {string} field field name
+ * @returns {string|null}
+ */
+export function readFrontmatterField(text, field) {
+  const fm = text.replace(/\r\n/g, '\n').match(FRONTMATTER);
+  if (!fm) return null;
+  const m = new RegExp(`^\\s*${field}:\\s*(\\S.*)$`, 'm').exec(fm[1]);
+  if (!m) return null;
+  // A few values carry a trailing YAML comment.
+  return m[1].replace(/\s+#.*$/, '').trim().replace(/^["']|["']$/g, '');
+}
+
+/**
+ * Write `field: value` into `text`'s frontmatter, replacing any existing occurrence.
+ *
+ * Anchored on the `source_commit` line and copying its exact indentation, rather than inserting
+ * at a fixed depth or before the closing `---`. That is deliberate: the corpus nests these
+ * fields differently from file to file, so a fixed depth produces valid-looking YAML in the
+ * wrong block. Anchoring on the sibling that already exists is the only placement that cannot
+ * disagree with the file it is editing.
+ *
+ * Refuses rather than guesses when there is no anchor, because the alternative — appending at
+ * top level — is exactly the `sed '/^  tags:/a\\'` bug that broke a batch of scaffolds by
+ * inserting a field between a key and its list items.
+ *
+ * @param {string} text whole file contents
+ * @param {string} field field name
+ * @param {string} value value to write
+ * @returns {string|null} updated text, or null if there is no frontmatter or no anchor field
+ */
+export function stampFrontmatterField(text, field, value) {
+  const normalized = text.replace(/\r\n/g, '\n');
+  const fm = normalized.match(FRONTMATTER);
+  if (!fm) return null;
+
+  const block = fm[1];
+  const existing = new RegExp(`^([ \\t]*)${field}:.*$`, 'm');
+  if (existing.test(block)) {
+    const updated = block.replace(existing, `$1${field}: ${value}`);
+    return normalized.replace(block, updated);
+  }
+
+  const anchor = new RegExp(`^([ \\t]*)${SOURCE_COMMIT_FIELD}:.*$`, 'm').exec(block);
+  if (!anchor) return null;
+  const updated = block.replace(anchor[0], `${anchor[0]}\n${anchor[1]}${field}: ${value}`);
+  return normalized.replace(block, updated);
+}
+
+/**
+ * Remove `field` from `text`'s frontmatter if present.
+ *
+ * The normalizer needs this: a partially-repaired file that still carries divergent fences must
+ * not keep a `fence_basis_commit` from an earlier, then-complete verification. Leaving a stale
+ * claim behind is worse than never having written one — it reads as verified.
+ *
+ * @param {string} text whole file contents
+ * @param {string} field field name
+ * @returns {string} updated text (unchanged when the field is absent)
+ */
+export function clearFrontmatterField(text, field) {
+  const normalized = text.replace(/\r\n/g, '\n');
+  const fm = normalized.match(FRONTMATTER);
+  if (!fm) return normalized;
+  const block = fm[1];
+  // Filter lines rather than regex-replace the line plus a `\n?`. The regex form is correct
+  // everywhere except the position the stamper actually produces — last line of the block —
+  // where there is no trailing newline to consume and it leaves the PRECEDING one behind as a
+  // blank line inside the frontmatter. Caught by the nested round-trip test.
+  const match = new RegExp(`^[ \\t]*${field}:`);
+  const lines = block.split('\n');
+  const kept = lines.filter((line) => !match.test(line));
+  if (kept.length === lines.length) return normalized;
+  return normalized.replace(block, kept.join('\n'));
+}

--- a/scripts/lib/translation-status.js
+++ b/scripts/lib/translation-status.js
@@ -264,8 +264,14 @@ function comparable(lines) {
  * If one of these survives into what `stripFrontmatter` returned, the frontmatter mask did not
  * close — and `stripFrontmatter` fails OPEN by design, returning the whole text when it cannot
  * find two `---` lines.
+ *
+ * `fence_basis_commit` is here for the same reason its siblings are (#552): it is a short line
+ * of metadata that clears the substantive filter and sits in NO English pool, so an unclosed
+ * mask turns it into one more line of "novel prose" and inflates the file toward TRANSLATED.
+ * Every new provenance field must be added here — see `scripts/lib/provenance.js`, which owns
+ * the field names.
  */
-const FRONTMATTER_KEYS = /^(locale|source_locale|source_commit|translator|translation_date):/;
+const FRONTMATTER_KEYS = /^(locale|source_locale|source_commit|fence_basis_commit|translator|translation_date):/;
 
 /**
  * Did the frontmatter mask fail to close over `body`?

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -96,6 +96,10 @@ import {
   extractFences, toLines, isGated, buildEnglishFenceHistory, TREES, contentKey,
 } from './lib/fences.js';
 import { assertNotShallow } from './lib/git-freshness.js';
+import {
+  SOURCE_COMMIT_FIELD, FENCE_BASIS_FIELD,
+  readFrontmatterField, stampFrontmatterField, clearFrontmatterField,
+} from './lib/provenance.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -323,14 +327,11 @@ if (WRITE) {
 
 const GIT_BUFFER = 512 * 1024 * 1024;
 
-function frontmatterField(text, field) {
-  const fm = text.replace(/\r\n/g, '\n').match(/^---\n([\s\S]*?)\n---(\n|$)/);
-  if (!fm) return null;
-  const m = new RegExp(`^\\s*${field}:\\s*(\\S.*)$`, 'm').exec(fm[1]);
-  if (!m) return null;
-  // A few source_commit values carry a trailing YAML comment.
-  return m[1].replace(/\s+#.*$/, '').trim().replace(/^["']|["']$/g, '');
-}
+// The frontmatter reader that used to live here moved to `scripts/lib/provenance.js` (#552),
+// which owns both provenance fields and the only reader anchored to the frontmatter block.
+// Three hand-rolled readers existed across this repo and they disagreed — the one in
+// `generate-translation-status.js` is unanchored and reads a `source_commit:` written inside a
+// body fence as metadata.
 
 /** Batch-resolve `<commit>:<englishRel>` blobs in one git process. */
 function readBlobs(specs) {
@@ -404,7 +405,7 @@ for (const locale of SCANNABLE_LOCALES) {
         locale, tree, key, path: translated, english, englishRel,
         relPath: `i18n/${locale}/${englishRel}`,
         text,
-        sourceCommit: frontmatterField(text, 'source_commit'),
+        sourceCommit: readFrontmatterField(text, SOURCE_COMMIT_FIELD),
       });
     }
   }
@@ -527,10 +528,41 @@ for (const t of targets) {
   }
   if (!restoredHere) continue;
 
+  let repairedText = lines.join('\n');
+
+  // #552: record which English revision these fences were verified against — but only when the
+  // claim is true, on both counts that can make it false.
+  //
+  //   1. The repair must leave NOTHING gated divergent. A `--tag`-scoped batch repairs one slice
+  //      and leaves the rest, so stamping after it would assert a whole-file verification the
+  //      file has not had. Re-derived from the repaired bytes rather than from `restoredHere`,
+  //      because "I fixed some" and "none remain" are different claims and only the second is
+  //      the one being written down.
+  //   2. The basis must be a real revision. `basisLabel` is `worktree` whenever the fallback
+  //      read English off disk, and the working tree is not a commit — the same distinction the
+  //      report already refuses to blur ("labelled `worktree`, not a commit").
+  //
+  // Otherwise CLEAR the field. A file that still diverges must not keep a claim from an earlier,
+  // then-complete verification: a stale claim reads as verified and is worse than no claim.
+  const stillDivergent = extractFences(repairedText)
+    .filter((f) => isGated(f) && !everEnglish.has(f.body)).length;
+  let basisStamp = null;
+  if (stillDivergent === 0 && basisLabel !== 'worktree') {
+    const stamped = stampFrontmatterField(repairedText, FENCE_BASIS_FIELD, basisLabel);
+    // `stamped` is null when the file has no `source_commit` to anchor beside. Repair the body
+    // anyway and leave the field off, rather than guessing a nesting depth.
+    if (stamped !== null) { repairedText = stamped; basisStamp = basisLabel; }
+  } else {
+    repairedText = clearFrontmatterField(repairedText, FENCE_BASIS_FIELD);
+  }
+
   filesChanged++;
   fencesRestored += restoredHere;
   changedByLocale.set(t.locale, (changedByLocale.get(t.locale) || 0) + restoredHere);
-  plan.push({ path: t.path, relPath: t.relPath, text: lines.join('\n'), n: restoredHere, basisLabel });
+  plan.push({
+    path: t.path, relPath: t.relPath, text: repairedText, n: restoredHere,
+    basisLabel, basisStamp, stillDivergent,
+  });
 }
 
 // Validate `--tag` against what the scan actually saw, not against a hand-kept
@@ -558,7 +590,16 @@ if (!PREVIEW && plan.length) {
 }
 
 for (const p of plan) {
-  console.log(`${PREVIEW ? 'would restore' : '   restoring'} ${String(p.n).padStart(2)} fence(s) in ${p.relPath}  (basis ${p.basisLabel})`);
+  // The provenance suffix says which of the three outcomes this file got, because they are not
+  // distinguishable from the fence count: stamped (fully verified against a named revision),
+  // still-divergent (claim withheld or cleared), or a worktree basis (repaired, but from bytes
+  // that are not a commit, so there is nothing honest to record).
+  const provenance = p.basisStamp
+    ? `, ${FENCE_BASIS_FIELD}=${p.basisStamp}`
+    : p.stillDivergent
+      ? `, no ${FENCE_BASIS_FIELD} (${p.stillDivergent} still divergent)`
+      : `, no ${FENCE_BASIS_FIELD} (basis is not a commit)`;
+  console.log(`${PREVIEW ? 'would restore' : '   restoring'} ${String(p.n).padStart(2)} fence(s) in ${p.relPath}  (basis ${p.basisLabel}${provenance})`);
 }
 
 if (!PREVIEW) {

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -533,21 +533,35 @@ for (const t of targets) {
   // #552: record which English revision these fences were verified against — but only when the
   // claim is true, on both counts that can make it false.
   //
-  //   1. The repair must leave NOTHING gated divergent. A `--tag`-scoped batch repairs one slice
-  //      and leaves the rest, so stamping after it would assert a whole-file verification the
-  //      file has not had. Re-derived from the repaired bytes rather than from `restoredHere`,
-  //      because "I fixed some" and "none remain" are different claims and only the second is
-  //      the one being written down.
+  //   1. The repaired file must MIRROR THE BASIS at every gated fence. An earlier version of
+  //      this tested "nothing gated is still divergent", which is a strictly weaker statement
+  //      and the gap is reachable. `everEnglish` is the union of every revision, so that test
+  //      proves each fence matches SOME revision while the stamp names ONE. The splice repairs
+  //      only the divergent fences, so an untouched fence keeps whatever revision it came from:
+  //      given English W=[A1,B1] and X=[A2,B2] and a mirror [localized, B1] whose source_commit
+  //      was bumped to X without retranslation (the #405 shape), the repair yields [A2,B1] —
+  //      X at one ordinal, W at the other — and the weaker test stamped X. That is a false
+  //      claim at the moment of writing, invisible to the parity checker because every body
+  //      does match some revision, and inherited by whatever reads the field next. Pinned by
+  //      `scripts/test/fence-basis-stamp.test.js`, which fails against the weaker test.
   //   2. The basis must be a real revision. `basisLabel` is `worktree` whenever the fallback
   //      read English off disk, and the working tree is not a commit — the same distinction the
   //      report already refuses to blur ("labelled `worktree`, not a commit").
   //
   // Otherwise CLEAR the field. A file that still diverges must not keep a claim from an earlier,
   // then-complete verification: a stale claim reads as verified and is worse than no claim.
-  const stillDivergent = extractFences(repairedText)
-    .filter((f) => isGated(f) && !everEnglish.has(f.body)).length;
+  // Clearing cannot destroy a TRUE claim here, because a file only reaches this point with a
+  // gated fence that matched no revision at all, and English history only grows — so any
+  // pre-existing stamp on it was already stale.
+  const repairedFences = extractFences(repairedText);
+  const stillDivergent = repairedFences.filter((f) => isGated(f) && !everEnglish.has(f.body)).length;
+  // Ordinal comparison is sound here for the same reason the splice was: the count and
+  // tag-alignment guards above already rejected this file otherwise. Re-checking the length is
+  // belt-and-braces against a basis body that itself contains a fence delimiter.
+  const mirrorsBasis = repairedFences.length === basisFences.length
+    && repairedFences.every((f, i) => !isGated(f) || f.body === basisFences[i].body);
   let basisStamp = null;
-  if (stillDivergent === 0 && basisLabel !== 'worktree') {
+  if (mirrorsBasis && basisLabel !== 'worktree') {
     const stamped = stampFrontmatterField(repairedText, FENCE_BASIS_FIELD, basisLabel);
     // `stamped` is null when the file has no `source_commit` to anchor beside. Repair the body
     // anyway and leave the field off, rather than guessing a nesting depth.
@@ -598,7 +612,9 @@ for (const p of plan) {
     ? `, ${FENCE_BASIS_FIELD}=${p.basisStamp}`
     : p.stillDivergent
       ? `, no ${FENCE_BASIS_FIELD} (${p.stillDivergent} still divergent)`
-      : `, no ${FENCE_BASIS_FIELD} (basis is not a commit)`;
+      : p.basisLabel === 'worktree'
+        ? `, no ${FENCE_BASIS_FIELD} (basis is not a commit)`
+        : `, no ${FENCE_BASIS_FIELD} (mirrors more than one revision)`;
   console.log(`${PREVIEW ? 'would restore' : '   restoring'} ${String(p.n).padStart(2)} fence(s) in ${p.relPath}  (basis ${p.basisLabel}${provenance})`);
 }
 

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -561,7 +561,17 @@ for (const t of targets) {
   const mirrorsBasis = repairedFences.length === basisFences.length
     && repairedFences.every((f, i) => !isGated(f) || f.body === basisFences[i].body);
   let basisStamp = null;
-  if (mirrorsBasis && basisLabel !== 'worktree') {
+  // `stillDivergent === 0` is kept as a conjunct even though `mirrorsBasis` implies it for any
+  // basis the walk can see. It does NOT imply it in general, and the gap is reachable without
+  // any unusual git state: the pool comes from `git log` over HEAD-reachable history with
+  // default simplification, while the basis blob is resolved with `git cat-file --batch`, which
+  // answers for any object in the store. The walker's own documented merge gap is the lead case
+  // — `--name-only` lists no paths for a merge, so a `source_commit` naming a conflict-resolved
+  // merge has a blob cat-file resolves and the pool never contains. There, `mirrorsBasis` is
+  // true while gated fences remain outside the pool, and stamping would sign a claim this
+  // repo's own gate contradicts on the next run. Refusing costs nothing when the basis is
+  // ordinary and keeps the tool from ever writing a claim the checker will flag.
+  if (stillDivergent === 0 && mirrorsBasis && basisLabel !== 'worktree') {
     const stamped = stampFrontmatterField(repairedText, FENCE_BASIS_FIELD, basisLabel);
     // `stamped` is null when the file has no `source_commit` to anchor beside. Repair the body
     // anyway and leave the field off, rather than guessing a nesting depth.
@@ -608,10 +618,14 @@ for (const p of plan) {
   // distinguishable from the fence count: stamped (fully verified against a named revision),
   // still-divergent (claim withheld or cleared), or a worktree basis (repaired, but from bytes
   // that are not a commit, so there is nothing honest to record).
-  const provenance = p.basisStamp
-    ? `, ${FENCE_BASIS_FIELD}=${p.basisStamp}`
-    : p.stillDivergent
-      ? `, no ${FENCE_BASIS_FIELD} (${p.stillDivergent} still divergent)`
+  // `stillDivergent` is tested BEFORE `basisStamp`, not after. A stamp and a non-zero divergence
+  // count are mutually exclusive by the condition above, so reporting the stamp first would only
+  // ever matter if that invariant broke — which is exactly when the operator needs to be told
+  // the file still diverges rather than reassured it was signed.
+  const provenance = p.stillDivergent
+    ? `, no ${FENCE_BASIS_FIELD} (${p.stillDivergent} still divergent)`
+    : p.basisStamp
+      ? `, ${FENCE_BASIS_FIELD}=${p.basisStamp}`
       : p.basisLabel === 'worktree'
         ? `, no ${FENCE_BASIS_FIELD} (basis is not a commit)`
         : `, no ${FENCE_BASIS_FIELD} (mirrors more than one revision)`;

--- a/scripts/test/fence-basis-claim.test.js
+++ b/scripts/test/fence-basis-claim.test.js
@@ -13,7 +13,7 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -115,6 +115,24 @@ describe('fence_basis_commit in the parity gate (#552)', () => {
     assert.equal(gated.length, 1, 'the divergent gated fence must still be a violation');
     assert.equal(gated[0].kind, 'diverged');
     assert.equal(out.violations, 1);
+  });
+
+  it('flags a claim contradicted by a RETAG, not just by a divergent body', (t) => {
+    // The #481 escape: a frozen ```bash fence retagged to ```text leaves the body check
+    // entirely, because gating is read off the translated file. The body divergence is then
+    // UNGATED, so a body-only predicate sees nothing and the frontmatter's claim goes
+    // unchallenged in exactly the case the escape exists to hide.
+    const { dir } = makeFixture(t, { basis: 'deadbee' });
+    const mirror = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+    writeFileSync(mirror, readFileSync(mirror, 'utf8').replace('```bash', '```text'), 'utf8');
+
+    const out = check(dir);
+    const claim = out.findings.find((f) => f.kind === 'stale-basis-claim');
+    assert.ok(claim, 'a retag must contradict the claim too');
+    assert.match(claim.firstDivergentLine, /tag sequence appears in no English revision/);
+    // The structural finding is still what fails the run; the claim finding stays ungated.
+    assert.equal(claim.gated, false);
+    assert.ok(out.findings.some((f) => f.kind === 'tag-sequence' && f.gated));
   });
 
   it('a verified file with matching fences carries its claim cleanly', (t) => {

--- a/scripts/test/fence-basis-claim.test.js
+++ b/scripts/test/fence-basis-claim.test.js
@@ -135,6 +135,28 @@ describe('fence_basis_commit in the parity gate (#552)', () => {
     assert.ok(out.findings.some((f) => f.kind === 'tag-sequence' && f.gated));
   });
 
+  it('flags a claim on a file no English revision has the fence count for', (t) => {
+    // `unalignable` is not a violation — without a count match there is no position to compare.
+    // It IS a contradicted claim: verified-against-X implies the count equals X's count, so an
+    // unalignable file cannot be carrying X's fences.
+    //
+    // The duplicated fence must repeat a body English HAS, not a novel one. A novel body is a
+    // gated divergence, which fires the body branch first and proves nothing about this path —
+    // the first version of this test did exactly that and asserted the wrong message.
+    const { dir } = makeFixture(t, { basis: 'deadbee', fence: ENGLISH_FENCE });
+    const mirror = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+    writeFileSync(mirror, `${readFileSync(mirror, 'utf8')}\n\`\`\`bash\n${ENGLISH_FENCE}\n\`\`\`\n`, 'utf8');
+
+    const out = check(dir);
+    const claim = out.findings.find((f) => f.kind === 'stale-basis-claim');
+    assert.ok(claim, 'an unalignable file carrying a claim must be flagged');
+    assert.match(claim.firstDivergentLine, /no English revision has its fence count/);
+    assert.equal(claim.gated, false);
+    // Still not a violation: unalignable must not become one via this route.
+    assert.equal(out.violations, 0);
+    assert.equal(out.tagSequenceUnalignable, 1);
+  });
+
   it('a verified file with matching fences carries its claim cleanly', (t) => {
     const { dir } = makeFixture(t, { basis: 'deadbee', fence: ENGLISH_FENCE });
     const out = check(dir);

--- a/scripts/test/fence-basis-claim.test.js
+++ b/scripts/test/fence-basis-claim.test.js
@@ -1,0 +1,126 @@
+/**
+ * fence-basis-claim.test.js — `fence_basis_commit` in the fence-parity gate (#552).
+ *
+ * The schema's whole risk is that the new field becomes either DECORATIVE (nothing reads it) or
+ * a BYPASS (it suppresses a comparison). These drive the real checker as a subprocess against a
+ * throwaway git repo, because both risks live in the wiring rather than in any pure function:
+ * a unit test of "claim && diverged" would pass against a checker that never calls it.
+ *
+ * The load-bearing case is `keeps flagging the divergence when the field is present` — the
+ * mutation #552's plan names, phrased as coverage: hand-edit a fence body, leave the field
+ * alone, and the gate must still go red.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const CHECKER = join(REPO, 'scripts', 'check-i18n-fence-parity.js');
+
+const ENGLISH_FENCE = 'echo "hello"';
+const DIVERGENT_FENCE = 'echo "hallo"';
+
+function git(cwd, args) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(r.status, 0, `git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+function englishSkill() {
+  return [
+    '---', 'name: demo-skill', 'description: A demo skill.', '---', '',
+    '# Demo Skill', '', '## Procedure', '',
+    '```bash', ENGLISH_FENCE, '```', '',
+  ].join('\n');
+}
+
+/**
+ * @param {{sourceCommit: string, basis?: string|null, fence?: string}} opts
+ */
+function translatedSkill({ sourceCommit, basis = null, fence = DIVERGENT_FENCE }) {
+  const fm = [
+    '---', 'name: demo-skill', 'description: Eine Demo-Fertigkeit.',
+    'locale: de', 'source_locale: en', `source_commit: ${sourceCommit}`,
+  ];
+  if (basis) fm.push(`fence_basis_commit: ${basis}`);
+  fm.push('---');
+  return [...fm, '', '# Demo-Fertigkeit', '', '## Ablauf', '', '```bash', fence, '```', ''].join('\n');
+}
+
+/** A minimal repo with one English skill and one German mirror, driven via `--root`. */
+function makeFixture(t, translatedOpts) {
+  const dir = mkdtempSync(join(tmpdir(), 'fence-basis-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+
+  mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'demo-skill', 'SKILL.md'), englishSkill(), 'utf8');
+  git(dir, ['add', 'skills']);
+  git(dir, ['commit', '-m', 'english source']);
+  const sourceCommit = git(dir, ['rev-parse', 'HEAD']);
+
+  const translated = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+  mkdirSync(dirname(translated), { recursive: true });
+  writeFileSync(translated, translatedSkill({ sourceCommit, ...translatedOpts }), 'utf8');
+  git(dir, ['add', 'i18n']);
+  git(dir, ['commit', '-m', 'de mirror']);
+
+  return { dir, sourceCommit };
+}
+
+function check(dir) {
+  const r = spawnSync(process.execPath, [CHECKER, '--root', dir, '--json'], { encoding: 'utf8' });
+  assert.ok(r.stdout.trim().startsWith('{'), `checker produced no JSON:\n${r.stderr}`);
+  return JSON.parse(r.stdout);
+}
+
+const kinds = (out) => out.findings.map((f) => f.kind);
+
+describe('fence_basis_commit in the parity gate (#552)', () => {
+  it('absence is silent — an unverified file gets no claim finding', (t) => {
+    const { dir } = makeFixture(t, {});
+    const out = check(dir);
+    assert.ok(kinds(out).includes('diverged'), 'the divergence itself must still be reported');
+    assert.equal(out.staleBasisClaims, 0);
+    assert.equal(kinds(out).includes('stale-basis-claim'), false);
+  });
+
+  it('flags a file whose claimed basis its fences contradict', (t) => {
+    // The value is opaque to the gate — any non-empty string is a claim, and the point is that
+    // the claim is contradicted by the bytes, not that the sha is wrong.
+    const { dir } = makeFixture(t, { basis: 'deadbee' });
+    const out = check(dir);
+    assert.equal(out.staleBasisClaims, 1);
+    const claim = out.findings.find((f) => f.kind === 'stale-basis-claim');
+    assert.ok(claim, 'expected a stale-basis-claim finding');
+    assert.match(claim.firstDivergentLine, /claims fence_basis_commit/);
+    // Ungated: it must not be able to fail a run the divergence did not already fail.
+    assert.equal(claim.gated, false);
+  });
+
+  it('keeps flagging the divergence when the field is present — the field is not a bypass', (t) => {
+    // #552's named mutation, as coverage. If the field ever gates the byte comparison, the
+    // gated violation disappears here and this goes red.
+    const withField = makeFixture(t, { basis: 'deadbee' });
+    const out = check(withField.dir);
+    const gated = out.findings.filter((f) => f.gated);
+    assert.equal(gated.length, 1, 'the divergent gated fence must still be a violation');
+    assert.equal(gated[0].kind, 'diverged');
+    assert.equal(out.violations, 1);
+  });
+
+  it('a verified file with matching fences carries its claim cleanly', (t) => {
+    const { dir } = makeFixture(t, { basis: 'deadbee', fence: ENGLISH_FENCE });
+    const out = check(dir);
+    assert.equal(out.violations, 0, 'a byte-identical fence is not a violation');
+    assert.equal(out.staleBasisClaims, 0, 'no divergence means no false claim');
+  });
+});

--- a/scripts/test/fence-basis-stamp.test.js
+++ b/scripts/test/fence-basis-stamp.test.js
@@ -1,0 +1,146 @@
+/**
+ * fence-basis-stamp.test.js — what the normalizer is allowed to CLAIM (#552).
+ *
+ * `normalize-i18n-fences.js` is the only writer of `fence_basis_commit`, and it was the only
+ * tool in the schema with no wiring test — the reader side got three suites and four killed
+ * mutations while the pen that signs the corpus got none.
+ *
+ * The claim it writes names ONE English revision. Proving "every gated fence matches SOME
+ * revision" is a weaker statement than that, and the gap between them is reachable: the splice
+ * repairs only the DIVERGENT fences, so an untouched fence keeps a body from whatever revision
+ * it came from. A file can therefore end up mirroring revision W at one ordinal and X at
+ * another, and be stamped X — a false claim at the moment it is written, invisible to the
+ * checker (each body matches some revision), and inherited by the backfill.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = 'scripts/normalize-i18n-fences.js';
+
+function git(cwd, args) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(r.status, 0, `git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+/** English with two gated fences, whose bodies are given. */
+const english = (a, b) => [
+  '---', 'name: demo-skill', 'description: A demo skill.', '---', '',
+  '# Demo Skill', '', '## One', '', '```bash', a, '```', '', '## Two', '', '```bash', b, '```', '',
+].join('\n');
+
+const translated = (sourceCommit, a, b) => [
+  '---', 'name: demo-skill', 'description: Eine Demo.', 'locale: de', 'source_locale: en',
+  `source_commit: ${sourceCommit}`, '---', '',
+  '# Demo', '', '## Eins', '', '```bash', a, '```', '', '## Zwei', '', '```bash', b, '```', '',
+].join('\n');
+
+/**
+ * Two English revisions where BOTH fences changed, and a translation that carries the OLD
+ * second fence with a bumped `source_commit` — the #405 shape: a tool moved the field without
+ * retranslating. Its first fence is hand-localized, so it is divergent and the file enters the
+ * repair plan.
+ */
+function makeFixture(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'fence-stamp-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  mkdirSync(join(dir, 'scripts'), { recursive: true });
+  cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+  cpSync(join(REPO, 'scripts', 'lib'), join(dir, 'scripts', 'lib'), { recursive: true });
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+
+  const skill = join(dir, 'skills', 'demo-skill', 'SKILL.md');
+  mkdirSync(dirname(skill), { recursive: true });
+
+  // Revision W.
+  writeFileSync(skill, english('echo "A1"', 'echo "B1"'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english W']);
+
+  // Revision X — BOTH fence bodies change, so B1 belongs to W alone.
+  writeFileSync(skill, english('echo "A2"', 'echo "B2"'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english X']);
+  const X = git(dir, ['rev-parse', '--short', 'HEAD']);
+
+  // The mirror: fence 1 localized (divergent), fence 2 still W's body, source_commit at X.
+  const mirror = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+  mkdirSync(dirname(mirror), { recursive: true });
+  writeFileSync(mirror, translated(X, 'echo "LOKALISIERT"', 'echo "B1"'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de mirror']);
+
+  return { dir, mirror, X };
+}
+
+const run = (dir, args) => spawnSync(process.execPath, [SCRIPT, ...args], { cwd: dir, encoding: 'utf8' });
+const field = (text, name) => (text.match(new RegExp(`^\\s*${name}:\\s*(\\S+)`, 'm')) || [])[1];
+
+describe('normalize-i18n-fences: what it may claim (#552)', () => {
+  it('does not stamp a basis the file only partly mirrors', (t) => {
+    const { dir, mirror, X } = makeFixture(t);
+    const r = run(dir, ['--write']);
+    assert.equal(r.status, 0, `normalizer failed:\n${r.stdout}\n${r.stderr}`);
+
+    const after = readFileSync(mirror, 'utf8');
+
+    // The repair itself must still have happened: the divergent fence takes X's body.
+    assert.ok(after.includes('echo "A2"'), 'the divergent fence should be repaired from the basis');
+    // And the untouched fence still carries W's body — it matched history, so nothing rewrote it.
+    assert.ok(after.includes('echo "B1"'), 'the non-divergent fence is left alone by design');
+
+    // Therefore the file mirrors X at ordinal 1 and W at ordinal 2. No single revision
+    // describes it, so there is no true value to write and the field must be absent.
+    assert.equal(field(after, 'fence_basis_commit'), undefined,
+      `stamped a basis (${X}) that only one of two fences mirrors — a false claim at birth`);
+  });
+
+  it('stamps when the repaired file mirrors the basis at every gated fence', (t) => {
+    const dir = mkdtempSync(join(tmpdir(), 'fence-stamp-ok-'));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+    cpSync(join(REPO, 'scripts', 'lib'), join(dir, 'scripts', 'lib'), { recursive: true });
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+
+    git(dir, ['init', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'test@example.invalid']);
+    git(dir, ['config', 'user.name', 'Fixture']);
+
+    const skill = join(dir, 'skills', 'demo-skill', 'SKILL.md');
+    mkdirSync(dirname(skill), { recursive: true });
+    writeFileSync(skill, english('echo "A1"', 'echo "B1"'), 'utf8');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-m', 'english']);
+    const head = git(dir, ['rev-parse', '--short', 'HEAD']);
+
+    // Only fence 1 diverges; fence 2 already equals the basis, so after the repair the whole
+    // file mirrors that one revision and the claim is true.
+    const mirror = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+    mkdirSync(dirname(mirror), { recursive: true });
+    writeFileSync(mirror, translated(head, 'echo "LOKALISIERT"', 'echo "B1"'), 'utf8');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-m', 'de mirror']);
+
+    const r = run(dir, ['--write']);
+    assert.equal(r.status, 0, `normalizer failed:\n${r.stdout}\n${r.stderr}`);
+
+    const after = readFileSync(mirror, 'utf8');
+    assert.ok(after.includes('echo "A1"'), 'repaired from the basis');
+    assert.equal(field(after, 'fence_basis_commit'), head,
+      'a file that fully mirrors its basis should carry the claim');
+  });
+});

--- a/scripts/test/fence-basis-stamp.test.js
+++ b/scripts/test/fence-basis-stamp.test.js
@@ -36,9 +36,11 @@ const english = (a, b) => [
   '# Demo Skill', '', '## One', '', '```bash', a, '```', '', '## Two', '', '```bash', b, '```', '',
 ].join('\n');
 
-const translated = (sourceCommit, a, b) => [
+const translated = (sourceCommit, a, b, staleClaim = null) => [
   '---', 'name: demo-skill', 'description: Eine Demo.', 'locale: de', 'source_locale: en',
-  `source_commit: ${sourceCommit}`, '---', '',
+  `source_commit: ${sourceCommit}`,
+  ...(staleClaim ? [`fence_basis_commit: ${staleClaim}`] : []),
+  '---', '',
   '# Demo', '', '## Eins', '', '```bash', a, '```', '', '## Zwei', '', '```bash', b, '```', '',
 ].join('\n');
 
@@ -75,10 +77,14 @@ function makeFixture(t) {
   git(dir, ['commit', '-m', 'english X']);
   const X = git(dir, ['rev-parse', '--short', 'HEAD']);
 
-  // The mirror: fence 1 localized (divergent), fence 2 still W's body, source_commit at X.
+  // The mirror: fence 1 localized (divergent), fence 2 still W's body, source_commit at X, and
+  // a PRE-EXISTING claim from some earlier run. The stale claim is load-bearing for the test:
+  // without it the clear branch is a no-op here and deleting the `clearFrontmatterField` call
+  // survives the whole suite, leaving the "a partial repair must not keep an old claim" half of
+  // the design uncovered — the half the module's own docs call worse than no claim at all.
   const mirror = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
   mkdirSync(dirname(mirror), { recursive: true });
-  writeFileSync(mirror, translated(X, 'echo "LOKALISIERT"', 'echo "B1"'), 'utf8');
+  writeFileSync(mirror, translated(X, 'echo "LOKALISIERT"', 'echo "B1"', 'deadbee'), 'utf8');
   git(dir, ['add', '-A']);
   git(dir, ['commit', '-m', 'de mirror']);
 
@@ -102,9 +108,12 @@ describe('normalize-i18n-fences: what it may claim (#552)', () => {
     assert.ok(after.includes('echo "B1"'), 'the non-divergent fence is left alone by design');
 
     // Therefore the file mirrors X at ordinal 1 and W at ordinal 2. No single revision
-    // describes it, so there is no true value to write and the field must be absent.
+    // describes it, so there is no true value to write and the field must be absent — which
+    // also means the pre-existing `deadbee` claim must have been DESTROYED, not merely left
+    // un-updated. Both halves are asserted by this one equality: `undefined` fails if the tool
+    // stamped X, and equally if it kept deadbee.
     assert.equal(field(after, 'fence_basis_commit'), undefined,
-      `stamped a basis (${X}) that only one of two fences mirrors — a false claim at birth`);
+      `stamped a basis (${X}) that only one of two fences mirrors, or kept the stale deadbee claim`);
   });
 
   it('stamps when the repaired file mirrors the basis at every gated fence', (t) => {

--- a/scripts/test/fence-basis-stamp.test.js
+++ b/scripts/test/fence-basis-stamp.test.js
@@ -116,6 +116,83 @@ describe('normalize-i18n-fences: what it may claim (#552)', () => {
       `stamped a basis (${X}) that only one of two fences mirrors, or kept the stale deadbee claim`);
   });
 
+  it('refuses a basis whose bytes the history walk cannot see', (t) => {
+    // The off-pool corner. `everEnglish` comes from `git log --name-only -- <trees>`, which is
+    // path-limited and so history-simplified, and which lists NO paths for a merge commit — the
+    // walk's own docstring records that a body existing only as conflict-resolution output
+    // never enters the pool. The basis, by contrast, is resolved with `git cat-file --batch`,
+    // which answers for any object in the store.
+    //
+    // So a `source_commit` naming a merge resolves to bytes the pool does not contain:
+    // `mirrorsBasis` is true while the repaired fences are still outside the pool. Stamping
+    // there would sign a claim the parity gate contradicts on its very next run. Without this
+    // case the `stillDivergent === 0` conjunct is uncovered — measured: deleting it survived
+    // the whole suite.
+    const dir = mkdtempSync(join(tmpdir(), 'fence-stamp-merge-'));
+    t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+    cpSync(join(REPO, 'scripts', 'lib'), join(dir, 'scripts', 'lib'), { recursive: true });
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ type: 'module' }), 'utf8');
+
+    git(dir, ['init', '-b', 'main']);
+    git(dir, ['config', 'user.email', 'test@example.invalid']);
+    git(dir, ['config', 'user.name', 'Fixture']);
+
+    const skill = join(dir, 'skills', 'demo-skill', 'SKILL.md');
+    mkdirSync(dirname(skill), { recursive: true });
+    const write1 = (body) => writeFileSync(skill, [
+      '---', 'name: demo-skill', 'description: A demo skill.', '---', '',
+      '# Demo Skill', '', '```bash', body, '```', '',
+    ].join('\n'), 'utf8');
+
+    write1('echo "A1"');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-m', 'A']);
+
+    git(dir, ['checkout', '-b', 'side']);
+    write1('echo "B1"');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-m', 'B']);
+
+    git(dir, ['checkout', 'main']);
+    write1('echo "C1"');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-m', 'C']);
+
+    // Conflicting merge, resolved to a body present in NEITHER parent.
+    spawnSync('git', ['merge', 'side'], { cwd: dir, encoding: 'utf8' }); // expected to conflict
+    write1('echo "R1"');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '--no-edit', '-m', 'merge side, resolved to R1']);
+    const merge = git(dir, ['rev-parse', '--short', 'HEAD']);
+
+    // A later commit, so the working-tree pass contributes D1 rather than R1 — otherwise the
+    // resolution body re-enters the pool through the working tree and the corner closes.
+    write1('echo "D1"');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-m', 'D']);
+
+    const mirror = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+    mkdirSync(dirname(mirror), { recursive: true });
+    writeFileSync(mirror, [
+      '---', 'name: demo-skill', 'description: Eine Demo.', 'locale: de', 'source_locale: en',
+      `source_commit: ${merge}`, '---', '',
+      '# Demo', '', '```bash', 'echo "LOKALISIERT"', '```', '',
+    ].join('\n'), 'utf8');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-m', 'de mirror']);
+
+    const r = run(dir, ['--write']);
+    assert.equal(r.status, 0, `normalizer failed:\n${r.stdout}\n${r.stderr}`);
+
+    const after = readFileSync(mirror, 'utf8');
+    assert.ok(after.includes('echo "R1"'), 'the repair itself still happens, from the merge blob');
+    assert.equal(field(after, 'fence_basis_commit'), undefined,
+      'must not claim a basis whose bytes the gate cannot find in any walked revision');
+  });
+
   it('stamps when the repaired file mirrors the basis at every gated fence', (t) => {
     const dir = mkdtempSync(join(tmpdir(), 'fence-stamp-ok-'));
     t.after(() => rmSync(dir, { recursive: true, force: true }));

--- a/scripts/test/provenance.test.js
+++ b/scripts/test/provenance.test.js
@@ -170,6 +170,50 @@ describe('provenance: stampFrontmatterField', () => {
   });
 });
 
+describe('provenance: $-patterns in frontmatter are data, not substitutions', () => {
+  // `String.prototype.replace` expands `$$`, `$&`, backtick-$ and `$'` in the replacement even
+  // when the search argument is a plain STRING, and every replacement in this module is derived
+  // from the file's own frontmatter. Before the fix, stamping this fixture spliced the whole
+  // remainder of the file back in and duplicated the body — inside frontmatter, where the fence
+  // gate is blind. Zero corpus files carry such a value today; this is the write path the
+  // backfill runs over ~3,644 of them.
+  const dollars = [
+    '---',
+    'name: demo',
+    'source_commit: abc1234',
+    "description: shell docs mentioning $' and $& and $$ and $`",
+    '---',
+    '',
+    '# Body',
+    '',
+    'SENTINEL-BODY-LINE',
+    '',
+  ].join('\n');
+
+  it('stamps without corrupting a $-bearing frontmatter', () => {
+    const out = stampFrontmatterField(dollars, FENCE_BASIS_FIELD, 'ff00ff0');
+    assert.ok(out);
+    assert.equal(readFrontmatterField(out, FENCE_BASIS_FIELD), 'ff00ff0');
+    assert.equal(readFrontmatterField(out, SOURCE_COMMIT_FIELD), 'abc1234');
+    // The description survives verbatim, and the body appears exactly once.
+    assert.ok(out.includes("description: shell docs mentioning $' and $& and $$ and $`"));
+    assert.equal(out.match(/SENTINEL-BODY-LINE/g).length, 1);
+    assert.equal(out.match(/^---$/gm).length, 2, 'exactly one frontmatter block');
+  });
+
+  it('clears without corrupting a $-bearing frontmatter', () => {
+    const stamped = stampFrontmatterField(dollars, FENCE_BASIS_FIELD, 'ff00ff0');
+    assert.equal(clearFrontmatterField(stamped, FENCE_BASIS_FIELD), dollars,
+      'stamp then clear must round-trip to the original bytes');
+  });
+
+  it('a $-bearing VALUE is written literally', () => {
+    const out = stampFrontmatterField(flat, FENCE_BASIS_FIELD, '$&evil');
+    assert.equal(readFrontmatterField(out, FENCE_BASIS_FIELD), '$&evil');
+    assert.equal(out.match(/SENTINEL/g), null);
+  });
+});
+
 describe('provenance: clearFrontmatterField', () => {
   it('removes the field', () => {
     const stamped = stampFrontmatterField(flat, FENCE_BASIS_FIELD, 'ff00ff0');

--- a/scripts/test/provenance.test.js
+++ b/scripts/test/provenance.test.js
@@ -1,0 +1,194 @@
+/**
+ * provenance.test.js — the two-field provenance schema (#552).
+ *
+ * These pin the three properties the schema rests on, each of which has a named failure the
+ * repo has already paid for once:
+ *
+ *   - the reader is ANCHORED to frontmatter, because the reader it replaces in
+ *     `generate-translation-status.js` is not, and an unanchored one reads a `source_commit:`
+ *     written inside a body fence as metadata;
+ *   - the stamper places the new field beside its SIBLING rather than at a fixed depth, because
+ *     the corpus nests these fields differently per file and a fixed depth writes valid-looking
+ *     YAML into the wrong block — the `sed '/^  tags:/a\'` scaffold bug;
+ *   - the field NAME cannot contain `source_commit`, because that unanchored reader would
+ *     capture it.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  SOURCE_COMMIT_FIELD,
+  FENCE_BASIS_FIELD,
+  readFrontmatterField,
+  stampFrontmatterField,
+  clearFrontmatterField,
+} from '../lib/provenance.js';
+import { frontmatterUnparsed } from '../lib/translation-status.js';
+
+const flat = [
+  '---',
+  'name: commit-changes',
+  'locale: de',
+  'source_locale: en',
+  'source_commit: abc1234',
+  'translator: Claude plus human review',
+  '---',
+  '',
+  '# Body',
+  '',
+].join('\n');
+
+const nested = [
+  '---',
+  'name: commit-changes',
+  'metadata:',
+  '  locale: de',
+  '  source_locale: en',
+  '  source_commit: abc1234',
+  '---',
+  '',
+  '# Body',
+  '',
+].join('\n');
+
+describe('provenance: field names', () => {
+  it('the new field name cannot contain the old one', () => {
+    // `generate-translation-status.js` matches /source_commit:.../ with no `^` anchor, so a
+    // name like `mirror_source_commit` would be read as the old field wherever it appeared.
+    // This is the guard on that reasoning, not a style assertion.
+    assert.equal(FENCE_BASIS_FIELD.includes(SOURCE_COMMIT_FIELD), false);
+    assert.notEqual(FENCE_BASIS_FIELD, SOURCE_COMMIT_FIELD);
+  });
+});
+
+describe('provenance: the frontmatter-mask tripwire covers the new field', () => {
+  // A provenance field missing from `FRONTMATTER_KEYS` is not cosmetic. When `stripFrontmatter`
+  // fails open — it returns the whole text when it cannot find two `---` lines — the field
+  // becomes body. It is short, it clears the substantive filter, and it sits in no English
+  // pool, so it reads as novel prose and pushes a scaffold toward TRANSLATED. That is the exact
+  // measured failure recorded above `frontmatterUnparsed`, which went `no-novel-lines` to
+  // `has-novel-lines` on four lines of a file's own metadata.
+  it('detects fence_basis_commit surviving into the body', () => {
+    assert.equal(frontmatterUnparsed(`${FENCE_BASIS_FIELD}: ff00ff0\n`), true);
+  });
+
+  it('still detects the field it was written for', () => {
+    assert.equal(frontmatterUnparsed(`${SOURCE_COMMIT_FIELD}: abc1234\n`), true);
+  });
+
+  it('does not fire on ordinary prose', () => {
+    assert.equal(frontmatterUnparsed('This paragraph mentions a commit.\n'), false);
+  });
+});
+
+describe('provenance: readFrontmatterField', () => {
+  it('reads a top-level field', () => {
+    assert.equal(readFrontmatterField(flat, SOURCE_COMMIT_FIELD), 'abc1234');
+  });
+
+  it('reads an indented field, because nesting varies per file', () => {
+    assert.equal(readFrontmatterField(nested, SOURCE_COMMIT_FIELD), 'abc1234');
+  });
+
+  it('is anchored to frontmatter and ignores a lookalike in the body', () => {
+    const decoy = [
+      '---',
+      'name: x',
+      'locale: de',
+      '---',
+      '',
+      'Example frontmatter you might write:',
+      '',
+      '```yaml',
+      'source_commit: deadbee',
+      '```',
+      '',
+    ].join('\n');
+    // The unanchored reader this replaces returns 'deadbee' here.
+    assert.equal(readFrontmatterField(decoy, SOURCE_COMMIT_FIELD), null);
+  });
+
+  it('strips quotes and a trailing YAML comment', () => {
+    const quoted = flat.replace('source_commit: abc1234', 'source_commit: "abc1234"  # scaffolded');
+    assert.equal(readFrontmatterField(quoted, SOURCE_COMMIT_FIELD), 'abc1234');
+  });
+
+  it('returns null when the file has no frontmatter', () => {
+    assert.equal(readFrontmatterField('# Just a body\n', SOURCE_COMMIT_FIELD), null);
+  });
+
+  it('returns null for an absent field', () => {
+    assert.equal(readFrontmatterField(flat, FENCE_BASIS_FIELD), null);
+  });
+});
+
+describe('provenance: stampFrontmatterField', () => {
+  it('inserts beside source_commit at top level, and reads back', () => {
+    const out = stampFrontmatterField(flat, FENCE_BASIS_FIELD, 'ff00ff0');
+    assert.ok(out);
+    assert.equal(readFrontmatterField(out, FENCE_BASIS_FIELD), 'ff00ff0');
+    assert.equal(readFrontmatterField(out, SOURCE_COMMIT_FIELD), 'abc1234', 'must not disturb the old field');
+    assert.match(out, /^source_commit: abc1234\nfence_basis_commit: ff00ff0$/m);
+  });
+
+  it('copies the anchor indentation when the block is nested', () => {
+    const out = stampFrontmatterField(nested, FENCE_BASIS_FIELD, 'ff00ff0');
+    assert.ok(out);
+    // Two spaces, matching its sibling — not column 0, which would leave the `metadata:` block
+    // and change the field's meaning while still parsing as YAML.
+    assert.match(out, /^ {2}source_commit: abc1234\n {2}fence_basis_commit: ff00ff0$/m);
+    assert.equal(readFrontmatterField(out, FENCE_BASIS_FIELD), 'ff00ff0');
+  });
+
+  it('replaces an existing value rather than adding a second line', () => {
+    const once = stampFrontmatterField(flat, FENCE_BASIS_FIELD, 'aaaaaaa');
+    const twice = stampFrontmatterField(once, FENCE_BASIS_FIELD, 'bbbbbbb');
+    assert.equal(readFrontmatterField(twice, FENCE_BASIS_FIELD), 'bbbbbbb');
+    assert.equal(twice.match(/fence_basis_commit:/g).length, 1);
+  });
+
+  it('preserves indentation when replacing a nested value', () => {
+    const once = stampFrontmatterField(nested, FENCE_BASIS_FIELD, 'aaaaaaa');
+    const twice = stampFrontmatterField(once, FENCE_BASIS_FIELD, 'bbbbbbb');
+    assert.match(twice, /^ {2}fence_basis_commit: bbbbbbb$/m);
+  });
+
+  it('refuses when there is no anchor field, rather than guessing a depth', () => {
+    const anchorless = ['---', 'name: x', 'locale: de', '---', '', 'body', ''].join('\n');
+    assert.equal(stampFrontmatterField(anchorless, FENCE_BASIS_FIELD, 'ff00ff0'), null);
+  });
+
+  it('refuses when there is no frontmatter', () => {
+    assert.equal(stampFrontmatterField('# body\n', FENCE_BASIS_FIELD, 'ff00ff0'), null);
+  });
+
+  it('leaves the body untouched', () => {
+    const withBody = flat + '\n```yaml\nkey: value\n```\n';
+    const out = stampFrontmatterField(withBody, FENCE_BASIS_FIELD, 'ff00ff0');
+    assert.ok(out.endsWith('```yaml\nkey: value\n```\n'));
+  });
+});
+
+describe('provenance: clearFrontmatterField', () => {
+  it('removes the field', () => {
+    const stamped = stampFrontmatterField(flat, FENCE_BASIS_FIELD, 'ff00ff0');
+    const cleared = clearFrontmatterField(stamped, FENCE_BASIS_FIELD);
+    assert.equal(readFrontmatterField(cleared, FENCE_BASIS_FIELD), null);
+    assert.equal(readFrontmatterField(cleared, SOURCE_COMMIT_FIELD), 'abc1234');
+  });
+
+  it('round-trips back to the original text', () => {
+    const stamped = stampFrontmatterField(flat, FENCE_BASIS_FIELD, 'ff00ff0');
+    assert.equal(clearFrontmatterField(stamped, FENCE_BASIS_FIELD), flat);
+  });
+
+  it('is a no-op when the field is absent', () => {
+    assert.equal(clearFrontmatterField(flat, FENCE_BASIS_FIELD), flat);
+  });
+
+  it('removes a nested field without disturbing its siblings', () => {
+    const stamped = stampFrontmatterField(nested, FENCE_BASIS_FIELD, 'ff00ff0');
+    assert.equal(clearFrontmatterField(stamped, FENCE_BASIS_FIELD), nested);
+  });
+});

--- a/scripts/test/translation-status-date.test.js
+++ b/scripts/test/translation-status-date.test.js
@@ -1,0 +1,119 @@
+/**
+ * translation-status-date.test.js — `last_updated` moves with the counts, not the clock (#603).
+ *
+ * The behaviour is one ternary, and a pure-function test of it would be worthless: the failure
+ * this guards is somebody "simplifying" `last_updated: unchanged ? previous.last_updated : today`
+ * back to `last_updated: today`, which leaves any extracted helper present and merely unused.
+ * Only a run of the real generator can see that, so these drive it as a subprocess against a
+ * throwaway repo via `--root`.
+ *
+ * Both directions are asserted. A date that never moves is not a fix — it is a different lie
+ * from the one #603 reported, and a test pinning only the preserve half would call it a pass.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = join(REPO, 'scripts', 'generate-translation-status.js');
+const STALE_DATE = '2020-01-01';
+
+function git(cwd, args) {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  assert.equal(r.status, 0, `git ${args.join(' ')} failed: ${r.stderr}`);
+  return r.stdout.trim();
+}
+
+function makeFixture(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'status-date-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+
+  mkdirSync(join(dir, 'i18n'), { recursive: true });
+  writeFileSync(join(dir, 'i18n', '_config.yml'),
+    'supported_locales:\n  - code: de\n    name: German\n', 'utf8');
+
+  // Source counts come from the registries, not from the disk, so the fixture needs them.
+  // teams/ and guides/ are optional to the generator and deliberately left out.
+  mkdirSync(join(dir, 'skills'), { recursive: true });
+  mkdirSync(join(dir, 'agents'), { recursive: true });
+  writeFileSync(join(dir, 'skills', '_registry.yml'), 'total_skills: 1\n', 'utf8');
+  writeFileSync(join(dir, 'agents', '_registry.yml'), 'total_agents: 0\n', 'utf8');
+
+  mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'demo-skill', 'SKILL.md'),
+    ['---', 'name: demo-skill', 'description: A demo.', '---', '', '# Demo', '',
+      'A substantive English paragraph that a translation can differ from.', ''].join('\n'),
+    'utf8');
+
+  const translated = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+  mkdirSync(dirname(translated), { recursive: true });
+  writeFileSync(translated,
+    ['---', 'name: demo-skill', 'description: Eine Demo.', 'locale: de', 'source_locale: en',
+      'source_commit: 0000000', '---', '', '# Demo', '',
+      'Ein inhaltlicher deutscher Absatz, der sich vom Englischen unterscheidet.', ''].join('\n'),
+    'utf8');
+
+  git(dir, ['add', 'skills', 'i18n']);
+  git(dir, ['commit', '-m', 'fixture']);
+
+  return { dir, statusPath: join(dir, 'i18n', 'de', 'translation_status.yml') };
+}
+
+function generate(dir) {
+  const r = spawnSync(process.execPath, [SCRIPT, '--root', dir], { encoding: 'utf8' });
+  assert.equal(r.status, 0, `generator failed:\n${r.stdout}\n${r.stderr}`);
+  return r.stdout;
+}
+
+const dateOf = (statusPath) =>
+  (readFileSync(statusPath, 'utf8').match(/^last_updated:\s*'?([\d-]+)'?/m) || [])[1];
+
+describe('translation_status last_updated (#603)', () => {
+  it('generates a status file with a date on first run', (t) => {
+    const { dir, statusPath } = makeFixture(t);
+    generate(dir);
+    assert.ok(existsSync(statusPath), 'expected a status file');
+    assert.match(dateOf(statusPath), /^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('PRESERVES a stale date when no count moved', (t) => {
+    const { dir, statusPath } = makeFixture(t);
+    generate(dir);
+
+    // Backdate only the date. Every count stays exactly as generated.
+    const backdated = readFileSync(statusPath, 'utf8')
+      .replace(/^last_updated:.*$/m, `last_updated: '${STALE_DATE}'`);
+    writeFileSync(statusPath, backdated, 'utf8');
+
+    const out = generate(dir);
+    assert.equal(dateOf(statusPath), STALE_DATE,
+      'the date must not move when the counts did not — that is #603');
+    assert.match(out, /UNCHANGED:/, 'a no-op regeneration should skip the write entirely');
+  });
+
+  it('BUMPS the date when a count moved', (t) => {
+    const { dir, statusPath } = makeFixture(t);
+    generate(dir);
+
+    // Backdate AND corrupt a count, so the only thing distinguishing this from the case above
+    // is that the coverage payload no longer matches what the generator computes.
+    const tampered = readFileSync(statusPath, 'utf8')
+      .replace(/^last_updated:.*$/m, `last_updated: '${STALE_DATE}'`)
+      .replace(/(translated|total):\s*\d+/, (m, k) => `${k}: 999`);
+    writeFileSync(statusPath, tampered, 'utf8');
+
+    const out = generate(dir);
+    assert.notEqual(dateOf(statusPath), STALE_DATE,
+      'a frozen date is its own lie — the date must move when the counts do');
+    assert.match(out, /GENERATED:/);
+  });
+});

--- a/scripts/translate-content.sh
+++ b/scripts/translate-content.sh
@@ -78,8 +78,19 @@ fi
 cp "$SOURCE_FILE" "$TARGET_FILE"
 
 # Add translation frontmatter fields after the existing frontmatter
-# We insert locale, source_locale, source_commit, translator, translation_date
-# into the YAML frontmatter block (before the closing ---)
+# We insert locale, source_locale, source_commit, fence_basis_commit, translator,
+# translation_date into the YAML frontmatter block (before the closing ---)
+#
+# fence_basis_commit (#552) is the revision this file's frozen fences were last verified
+# against, and it is separate from source_commit for a reason a scaffold makes vivid: the two
+# are equal HERE and diverge immediately afterwards. A scaffold is a byte copy, so its fences
+# trivially mirror $SOURCE_COMMIT and the claim is true at birth. From then on a human bumps
+# source_commit by retranslating, while normalize-i18n-fences.js bumps fence_basis_commit by
+# propagating English bytes -- two different events that one field could not record.
+#
+# Stamping it here is what keeps the field's absence meaningful. If new translations were born
+# without it, "absent" would mean both "unverified" and "recent", and it would stop being usable
+# as a backlog signal.
 
 # Find the line number of the second --- (closing frontmatter)
 CLOSE_LINE=$(awk '/^---$/{count++; if(count==2){print NR; exit}}' "$TARGET_FILE")
@@ -95,6 +106,7 @@ if [ "$CONTENT_TYPE" = "skills" ]; then
   locale: $LOCALE\\
   source_locale: en\\
   source_commit: $SOURCE_COMMIT\\
+  fence_basis_commit: $SOURCE_COMMIT\\
   translator: \"Claude + human review\"\\
   translation_date: \"$TODAY\"" "$TARGET_FILE"
 else
@@ -103,9 +115,10 @@ else
 locale: $LOCALE\\
 source_locale: en\\
 source_commit: $SOURCE_COMMIT\\
+fence_basis_commit: $SOURCE_COMMIT\\
 translator: \"Claude + human review\"\\
 translation_date: \"$TODAY\"" "$TARGET_FILE"
 fi
 
-echo "CREATED: $TARGET_FILE (source_commit: $SOURCE_COMMIT)"
+echo "CREATED: $TARGET_FILE (source_commit: $SOURCE_COMMIT, fence_basis_commit: $SOURCE_COMMIT)"
 echo "  Next: translate prose sections, keeping code blocks and IDs in English"

--- a/skills/translate-content/SKILL.md
+++ b/skills/translate-content/SKILL.md
@@ -70,7 +70,10 @@ npm run translate:scaffold -- <content-type> <id> <locale>
 2.3. Verify the scaffolded file has translation frontmatter fields:
    - `locale` — matches target locale
    - `source_locale` — `en`
-   - `source_commit` — current git short hash
+   - `source_commit` — current git short hash; the English revision a human translated against
+   - `fence_basis_commit` — the revision this file's frozen fences were verified against (#552).
+     Equal to `source_commit` on a fresh scaffold, because a scaffold is a byte copy, and they
+     diverge from the first edit of either kind. Never move this one by hand.
    - `translator` — attribution string
    - `translation_date` — today's date
 


### PR DESCRIPTION
Unit 3 of the sprint. **Schema and tooling only — the corpus backfill is a separate PR**, deliberately, so the mechanical 10-locale diff lands on its own and stays reviewable.

Addresses #552 and #603. Unblocks units 4 and 5.

## The problem

`source_commit` was asked to mean two things, and a mechanical fence repair forces the contradiction:

- **Which English revision did a human translate against?** Staleness reads this. A tool must never move it — bumping it asserts a translation event that never happened, the lie #405 caught `evolve-skill` telling.
- **Which English revision do this file's frozen fences mirror?** Fence parity reads this. It *must* move when the normalizer propagates English bytes, or the frontmatter contradicts the body it just rewrote.

Bump it and the first is false; leave it and the second is. A second field resolves it instead of choosing a side.

## `fence_basis_commit`

New module `scripts/lib/provenance.js` owns both field names and one frontmatter reader. Two design rules, both load-bearing:

**Presence is a claim; absence is not a defect.** Absent means unverified — the honest state for the ~40 files whose fences match no English revision, and for every file predating the field. The alternative, stamping `source_commit` everywhere at backfill, writes a *false* claim into the corpus to be corrected later, which is the disagreement-between-files failure this whole change exists to end.

**It never gates a comparison.** The byte check stays unconditional. The field is read for reporting and for the one thing bytes cannot say: a file *claiming* a verified basis whose fences diverge. Reported as `stale-basis-claim`, deliberately ungated, since the divergence underneath is already counted and gating it would double-count the same file.

The name avoids the substring `source_commit` on purpose — the status generator's reader was unanchored, so a name like `mirror_source_commit` would have been captured by it. Pinned by a test rather than a comment.

## Writers

| Writer | Behaviour |
|---|---|
| `translate-content.sh`, `bulk-scaffold-caveman.sh` | stamp it — a scaffold is a byte copy, so the claim is true at birth. Stamping keeps *absent* meaning "unverified" rather than also meaning "recent". |
| `normalize-i18n-fences.js` | stamps **only** when the repair leaves nothing gated divergent, re-derived from the repaired bytes rather than the restore count, and **only** when the basis is a real revision — never the `worktree` fallback. Otherwise it **clears** the field, so a `--tag`-scoped partial repair cannot leave a claim from an earlier complete verification. |

`fence_basis_commit` is also added to the frontmatter-mask tripwire in `lib/translation-status.js`. A provenance field missing there becomes body text when the mask fails open, clears the substantive filter, sits in no English pool, and inflates a scaffold toward TRANSLATED — the measured failure already recorded above `frontmatterUnparsed`.

## #603, settled in the same pass

`last_updated` stamped the **run** date, so every regeneration dirtied all ten status files whether or not a count moved — 33 of the 61 commits touching `i18n/de/translation_status.yml` changed nothing else. It now moves only when the counts move, and a no-op regeneration skips the write entirely.

`generate-translation-status.js` gained `--root` so this is *tested* rather than demonstrated. Extending it meant extending the strict unknown-flag guard; the value after `--root` is excused **by position, not by shape**, because excusing "anything not starting with `--`" would also swallow a genuine typo like `verdicts` — the exact silent-misparse class that guard exists to catch. Verified both ways: `--verdcits` still rejected, bare `--root` exits 2.

## Reader unification

Three hand-rolled `source_commit` readers existed with three different regexes and three different bugs. The status generator's had **no `^` anchor at all**, so it read a `source_commit:` inside a ```` ```yaml ```` fence as the file's own metadata — the exact shape `i18n/README.md` documents. That is why the staleness gate and the status generator could read the same field differently without anything noticing. There is now one reader, anchored to the frontmatter block.

## Invariants — measured, not assumed

A reader change could silently move every verdict in the corpus, so both swaps were measured:

| Measurement | Before | After |
|---|---|---|
| fence parity: file pairs / fences | 3,644 / 22,970 | 3,644 / 22,970 |
| gated findings (78 diverged + 9 tag-sequence) | 87 across 40 files | 87 across 40 files |
| ungated divergences / unalignable | 756 / 60 | 756 / 60 |
| `staleBasisClaims` | — | 0 (no file carries the field yet) |
| `check-translation-freshness` stale | 2,571 | 2,571 |
| `translation:status` | — | all ten `UNCHANGED`, i.e. byte-identical |

## Proving the new checks can fail

Four mutations, each run against `npm run test:scripts` — the command CI runs, not an inner one:

| Mutation | Result |
|---|---|
| drop `fence_basis_commit` from the frontmatter tripwire | **KILLED** by 1 |
| delete the `stale-basis-claim` reporting | **KILLED** by 1 |
| make the field suppress the byte check (`claimedBasis \|\| englishFences.has(...)`) | **KILLED** by 2 |
| revert the date fix to `last_updated: today` | **KILLED** by 1 |

The third is the one that matters: it is the design's central risk, and it proves the field is neither decorative nor a bypass.

## Gates

`test:scripts` 330 pass / 0 fail (302 on main, 28 new). `validate:line-endings`, `check-readmes`, `validate:i18n-parity` all clean. All run bare with `$?` read directly, never through a pipe.

`validate:translations` exits 1 both here and on `origin/main` with the identical 2,571 — pre-existing backlog, not this branch.

## Next

The backfill PR decides what to write for the ~40 divergent files. Per the rule above it writes **nothing** for them — presence would be a false claim — and the invariant for that commit is: fence-parity count unchanged, verdict counts unchanged, and frontmatter hunks only with zero fence-body bytes in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4ZV4v4eV288vnpBcoHE9m