### PR TITLE
fix(readmes): derive guide category order from the registry (#644)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ New here? Start with [Understanding the System](guides/understanding-the-system.
 - [Epigenetics-Inspired Activation Control](guides/epigenetics-activation-control.md) — Runtime activation profiles controlling which agents, skills, and teams are expressed, grounded in molecular epigenetics
 - [Understanding the Synoptic Mind](guides/understanding-the-synoptic-mind.md) — The adaptic concept — panoramic synthesis through simultaneous multi-domain awareness, theoretical foundations, and practical use
 - [Agent Memory Hygiene](guides/agent-memory-hygiene.md) — Three-layer model — weights, retrieval, behavior — for diagnosing what kind of forgetting a memory problem actually needs and applying the right tool
+
+**Investigation**
+
+- [Reverse-Engineering a CLI Harness](guides/reverse-engineering-a-cli-harness.md) — Five-phase methodology for legitimate integration research against a closed-source CLI harness — baseline, flag discovery, dark-launch detection, wire capture, redaction discipline
 <!-- AUTO:END:guides -->
 
 ## Translations

--- a/guides/README.md
+++ b/guides/README.md
@@ -119,3 +119,10 @@ The adaptic concept — panoramic synthesis through simultaneous multi-domain aw
 
 ### [Agent Memory Hygiene](agent-memory-hygiene.md)
 Three-layer model — weights, retrieval, behavior — for diagnosing what kind of forgetting a memory problem actually needs and applying the right tool.
+
+## Investigation
+
+*Methodology guides for legitimate research, audit, and reverse-engineering of integration surfaces*
+
+### [Reverse-Engineering a CLI Harness](reverse-engineering-a-cli-harness.md)
+Five-phase methodology for legitimate integration research against a closed-source CLI harness — baseline, flag discovery, dark-launch detection, wire capture, redaction discipline.

--- a/scripts/envelopes/a11-guide-category-render.mjs
+++ b/scripts/envelopes/a11-guide-category-render.mjs
@@ -12,7 +12,16 @@
  *
  *   npm run gate-envelope -- --spec scripts/envelopes/a11-guide-category-render.mjs
  *
- * Result at introduction, 2026-08-18:
+ * Result on the first run, 2026-08-18, against A11's first version:
+ *
+ *     gate-envelope: 3 killed, 1 survived as documented of 5 case(s).
+ *     [WRONG-RED] the A11 extraction pattern drifts and matches nothing
+ *
+ * That row was a real defect in A11, not a mis-specified case, and it is the reason the
+ * third case exists. Under `set -euo pipefail` the bare `a11_cats=$(grep ... | ...)`
+ * assignment aborted the whole script the moment grep matched nothing: red, but with no
+ * diagnostic, with A11's zero-check dead, and with A12 and all of categories B and C never
+ * reached. A `|| true` on the extraction fixed it. Re-measured after that fix:
  *
  *     gate-envelope: 4 killed, 1 survived as documented of 5 case(s).
  *

--- a/scripts/envelopes/a11-guide-category-render.mjs
+++ b/scripts/envelopes/a11-guide-category-render.mjs
@@ -25,9 +25,21 @@
  *
  *     gate-envelope: 4 killed, 1 survived as documented of 5 case(s).
  *
+ * An adversarial review then found three further routes to #644's exact symptom — a guide in
+ * no generated index with every gate green — that the five cases above could not see. Each
+ * was reproduced by hand, then fixed, and cases 5-8 are those reproductions:
+ *
+ *     gate-envelope: 8 killed, 1 survived as documented of 9 case(s).
+ *
  * Note the first case. It is not a synthetic break — it restores `guides/README.md` to the
- * exact state `main` was in before this PR, which is what makes it evidence that A11 would
- * have caught #644 rather than merely that A11 can go red.
+ * state `main` was in before this PR, up to one trailing newline (the `find` below opens with
+ * a newline and takes the second of the two blank-line bytes; measured delta is 1 byte). That
+ * is what makes it evidence A11 would have caught #644, rather than merely that A11 can go red.
+ *
+ * ROT WARNING: cases below hardcode `total_guides: 35` and the full text of the investigation
+ * entry. Adding a guide changes both, and the runner will report INCONCLUSIVE rather than
+ * mutate the wrong site — correct, but silent until someone runs this, since the envelope is
+ * deliberately not in CI. Update the literals in the same commit that adds a guide.
  *
  * The `expect: null` case at the end pins A11's scope boundary as a measurement rather than
  * a prose claim: A11 is a CATEGORY-level assertion and does not notice a single guide missing
@@ -85,6 +97,58 @@ Five-phase methodology for legitimate integration research against a closed-sour
     find: 'total_guides: 35',
     replace: 'total_guides: 36',
     expect: 'guides disk=35 registry=36',
+  },
+  {
+    // A11a. The review's sharpest finding: an entry whose category is unusable drops the
+    // guide from BOTH indexes while every surviving category still renders, so a check on
+    // DISTINCT values finds nothing wrong. Reproduced by hand before the fix — the guide
+    // vanished from both files and the first version of A11 stayed green. The deleted-line
+    // and bare-`category:` variants take the same route and the same count check catches them.
+    label: 'a guide entry whose category is empty — invisible in both indexes, no value to check',
+    file: 'guides/_registry.yml',
+    find: '    category: investigation',
+    replace: '    category: ""',
+    expect: "usable 'category:' value(s)",
+  },
+  {
+    // A11b. The laundered state: the category renders correctly everywhere, but nothing
+    // declares it. Reached in practice by typo'ing a category and then following A11c's own
+    // remediation advice — measured, `npm run update-readmes` renders `## Investigatoin` with
+    // `*investigatoin*` as its description and turns every gate green. Mutating the block
+    // rather than the guide reaches that end state in one file, which is what the runner does.
+    label: 'a used category is not declared in the categories block',
+    file: 'guides/_registry.yml',
+    find: `  investigation:
+    description: Methodology guides for legitimate research, audit, and reverse-engineering of integration surfaces
+`,
+    replace: '',
+    expect: "is not declared in the 'categories:' block",
+  },
+  {
+    // A11c, the README.md half. The two generators share their ORDER and nothing else — the
+    // loop, the empty-skip and the rendering are separately duplicated. Measured: reverting
+    // `generateGuidesSection` alone to the old literal drops the guide from README.md while
+    // guides/README.md keeps it, and `check-readmes` and the old A11 both stay green. This
+    // case mutates the rendered file directly, because the runner does find/replace and never
+    // regenerates. Note the different markup: `**Label**` here, `## Label` in guides/README.md.
+    label: 'the investigation block absent from the ROOT README index',
+    file: 'README.md',
+    find: `
+**Investigation**
+
+- [Reverse-Engineering a CLI Harness](guides/reverse-engineering-a-cli-harness.md) — Five-phase methodology for legitimate integration research against a closed-source CLI harness — baseline, flag discovery, dark-launch detection, wire capture, redaction discipline`,
+    replace: '',
+    expect: "has no '**Investigation**' line in README.md",
+  },
+  {
+    // A12's path set. The count alone inherits A4/A5's blindness — a guide file on disk with
+    // `total_guides` bumped and no registry entry keeps both numbers equal and is in no index.
+    // A path pointing nowhere is the same disagreement in the reachable-by-find/replace form.
+    label: 'a registry path that no file on disk backs',
+    file: 'guides/_registry.yml',
+    find: '    path: guides/reverse-engineering-a-cli-harness.md',
+    replace: '    path: guides/does-not-exist.md',
+    expect: 'path set differs from guides/*.md on disk',
   },
   {
     // A11's scope boundary, measured. The guide's category heading survives, so A11 is

--- a/scripts/envelopes/a11-guide-category-render.mjs
+++ b/scripts/envelopes/a11-guide-category-render.mjs
@@ -40,9 +40,16 @@
  *     [KILLED]   total_guides drifts from the guides on disk
  *                FAIL: guides disk=35 total_guides=36
  *
- * so the standing tally is 8 killed, 1 survived as documented of 9. Recorded as two runs rather
- * than restated as one clean nine, because the WRONG-RED is the useful part: a case asserting
- * only "the gate went red" would have passed and told nobody the message had moved.
+ * Recorded as two runs rather than restated as one clean nine, because the WRONG-RED is the
+ * useful part: a case asserting only "the gate went red" would have passed and told nobody the
+ * message had moved.
+ *
+ * A verification pass then found that A12's own two extractions carried no `|| true` (round 1
+ * lines copied from A4/A5), and that the co-deletion route — a whole entry removed, every count
+ * still agreeing — was guarded by the path set alone and tested in one direction only. Case 5
+ * is that missing direction. Full run after both fixes:
+ *
+ *     gate-envelope: 9 killed, 1 survived as documented of 10 case(s).
  *
  * Note the first case. It is not a synthetic break — it restores `guides/README.md` to the
  * state `main` was in before this PR, up to one trailing newline (the `find` below opens with

--- a/scripts/envelopes/a11-guide-category-render.mjs
+++ b/scripts/envelopes/a11-guide-category-render.mjs
@@ -27,9 +27,22 @@
  *
  * An adversarial review then found three further routes to #644's exact symptom — a guide in
  * no generated index with every gate green — that the five cases above could not see. Each
- * was reproduced by hand, then fixed, and cases 5-8 are those reproductions:
+ * was reproduced by hand, then fixed, and cases 5-8 are those reproductions. The nine-case run
+ * reported:
  *
- *     gate-envelope: 8 killed, 1 survived as documented of 9 case(s).
+ *     gate-envelope: 7 killed, 1 survived as documented, 1 inconclusive/invalid of 9 case(s).
+ *     [WRONG-RED] total_guides drifts from the guides on disk
+ *
+ * — because round 2 renamed A12's message field and case 4's `expect` still named the old one.
+ * The gate was red and correct throughout; only the expectation was stale. After updating it,
+ * re-run with `--only 'total_guides drifts'`:
+ *
+ *     [KILLED]   total_guides drifts from the guides on disk
+ *                FAIL: guides disk=35 total_guides=36
+ *
+ * so the standing tally is 8 killed, 1 survived as documented of 9. Recorded as two runs rather
+ * than restated as one clean nine, because the WRONG-RED is the useful part: a case asserting
+ * only "the gate went red" would have passed and told nobody the message had moved.
  *
  * Note the first case. It is not a synthetic break — it restores `guides/README.md` to the
  * state `main` was in before this PR, up to one trailing newline (the `find` below opens with
@@ -92,11 +105,16 @@ Five-phase methodology for legitimate integration research against a closed-sour
   {
     // A12: the total no validator compared to disk before #644. `total_skills` is checked by
     // validate-skills.yml, agents and teams by A4/A5, guides by nothing.
+    // The `expect` names A12's message verbatim, and that is the point of naming it: round 2
+    // renamed the field from `registry=` to `total_guides=` (A12 now checks two things, so
+    // "registry" had become ambiguous) and this case reported WRONG-RED until it was updated.
+    // The gate was red and correct throughout — only the expectation was stale. A case that
+    // asserted merely "went red" would have passed and told nobody the message had moved.
     label: 'total_guides drifts from the guides on disk',
     file: 'guides/_registry.yml',
     find: 'total_guides: 35',
     replace: 'total_guides: 36',
-    expect: 'guides disk=35 registry=36',
+    expect: 'guides disk=35 total_guides=36',
   },
   {
     // A11a. The review's sharpest finding: an entry whose category is unusable drops the

--- a/scripts/envelopes/a11-guide-category-render.mjs
+++ b/scripts/envelopes/a11-guide-category-render.mjs
@@ -27,7 +27,7 @@
  *
  * An adversarial review then found three further routes to #644's exact symptom — a guide in
  * no generated index with every gate green — that the five cases above could not see. Each
- * was reproduced by hand, then fixed, and cases 5-8 are those reproductions. The nine-case run
+ * was reproduced by hand, then fixed, and cases 6-9 are those reproductions. The nine-case run
  * reported:
  *
  *     gate-envelope: 7 killed, 1 survived as documented, 1 inconclusive/invalid of 9 case(s).
@@ -129,7 +129,7 @@ Five-phase methodology for legitimate integration research against a closed-sour
     // 34 in lockstep and stay equal. `total_guides` and the disk count are both untouched at
     // 35. Measured on this exact mutation: A11a green, count green, and the path set is the
     // ONLY red left standing. It is therefore the sole control over this route, and until now
-    // the only direction it was tested in was the other one -- case 8 points a path at nothing,
+    // the only direction it was tested in was the other one -- case 9 points a path at nothing,
     // while this points nothing at a file. A control that survives alone is a control nobody
     // has checked.
     label: 'a whole registry entry deleted — every count still agrees, only the path set differs',

--- a/scripts/envelopes/a11-guide-category-render.mjs
+++ b/scripts/envelopes/a11-guide-category-render.mjs
@@ -1,0 +1,93 @@
+/**
+ * Envelope for integrity checks A11 and A12 — guide category render coverage (#644).
+ *
+ * A11 exists because `check-readmes` cannot own this assertion. That gate regenerates with the
+ * generator's own category ordering and diffs the result against the file, so generator and
+ * check agreed perfectly about a category neither rendered: the `investigation` guide was
+ * absent from every generated index while `npm run check-readmes` exited 0. A gate that
+ * consults the same source as its subject measures nothing.
+ *
+ * So A11 compares the OTHER side — the registry's guide entries — against the rendered
+ * `guides/README.md`. This is the committed record of which of that claim actually fires:
+ *
+ *   npm run gate-envelope -- --spec scripts/envelopes/a11-guide-category-render.mjs
+ *
+ * Result at introduction, 2026-08-18:
+ *
+ *     gate-envelope: 4 killed, 1 survived as documented of 5 case(s).
+ *
+ * Note the first case. It is not a synthetic break — it restores `guides/README.md` to the
+ * exact state `main` was in before this PR, which is what makes it evidence that A11 would
+ * have caught #644 rather than merely that A11 can go red.
+ *
+ * The `expect: null` case at the end pins A11's scope boundary as a measurement rather than
+ * a prose claim: A11 is a CATEGORY-level assertion and does not notice a single guide missing
+ * from a rendered category. That case is genuinely covered — by `check-readmes`, which
+ * regenerates the file — and this envelope's gate is `validate-integrity.sh`, so it correctly
+ * reports green here. If it ever starts being killed, A11's scope grew and this comment is
+ * the thing that went stale.
+ */
+
+export const gate = { command: ['bash', 'scripts/validate-integrity.sh'] };
+
+export const cases = [
+  {
+    // The #644 defect itself, restored byte-for-byte: the section the four-category literal
+    // omitted. The registry still declares and uses `investigation`; the index no longer
+    // renders it. This is the state every gate in the repo passed on.
+    label: 'the pre-#644 state — the investigation section absent from the rendered index',
+    file: 'guides/README.md',
+    find: `
+## Investigation
+
+*Methodology guides for legitimate research, audit, and reverse-engineering of integration surfaces*
+
+### [Reverse-Engineering a CLI Harness](reverse-engineering-a-cli-harness.md)
+Five-phase methodology for legitimate integration research against a closed-source CLI harness — baseline, flag discovery, dark-launch detection, wire capture, redaction discipline.`,
+    replace: '',
+    expect: "guide category 'investigation' has no '## Investigation' heading",
+  },
+  {
+    // The likelier drift than #644, and the reason A11 reads the guides' own `category:`
+    // fields rather than the `categories:` block keys: a value no category block declares
+    // still renders (the helper appends it), so the index and the registry disagree about a
+    // heading name. A block-keyed rule would not see this at all.
+    label: "a guide's category is typo'd, so it renders under a heading nothing declares",
+    file: 'guides/_registry.yml',
+    find: '    category: investigation',
+    replace: '    category: investigatoin',
+    expect: "guide category 'investigatoin' has no '## Investigatoin' heading",
+  },
+  {
+    // The vacuous pass this check exists to prevent. A drifted extraction pattern yields an
+    // empty category list, and an empty list satisfies a for-loop trivially — every category
+    // would go unchecked while the run stayed green. A11 reports FAIL on zero instead.
+    label: 'the A11 extraction pattern drifts and matches nothing',
+    file: 'scripts/validate-integrity.sh',
+    find: "grep -E '^    category: ' guides/_registry.yml",
+    replace: "grep -E '^    categoree: ' guides/_registry.yml",
+    expect: 'A11 extracted 0 guide categories',
+  },
+  {
+    // A12: the total no validator compared to disk before #644. `total_skills` is checked by
+    // validate-skills.yml, agents and teams by A4/A5, guides by nothing.
+    label: 'total_guides drifts from the guides on disk',
+    file: 'guides/_registry.yml',
+    find: 'total_guides: 35',
+    replace: 'total_guides: 36',
+    expect: 'guides disk=35 registry=36',
+  },
+  {
+    // A11's scope boundary, measured. The guide's category heading survives, so A11 is
+    // satisfied and SHOULD be: it asserts that every category reaches the index, not that
+    // every guide does. `check-readmes` owns the per-guide claim and does catch this — it is
+    // simply a different gate than the one this envelope runs.
+    label: 'a single guide dropped from a category that still has other guides',
+    file: 'guides/README.md',
+    find: `### [Agent Memory Hygiene](agent-memory-hygiene.md)
+Three-layer model — weights, retrieval, behavior — for diagnosing what kind of forgetting a memory problem actually needs and applying the right tool.`,
+    replace: '',
+    expect: null,
+    why: 'A11 is category-level by design; the per-guide claim belongs to check-readmes, which regenerates the file.',
+  },
+];

--- a/scripts/envelopes/a11-guide-category-render.mjs
+++ b/scripts/envelopes/a11-guide-category-render.mjs
@@ -66,9 +66,9 @@ export const gate = { command: ['bash', 'scripts/validate-integrity.sh'] };
 
 export const cases = [
   {
-    // The #644 defect itself, restored byte-for-byte: the section the four-category literal
-    // omitted. The registry still declares and uses `investigation`; the index no longer
-    // renders it. This is the state every gate in the repo passed on.
+    // The #644 defect itself, restored up to one trailing newline (see the header): the
+    // section the four-category literal omitted. The registry still declares and uses
+    // `investigation`; the index no longer renders it. This is the state every gate passed on.
     label: 'the pre-#644 state — the investigation section absent from the rendered index',
     file: 'guides/README.md',
     find: `
@@ -115,6 +115,29 @@ Five-phase methodology for legitimate integration research against a closed-sour
     find: 'total_guides: 35',
     replace: 'total_guides: 36',
     expect: 'guides disk=35 total_guides=36',
+  },
+  {
+    // The co-deletion class, and the reason it earns its own case: when a WHOLE entry goes,
+    // the `- id:` line and the `category:` line vanish together, so A11a's two counts fall to
+    // 34 in lockstep and stay equal. `total_guides` and the disk count are both untouched at
+    // 35. Measured on this exact mutation: A11a green, count green, and the path set is the
+    // ONLY red left standing. It is therefore the sole control over this route, and until now
+    // the only direction it was tested in was the other one -- case 8 points a path at nothing,
+    // while this points nothing at a file. A control that survives alone is a control nobody
+    // has checked.
+    label: 'a whole registry entry deleted — every count still agrees, only the path set differs',
+    file: 'guides/_registry.yml',
+    find: `  - id: reverse-engineering-a-cli-harness
+    path: guides/reverse-engineering-a-cli-harness.md
+    title: "Reverse-Engineering a CLI Harness"
+    description: "Five-phase methodology for legitimate integration research against a closed-source CLI harness — baseline, flag discovery, dark-launch detection, wire capture, redaction discipline"
+    category: investigation
+    agents: [security-analyst, code-reviewer]
+    teams: []
+    skills: [audit-dependency-versions, security-audit-codebase]
+`,
+    replace: '',
+    expect: 'path set differs from guides/*.md on disk',
   },
   {
     // A11a. The review's sharpest finding: an entry whose category is unusable drops the

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -17,6 +17,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { CONTENT_TYPES } from './lib/content-types.js';
+import { guideCategoryOrder, guideCategoryLabel } from './lib/guide-categories.js';
 import { applySections, renderTranslationsTable, renderLocaleTable } from './lib/readme-sections.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -279,20 +280,14 @@ When adding or removing skills, agents, teams, or guides, the corresponding regi
 // ── Fully generated files ────────────────────────────────────────
 
 function generateGuidesSection() {
-  const categoryOrder = ['workflow', 'infrastructure', 'reference', 'design'];
-  const categoryLabels = {
-    workflow: 'Workflow',
-    infrastructure: 'Infrastructure',
-    reference: 'Reference',
-    design: 'Design',
-  };
+  const categoryOrder = guideCategoryOrder(guideCategories, guides);
   const lines = [];
 
   for (const catId of categoryOrder) {
     const catGuides = guides.filter((g) => g.category === catId);
     if (catGuides.length === 0) continue;
 
-    lines.push(`**${categoryLabels[catId]}**`);
+    lines.push(`**${guideCategoryLabel(catId)}**`);
     lines.push('');
     for (const guide of catGuides) {
       lines.push(
@@ -309,7 +304,7 @@ function generateGuidesSection() {
 }
 
 function generateGuidesReadme() {
-  const categoryOrder = ['workflow', 'infrastructure', 'reference', 'design'];
+  const categoryOrder = guideCategoryOrder(guideCategories, guides);
   const lines = [
     '# Guides',
     '',
@@ -323,7 +318,7 @@ function generateGuidesReadme() {
     const catDesc = guideCategories[catId]
       ? guideCategories[catId].description
       : catId;
-    const catName = catId[0].toUpperCase() + catId.slice(1);
+    const catName = guideCategoryLabel(catId);
     lines.push(`## ${catName}`);
     lines.push('');
     lines.push(`*${catDesc}*`);

--- a/scripts/lib/guide-categories.js
+++ b/scripts/lib/guide-categories.js
@@ -1,0 +1,72 @@
+/**
+ * guide-categories.js — the display order and labels for guide categories (#644).
+ *
+ * `generate-readmes.js` rendered its guide indexes from a hardcoded
+ * `['workflow', 'infrastructure', 'reference', 'design']`, written twice, while
+ * `guides/_registry.yml` and `CLAUDE.md` both carry five categories. Each literal was
+ * followed by `for (const catId of categoryOrder)`, so a guide in the fifth category
+ * — `investigation` — was iterated over by nothing and appeared in no generated index.
+ *
+ * The failure is silent in the way this repo keeps rediscovering. `check-readmes`
+ * cannot see it *by construction*: it regenerates with the same literal and compares
+ * the result to itself, so the generator and its check agree perfectly about a guide
+ * neither of them renders. `validate-integrity.sh` passed. The guide was reachable
+ * only by knowing its filename.
+ *
+ * ## Order is a union, not a lookup
+ *
+ * `categoryOrder` takes the declared block's key order first — that is the intended
+ * display order, and YAML preserves it — then appends any category a guide actually
+ * uses that the block never declared. Deriving from the block alone would fix the
+ * `investigation` case and leave the more likely one open: a typo in a guide's
+ * `category:` field, or a category someone adds to a guide but forgets to declare,
+ * drops that guide from every index with every gate still green. Appending is
+ * deliberately not de-duplicating the *declared* side — an empty declared category
+ * renders nothing because the caller skips empty groups, which is correct.
+ *
+ * ## What this module does not carry
+ *
+ * The gate. A shared helper means the two indexes can no longer disagree with each
+ * other, but nothing here compares the rendered output to the registry — both call
+ * sites could still be wrong together, which is exactly the shape that shipped. That
+ * assertion lives in `scripts/validate-integrity.sh` check A11, which reads the
+ * guides' own `category:` fields and requires each to appear as a heading in
+ * `guides/README.md`.
+ */
+
+/**
+ * Display order for guide categories: declared order first, then any undeclared
+ * category some guide actually uses.
+ *
+ * @param {Object} categoriesBlock - the registry's `categories:` mapping (may be undefined)
+ * @param {Array<{category?: string}>} guides - the registry's `guides:` list (may be undefined)
+ * @returns {string[]} category ids in display order, no duplicates
+ */
+export function guideCategoryOrder(categoriesBlock, guides) {
+  const declared = Object.keys(categoriesBlock || {});
+  const seen = new Set(declared);
+  const undeclared = [];
+  for (const guide of guides || []) {
+    const category = guide && guide.category;
+    if (!category || seen.has(category)) continue;
+    seen.add(category);
+    undeclared.push(category);
+  }
+  return [...declared, ...undeclared];
+}
+
+/**
+ * Heading label for a category id.
+ *
+ * Capitalises the first letter only, which is what `generateGuidesReadme` already did
+ * inline; the replaced `categoryLabels` map in `generateGuidesSection` held the same
+ * four strings that rule produces. A hyphenated id would render as `Edge-computing`
+ * rather than `Edge Computing` — no category on disk has a hyphen, so this changes no
+ * current output, and title-casing is left for whoever first adds one.
+ *
+ * @param {string} catId
+ * @returns {string}
+ */
+export function guideCategoryLabel(catId) {
+  return catId[0].toUpperCase() + catId.slice(1);
+}

--- a/scripts/test/guide-categories.test.js
+++ b/scripts/test/guide-categories.test.js
@@ -67,6 +67,14 @@ test('a repeated undeclared category is emitted once', () => {
   assert.equal(new Set(order).size, order.length);
 });
 
+test('a null entry in the guides list does not throw', () => {
+  // A YAML `- ` with nothing after it parses to null. Without the `guide &&` guard in
+  // guideCategoryOrder this throws and takes the whole generator down. Measured: deleting
+  // that guard left all other cases in this file green, so this is the test that kills it.
+  assert.deepEqual(guideCategoryOrder(block('workflow'), [null, { id: 'a', category: 'workflow' }]), ['workflow']);
+  assert.deepEqual(guideCategoryOrder(block('workflow'), [undefined]), ['workflow']);
+});
+
 test('guides with a missing or empty category contribute nothing', () => {
   const order = guideCategoryOrder(block('workflow'), [
     { id: 'a' }, { id: 'b', category: '' }, { id: 'c', category: null }, { id: 'd', category: 'workflow' },

--- a/scripts/test/guide-categories.test.js
+++ b/scripts/test/guide-categories.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for `scripts/lib/guide-categories.js` (#644).
+ *
+ * The defect these cover: `generate-readmes.js` iterated a hardcoded four-category
+ * literal, written twice, over a registry carrying five — so the one `investigation`
+ * guide rendered in no generated index while every gate stayed green.
+ *
+ * The generator itself still cannot be imported (it reads the registries and runs its
+ * MANAGED loop at module scope, so an `import()` writes all nine committed files), which
+ * is the same constraint that produced `readme-sections.test.js`. Extracting the ordering
+ * rule into a pure function is what makes it testable at all.
+ *
+ * Coverage here is the ordering rule only. That a rendered index actually contains the
+ * heading is a different claim about a different artifact, and it belongs to
+ * `validate-integrity.sh` check A11 — a unit test over this module cannot catch both call
+ * sites being wrong together, which is exactly how #644 shipped.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { guideCategoryOrder, guideCategoryLabel } from '../lib/guide-categories.js';
+
+const block = (...ids) => Object.fromEntries(ids.map((id) => [id, { description: id }]));
+const guidesIn = (...categories) => categories.map((category, i) => ({ id: `g${i}`, category }));
+
+test('declared categories keep the registry block order', () => {
+  const order = guideCategoryOrder(
+    block('workflow', 'infrastructure', 'reference', 'design'),
+    guidesIn('design', 'workflow', 'workflow')
+  );
+  assert.deepEqual(order, ['workflow', 'infrastructure', 'reference', 'design']);
+});
+
+test('a declared category with no guides is still ordered (the caller skips empties)', () => {
+  // generateGuidesSection/generateGuidesReadme do `if (catGuides.length === 0) continue`,
+  // so emptiness is the caller's business. Dropping it here would move that decision.
+  const order = guideCategoryOrder(block('workflow', 'design'), guidesIn('workflow'));
+  assert.deepEqual(order, ['workflow', 'design']);
+});
+
+test('#644 regression: the fifth declared category is not truncated away', () => {
+  const order = guideCategoryOrder(
+    block('workflow', 'infrastructure', 'reference', 'design', 'investigation'),
+    guidesIn('investigation')
+  );
+  assert.ok(
+    order.includes('investigation'),
+    'investigation must be iterated, or its guide renders in no index'
+  );
+});
+
+test('a category a guide uses but the block never declares is appended, not dropped', () => {
+  // The likelier drift than #644 itself: a typo, or a category added to a guide and
+  // forgotten in the block. Deriving order from the block alone loses that guide silently.
+  const order = guideCategoryOrder(block('workflow', 'design'), guidesIn('workflow', 'investigatoin'));
+  assert.deepEqual(order, ['workflow', 'design', 'investigatoin']);
+});
+
+test('undeclared categories are appended after every declared one, in first-use order', () => {
+  const order = guideCategoryOrder(block('workflow'), guidesIn('zebra', 'workflow', 'alpha'));
+  assert.deepEqual(order, ['workflow', 'zebra', 'alpha']);
+});
+
+test('a repeated undeclared category is emitted once', () => {
+  const order = guideCategoryOrder(block('workflow'), guidesIn('extra', 'extra', 'extra'));
+  assert.deepEqual(order, ['workflow', 'extra']);
+  assert.equal(new Set(order).size, order.length);
+});
+
+test('guides with a missing or empty category contribute nothing', () => {
+  const order = guideCategoryOrder(block('workflow'), [
+    { id: 'a' }, { id: 'b', category: '' }, { id: 'c', category: null }, { id: 'd', category: 'workflow' },
+  ]);
+  assert.deepEqual(order, ['workflow']);
+});
+
+test('absent registry sections do not throw', () => {
+  assert.deepEqual(guideCategoryOrder(undefined, undefined), []);
+  assert.deepEqual(guideCategoryOrder({}, []), []);
+  assert.deepEqual(guideCategoryOrder(undefined, guidesIn('workflow')), ['workflow']);
+});
+
+test('label capitalises the first letter and leaves the rest alone', () => {
+  assert.equal(guideCategoryLabel('workflow'), 'Workflow');
+  assert.equal(guideCategoryLabel('investigation'), 'Investigation');
+  // The four labels the replaced `categoryLabels` map held, reproduced by the rule.
+  assert.deepEqual(
+    ['workflow', 'infrastructure', 'reference', 'design'].map(guideCategoryLabel),
+    ['Workflow', 'Infrastructure', 'Reference', 'Design']
+  );
+});
+
+test('label does not title-case a hyphenated id — documented, not accidental', () => {
+  // No category on disk has a hyphen; if one is added, this is the decision to revisit.
+  assert.equal(guideCategoryLabel('edge-computing'), 'Edge-computing');
+});

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -715,7 +715,12 @@ else
     # in the file stand in for the generated one. Measured today: the file's only whole-line
     # bold entries are the five category labels, all inside the block, so this changes nothing
     # now and closes the coincidence later.
-    if ! printf '%s' "$a11_readme_block" | grep -qxF "**$label**"; then
+    # `printf '%s\n'`, not `'%s'`: command substitution strips the block's trailing newline, so
+    # `'%s'` leaves the last line unterminated. Both greps this repo runs -- ugrep locally, GNU
+    # grep in CI -- match an incomplete last line with `-qxF`, verified on both, so this is not
+    # a live bug. It is one byte to stop depending on that semantic, and the dependence would
+    # be invisible in situ: the block's last line is always the END marker, never a label.
+    if ! printf '%s\n' "$a11_readme_block" | grep -qxF "**$label**"; then
       echo "FAIL: guide category '$guide_cat' has no '**$label**' line in README.md's AUTO:guides block"
       echo "      (the two indexes share only their ORDER; each renders separately)"
       failed=1; a11_fail=1

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -591,6 +591,72 @@ fi
 
 [ "$a10_fail" -eq 0 ] && echo "OK: $((a10_full + a10_flatsites + a10_checked_find * 2)) shell/YAML content-type list(s) agree with CONTENT_TYPES ($a10_loops_full full loop(s), $a10_flatsites flat loop(s), $((a10_full - a10_loops_full)) full surface(s), $((a10_checked_find * 2)) find pathspec(s))"
 
+# A11: Every guide category reaches the rendered index (#644)
+#
+# `generate-readmes.js` rendered its two guide indexes from a hardcoded four-category
+# literal while the registry carried five, so the one `investigation` guide appeared in
+# no generated index at all. #644 replaced both literals with `lib/guide-categories.js`,
+# which means the two indexes can no longer disagree with EACH OTHER -- and that is the
+# whole of what sharing buys. Both call sites could still be wrong together, which is
+# precisely the shape that shipped.
+#
+# `check-readmes` cannot own this assertion, by construction rather than by omission: it
+# regenerates with the generator's own ordering and diffs the result against the file, so
+# generator and check agree perfectly about a category neither renders. A gate that
+# consults the same source as its subject measures nothing. So the comparison here is
+# against the OTHER side -- the registry's guide entries -- and it belongs in this script.
+#
+# Derived from the guides' own `category:` fields, NOT from the `categories:` block keys.
+# The generator skips a category with no guides (`if (catGuides.length === 0) continue`),
+# so a declared-but-empty category legitimately renders nothing and a block-keyed rule
+# would fail on a correct tree. Reading the guide entries also covers the likelier drift:
+# a typo'd or undeclared `category:` value, which the #644 helper now renders but which
+# nothing else would notice.
+#
+# Only `guides/README.md` is asserted. README.md's guides section is produced by the same
+# shared helper over the same list, so it carries that file's parity; naming one file
+# keeps the failure message pointing at one place to look.
+#
+# Fails CLOSED. An empty extraction is FAIL, never OK -- a pattern that drifts and matches
+# nothing is the vacuous pass this check exists to prevent (the A10 rule, applied here).
+echo "--- A11: Guide category render coverage ---"
+a11_fail=0
+a11_cats=$(grep -E '^    category: ' guides/_registry.yml | tr -d '\r' \
+  | sed -E 's/^    category: *//' | sed -E 's/^"(.*)"$/\1/' | sed '/^$/d' | sort -u)
+a11_count=$(printf '%s\n' "$a11_cats" | sed '/^$/d' | wc -l)
+if [ "$a11_count" -eq 0 ]; then
+  echo "FAIL: A11 extracted 0 guide categories from guides/_registry.yml -- pattern drift, not a clean tree"
+  failed=1
+  a11_fail=1
+else
+  while IFS= read -r cat; do
+    [ -z "$cat" ] && continue
+    # Capitalise the first letter only: the rule guideCategoryLabel() applies.
+    heading="## $(printf '%s' "${cat:0:1}" | tr '[:lower:]' '[:upper:]')${cat:1}"
+    if ! grep -qxF "$heading" guides/README.md; then
+      echo "FAIL: guide category '$cat' has no '$heading' heading in guides/README.md"
+      echo "      (a guide in that category renders in no generated index; run 'npm run update-readmes')"
+      failed=1
+      a11_fail=1
+    fi
+  done <<< "$a11_cats"
+fi
+[ "$a11_fail" -eq 0 ] && echo "OK: all $a11_count guide categories render in guides/README.md"
+
+# A12: Guide registry count (#644)
+# Mirrors A4/A5. `total_guides` was the one registry total no validator compared to disk --
+# `total_skills` is checked by validate-skills.yml against a find-count, agents and teams by
+# A4 and A5 above, and guides by nothing. Decorative totals drift silently.
+echo "--- A12: Guide registry count ---"
+disk_count=$(find guides -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l)
+reg_count=$(grep 'total_guides:' guides/_registry.yml | tr -d '\r' | awk '{print $2}')
+if [ "$disk_count" != "$reg_count" ]; then
+  echo "FAIL: guides disk=$disk_count registry=$reg_count"
+  failed=1
+else
+  echo "OK: $disk_count guides on disk match registry"
+fi
+
 echo ""
 echo "=== Category B: Structural Integrity ==="
 

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -609,61 +609,128 @@ fi
 # Derived from the guides' own `category:` fields, NOT from the `categories:` block keys.
 # The generator skips a category with no guides (`if (catGuides.length === 0) continue`),
 # so a declared-but-empty category legitimately renders nothing and a block-keyed rule
-# would fail on a correct tree. Reading the guide entries also covers the likelier drift:
-# a typo'd or undeclared `category:` value, which the #644 helper now renders but which
-# nothing else would notice.
+# would fail on a correct tree.
 #
-# Only `guides/README.md` is asserted. README.md's guides section is produced by the same
-# shared helper over the same list, so it carries that file's parity; naming one file
-# keeps the failure message pointing at one place to look.
+# FOUR sub-checks, because an adversarial review of the first version found three ways to
+# reproduce #644's exact symptom -- a guide in no generated index, every gate green -- that
+# render coverage alone cannot see. Each was reproduced before being fixed:
+#
+#   A11a  every guide entry yields a USABLE category. A deleted `category:` line, an empty
+#         `category: ""`, or a bare `category:` (no trailing space, so the pattern misses it)
+#         all drop the guide from BOTH indexes while leaving the surviving categories fully
+#         rendered -- so a distinct-value check finds nothing wrong. Measured: setting the
+#         investigation guide to `category: ""` removed it from both files and left the old
+#         A11 green. Compares a NON-uniqued count against the entry count for that reason.
+#   A11b  every used category is DECLARED in the `categories:` block. Without this the union
+#         in guideCategoryOrder() renders a typo'd category under a garbage heading, and
+#         A11c then finds that heading and passes. Worse, A11c's own remediation advice
+#         ("run npm run update-readmes") is the laundering step: measured, regenerating with
+#         `category: investigatoin` produces `## Investigatoin` / `*investigatoin*` and turns
+#         every gate green. The union stays -- rendering under a wrong heading beats not
+#         rendering -- but it is now reported rather than silently absorbed.
+#   A11c  every used category reaches BOTH rendered indexes. `guides/README.md` alone is not
+#         enough: the two generators share only the ORDER, while the loop, the empty-skip and
+#         the rendering are separately duplicated. Measured: reverting `generateGuidesSection`
+#         alone to the old literal drops the guide from README.md while guides/README.md keeps
+#         it, and `check-readmes` plus the old A11 both stay green. Note the two files use
+#         DIFFERENT markup -- `## Label` in guides/README.md, `**Label**` in README.md.
+#
+# `check-readmes` cannot own any of this, by construction rather than by omission: it
+# regenerates with the generator's own ordering and diffs the result against the file, so
+# generator and check agree perfectly about a guide neither renders. A gate that consults
+# the same source as its subject measures nothing. The comparison here is against the OTHER
+# side -- the registry -- which is why it belongs in this script.
 #
 # Fails CLOSED. An empty extraction is FAIL, never OK -- a pattern that drifts and matches
 # nothing is the vacuous pass this check exists to prevent (the A10 rule, applied here).
 #
-# The trailing `|| true` on the extraction is load-bearing, and is the difference between
-# failing closed LOUDLY and failing closed silently. Under `set -euo pipefail` a bare
-# `a11_cats=$(grep ... | ...)` aborts the entire script the moment grep matches nothing --
-# so the run goes red with no diagnostic, the zero-check below is dead code, and every
-# check after this line never executes. That is the exact shape the B13 comment at the foot
-# of this script records; the envelope's third case reported WRONG-RED on the first version
-# of A11 for precisely this reason, which is what the case is for.
+# Every extraction below carries `|| true`, and that is load-bearing rather than noise. Under
+# `set -euo pipefail` a bare `x=$(grep ... )` aborts the ENTIRE script the moment grep matches
+# nothing -- red with no diagnostic, the zero-check dead, and every later check skipped. The
+# envelope reported WRONG-RED on the first version of A11 for exactly this. `grep -c` is the
+# sneakiest member of the family: it prints `0` and exits 1, so a count extraction aborts even
+# though the number you wanted was produced. Tracked for the whole script as #647.
 echo "--- A11: Guide category render coverage ---"
 a11_fail=0
-a11_cats=$(grep -E '^    category: ' guides/_registry.yml | tr -d '\r' \
-  | sed -E 's/^    category: *//' | sed -E 's/^"(.*)"$/\1/' | sed '/^$/d' | sort -u || true)
-a11_count=$(printf '%s\n' "$a11_cats" | sed '/^$/d' | wc -l)
-if [ "$a11_count" -eq 0 ]; then
+# Non-uniqued, empties dropped: this is a per-ENTRY list, not a set (A11a needs the count).
+a11_used=$(grep -E '^    category: ' guides/_registry.yml | tr -d '\r' \
+  | sed -E 's/^    category: *//' | sed -E 's/^"(.*)"$/\1/' | sed -E "s/^'(.*)'$/\1/" \
+  | sed '/^[[:space:]]*$/d' || true)
+a11_used_count=$(printf '%s\n' "$a11_used" | sed '/^[[:space:]]*$/d' | wc -l)
+a11_entries=$(grep -c '^  - id: ' guides/_registry.yml || true)
+a11_declared=$(sed -n '/^categories:$/,/^guides:$/p' guides/_registry.yml | tr -d '\r' \
+  | grep -E '^  [a-z][a-z0-9_-]*:$' | sed 's/[: ]//g' || true)
+a11_cats=$(printf '%s\n' "$a11_used" | sed '/^[[:space:]]*$/d' | sort -u || true)
+
+# A11a: no guide entry silently lacks a usable category.
+if [ "$a11_used_count" -ne "$a11_entries" ]; then
+  echo "FAIL: $a11_entries guide entries but only $a11_used_count usable 'category:' value(s)"
+  echo "      (an entry with a deleted, empty or valueless category renders in NO index, and"
+  echo "       the categories that remain still render, so nothing else here would notice)"
+  failed=1; a11_fail=1
+fi
+
+if [ "$a11_used_count" -eq 0 ]; then
   echo "FAIL: A11 extracted 0 guide categories from guides/_registry.yml -- pattern drift, not a clean tree"
-  failed=1
-  a11_fail=1
+  failed=1; a11_fail=1
 else
   while IFS= read -r guide_cat; do
     [ -z "$guide_cat" ] && continue
-    # Capitalise the first letter only: the rule guideCategoryLabel() applies.
-    heading="## $(printf '%s' "${guide_cat:0:1}" | tr '[:lower:]' '[:upper:]')${guide_cat:1}"
-    if ! grep -qxF "$heading" guides/README.md; then
-      echo "FAIL: guide category '$guide_cat' has no '$heading' heading in guides/README.md"
+    # A11b: used must be declared. Additive with A11c -- both report, neither short-circuits,
+    # so the envelope's typo case keeps matching the A11c message it expects.
+    if ! printf '%s\n' "$a11_declared" | grep -qxF "$guide_cat"; then
+      echo "FAIL: guide category '$guide_cat' is not declared in the 'categories:' block of guides/_registry.yml"
+      echo "      (it still renders, under a heading with no description -- do NOT fix this by"
+      echo "       regenerating, which makes the garbage heading real and turns every gate green)"
+      failed=1; a11_fail=1
+    fi
+    # A11c: rendered in both indexes. Capitalise the first letter only -- guideCategoryLabel().
+    label="$(printf '%s' "${guide_cat:0:1}" | tr '[:lower:]' '[:upper:]')${guide_cat:1}"
+    if ! grep -qxF "## $label" guides/README.md; then
+      echo "FAIL: guide category '$guide_cat' has no '## $label' heading in guides/README.md"
       echo "      (a guide in that category renders in no generated index; run 'npm run update-readmes')"
-      failed=1
-      a11_fail=1
+      failed=1; a11_fail=1
+    fi
+    if ! grep -qxF "**$label**" README.md; then
+      echo "FAIL: guide category '$guide_cat' has no '**$label**' line in README.md"
+      echo "      (the two indexes share only their ORDER; each renders separately)"
+      failed=1; a11_fail=1
     fi
   done <<< "$a11_cats"
 fi
-[ "$a11_fail" -eq 0 ] && echo "OK: all $a11_count guide categories render in guides/README.md"
+[ "$a11_fail" -eq 0 ] && echo "OK: $a11_used_count guide entries, $(printf '%s\n' "$a11_cats" | wc -l) declared categories, all rendered in both indexes"
 
-# A12: Guide registry count (#644)
-# Mirrors A4/A5. `total_guides` was the one registry total no validator compared to disk --
-# `total_skills` is checked by validate-skills.yml against a find-count, agents and teams by
-# A4 and A5 above, and guides by nothing. Decorative totals drift silently.
-echo "--- A12: Guide registry count ---"
+# A12: Guide registry vs disk (#644)
+# Mirrors A4/A5 on the total, and then goes past them. `total_guides` was the one registry
+# total no validator compared to disk -- `total_skills` is checked by validate-skills.yml
+# against a find-count, agents and teams by A4/A5, guides by nothing.
+#
+# The PATH SET is checked too, because the count alone inherits A4/A5's blindness: a guide
+# file added with valid frontmatter and `total_guides` bumped, but NO registry entry, keeps
+# both numbers equal and is in no index -- one more route to the #644 symptom with everything
+# green. A set comparison also catches the swap a count cannot see (one file added, one
+# removed). A4/A5 have the same gap against their own registries; that is #648, not this PR.
+echo "--- A12: Guide registry vs disk ---"
+a12_fail=0
 disk_count=$(find guides -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l)
 reg_count=$(grep 'total_guides:' guides/_registry.yml | tr -d '\r' | awk '{print $2}')
 if [ "$disk_count" != "$reg_count" ]; then
-  echo "FAIL: guides disk=$disk_count registry=$reg_count"
-  failed=1
-else
-  echo "OK: $disk_count guides on disk match registry"
+  echo "FAIL: guides disk=$disk_count total_guides=$reg_count"
+  failed=1; a12_fail=1
 fi
+a12_reg_paths=$(grep -E '^    path: ' guides/_registry.yml | tr -d '\r' \
+  | sed -E 's/^    path: *//' | sed -E 's/^"(.*)"$/\1/' | sort -u || true)
+a12_disk_paths=$(find guides -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | sort || true)
+if [ -z "$a12_reg_paths" ]; then
+  echo "FAIL: A12 extracted 0 'path:' values from guides/_registry.yml -- pattern drift, not a clean tree"
+  failed=1; a12_fail=1
+elif [ "$a12_reg_paths" != "$a12_disk_paths" ]; then
+  echo "FAIL: guides/_registry.yml path set differs from guides/*.md on disk"
+  comm -3 <(printf '%s\n' "$a12_reg_paths") <(printf '%s\n' "$a12_disk_paths") \
+    | sed 's/^\t/      only on disk: /; s/^\([^ ]\)/      only in registry: \1/'
+  failed=1; a12_fail=1
+fi
+[ "$a12_fail" -eq 0 ] && echo "OK: $disk_count guides on disk match total_guides and the registry path set"
 
 echo ""
 echo "=== Category B: Structural Integrity ==="

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -619,22 +619,30 @@ fi
 #
 # Fails CLOSED. An empty extraction is FAIL, never OK -- a pattern that drifts and matches
 # nothing is the vacuous pass this check exists to prevent (the A10 rule, applied here).
+#
+# The trailing `|| true` on the extraction is load-bearing, and is the difference between
+# failing closed LOUDLY and failing closed silently. Under `set -euo pipefail` a bare
+# `a11_cats=$(grep ... | ...)` aborts the entire script the moment grep matches nothing --
+# so the run goes red with no diagnostic, the zero-check below is dead code, and every
+# check after this line never executes. That is the exact shape the B13 comment at the foot
+# of this script records; the envelope's third case reported WRONG-RED on the first version
+# of A11 for precisely this reason, which is what the case is for.
 echo "--- A11: Guide category render coverage ---"
 a11_fail=0
 a11_cats=$(grep -E '^    category: ' guides/_registry.yml | tr -d '\r' \
-  | sed -E 's/^    category: *//' | sed -E 's/^"(.*)"$/\1/' | sed '/^$/d' | sort -u)
+  | sed -E 's/^    category: *//' | sed -E 's/^"(.*)"$/\1/' | sed '/^$/d' | sort -u || true)
 a11_count=$(printf '%s\n' "$a11_cats" | sed '/^$/d' | wc -l)
 if [ "$a11_count" -eq 0 ]; then
   echo "FAIL: A11 extracted 0 guide categories from guides/_registry.yml -- pattern drift, not a clean tree"
   failed=1
   a11_fail=1
 else
-  while IFS= read -r cat; do
-    [ -z "$cat" ] && continue
+  while IFS= read -r guide_cat; do
+    [ -z "$guide_cat" ] && continue
     # Capitalise the first letter only: the rule guideCategoryLabel() applies.
-    heading="## $(printf '%s' "${cat:0:1}" | tr '[:lower:]' '[:upper:]')${cat:1}"
+    heading="## $(printf '%s' "${guide_cat:0:1}" | tr '[:lower:]' '[:upper:]')${guide_cat:1}"
     if ! grep -qxF "$heading" guides/README.md; then
-      echo "FAIL: guide category '$cat' has no '$heading' heading in guides/README.md"
+      echo "FAIL: guide category '$guide_cat' has no '$heading' heading in guides/README.md"
       echo "      (a guide in that category renders in no generated index; run 'npm run update-readmes')"
       failed=1
       a11_fail=1

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -600,12 +600,6 @@ fi
 # whole of what sharing buys. Both call sites could still be wrong together, which is
 # precisely the shape that shipped.
 #
-# `check-readmes` cannot own this assertion, by construction rather than by omission: it
-# regenerates with the generator's own ordering and diffs the result against the file, so
-# generator and check agree perfectly about a category neither renders. A gate that
-# consults the same source as its subject measures nothing. So the comparison here is
-# against the OTHER side -- the registry's guide entries -- and it belongs in this script.
-#
 # Derived from the guides' own `category:` fields, NOT from the `categories:` block keys.
 # The generator skips a category with no guides (`if (catGuides.length === 0) continue`),
 # so a declared-but-empty category legitimately renders nothing and a block-keyed rule
@@ -644,12 +638,18 @@ fi
 # Fails CLOSED. An empty extraction is FAIL, never OK -- a pattern that drifts and matches
 # nothing is the vacuous pass this check exists to prevent (the A10 rule, applied here).
 #
-# Every extraction below carries `|| true`, and that is load-bearing rather than noise. Under
-# `set -euo pipefail` a bare `x=$(grep ... )` aborts the ENTIRE script the moment grep matches
-# nothing -- red with no diagnostic, the zero-check dead, and every later check skipped. The
-# envelope reported WRONG-RED on the first version of A11 for exactly this. `grep -c` is the
-# sneakiest member of the family: it prints `0` and exits 1, so a count extraction aborts even
-# though the number you wanted was produced. Tracked for the whole script as #647.
+# Every extraction in A11 and A12 carries `|| true`, and that is load-bearing rather than
+# noise. Under `set -euo pipefail` a bare `x=$(grep ... )` aborts the ENTIRE script the moment
+# grep matches nothing -- red with no diagnostic, the zero-check dead, and every later check
+# skipped. The envelope reported WRONG-RED on the first version of A11 for exactly this.
+# `grep -c` is the sneakiest member of the family: it prints `0` and exits 1, so a count
+# extraction aborts even though the number you wanted was produced.
+#
+# The scope of that sentence is A11 and A12 ONLY. It said "every extraction below" until a
+# review pointed out that A12's own two lines -- copied from A4/A5 in round 1 -- had no guard,
+# which made the claim false about the exact failure class this gate exists to measure, five
+# lines above the note tracking that class. They are guarded now, but the rest of this script
+# is not: #647 is the sweep, and until it lands do not read this paragraph as covering A1-A10.
 echo "--- A11: Guide category render coverage ---"
 a11_fail=0
 # Non-uniqued, empties dropped: this is a per-ENTRY list, not a set (A11a needs the count).
@@ -658,9 +658,26 @@ a11_used=$(grep -E '^    category: ' guides/_registry.yml | tr -d '\r' \
   | sed '/^[[:space:]]*$/d' || true)
 a11_used_count=$(printf '%s\n' "$a11_used" | sed '/^[[:space:]]*$/d' | wc -l)
 a11_entries=$(grep -c '^  - id: ' guides/_registry.yml || true)
-a11_declared=$(sed -n '/^categories:$/,/^guides:$/p' guides/_registry.yml | tr -d '\r' \
-  | grep -E '^  [a-z][a-z0-9_-]*:$' | sed 's/[: ]//g' || true)
+# `tr -d '\r'` FIRST: the range anchors are `$`-terminated, so on a CRLF file they would miss
+# both delimiters and the range would run to EOF. Moot under the repo's line-endings gate, but
+# a guard positioned where it cannot do what its placement implies is worse than no guard.
+# `[a-z0-9]` for the first character, not `[a-z]`: `3d-printing` already exists as a skills
+# domain, so a digit-initial guide category is a realistic future key, and rejecting it here
+# would be a loud FAIL on a correct tree.
+a11_declared=$(tr -d '\r' < guides/_registry.yml | sed -n '/^categories:$/,/^guides:$/p' \
+  | grep -E '^  [a-z0-9][a-z0-9_-]*:$' | sed 's/[: ]//g' || true)
+if [ -z "$a11_declared" ]; then
+  # Without this the run still goes red -- every used category cascades into a "not declared"
+  # FAIL -- but it reports five wrong diagnoses instead of the one true one.
+  echo "FAIL: A11 extracted 0 declared categories from the 'categories:' block -- pattern drift, not a clean tree"
+  failed=1; a11_fail=1
+fi
 a11_cats=$(printf '%s\n' "$a11_used" | sed '/^[[:space:]]*$/d' | sort -u || true)
+a11_readme_block=$(sed -n '/<!-- AUTO:START:guides -->/,/<!-- AUTO:END:guides -->/p' README.md | tr -d '\r' || true)
+if [ -z "$a11_readme_block" ]; then
+  echo "FAIL: A11 found no AUTO:guides block in README.md -- the markers moved or were deleted"
+  failed=1; a11_fail=1
+fi
 
 # A11a: no guide entry silently lacks a usable category.
 if [ "$a11_used_count" -ne "$a11_entries" ]; then
@@ -691,14 +708,21 @@ else
       echo "      (a guide in that category renders in no generated index; run 'npm run update-readmes')"
       failed=1; a11_fail=1
     fi
-    if ! grep -qxF "**$label**" README.md; then
-      echo "FAIL: guide category '$guide_cat' has no '**$label**' line in README.md"
+    # Scoped to the AUTO block, unlike the `## $label` side. `guides/README.md` is fully
+    # generated and its only `##` lines ARE the category headings, so that one needs no scope.
+    # README.md is hand-written outside its markers, and a whole-line bold is a common way to
+    # label a prose section -- an unscoped match would let a hand-added `**Design**` elsewhere
+    # in the file stand in for the generated one. Measured today: the file's only whole-line
+    # bold entries are the five category labels, all inside the block, so this changes nothing
+    # now and closes the coincidence later.
+    if ! printf '%s' "$a11_readme_block" | grep -qxF "**$label**"; then
+      echo "FAIL: guide category '$guide_cat' has no '**$label**' line in README.md's AUTO:guides block"
       echo "      (the two indexes share only their ORDER; each renders separately)"
       failed=1; a11_fail=1
     fi
   done <<< "$a11_cats"
 fi
-[ "$a11_fail" -eq 0 ] && echo "OK: $a11_used_count guide entries, $(printf '%s\n' "$a11_cats" | wc -l) declared categories, all rendered in both indexes"
+[ "$a11_fail" -eq 0 ] && echo "OK: $a11_used_count guide entries, $(printf '%s\n' "$a11_cats" | wc -l) distinct categories in use, all declared and rendered in both indexes"
 
 # A12: Guide registry vs disk (#644)
 # Mirrors A4/A5 on the total, and then goes past them. `total_guides` was the one registry
@@ -712,14 +736,29 @@ fi
 # removed). A4/A5 have the same gap against their own registries; that is #648, not this PR.
 echo "--- A12: Guide registry vs disk ---"
 a12_fail=0
-disk_count=$(find guides -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l)
-reg_count=$(grep 'total_guides:' guides/_registry.yml | tr -d '\r' | awk '{print $2}')
+# Both guarded. Deleting or renaming the `total_guides:` key makes grep exit 1, which under
+# `set -euo pipefail` aborted the whole script here -- red with no diagnostic, A12's own FAIL
+# never printed, categories B and C never reached. Verified before the guard was added. The
+# envelope's count case cannot see it: mutating 35 -> 36 keeps the key greppable, so only a
+# deletion reaches this path. Safe because the comparison below is a string `!=` -- an empty
+# `reg_count` compares unequal and fails correctly rather than passing.
+disk_count=$(find guides -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l || true)
+reg_count=$(grep 'total_guides:' guides/_registry.yml | tr -d '\r' | awk '{print $2}' || true)
 if [ "$disk_count" != "$reg_count" ]; then
   echo "FAIL: guides disk=$disk_count total_guides=$reg_count"
   failed=1; a12_fail=1
 fi
-a12_reg_paths=$(grep -E '^    path: ' guides/_registry.yml | tr -d '\r' \
-  | sed -E 's/^    path: *//' | sed -E 's/^"(.*)"$/\1/' | sort -u || true)
+a12_reg_paths_all=$(grep -E '^    path: ' guides/_registry.yml | tr -d '\r' \
+  | sed -E 's/^    path: *//' | sed -E 's/^"(.*)"$/\1/' | sort || true)
+a12_dupe_paths=$(printf '%s\n' "$a12_reg_paths_all" | uniq -d || true)
+if [ -n "$a12_dupe_paths" ]; then
+  # `sort -u` below would collapse a duplicate and let the set still match disk, so two entries
+  # pointing at one file would be forgiven by the very check meant to pair them one-to-one.
+  echo "FAIL: guides/_registry.yml has two entries sharing one path:"
+  printf '%s\n' "$a12_dupe_paths" | sed 's/^/      /'
+  failed=1; a12_fail=1
+fi
+a12_reg_paths=$(printf '%s\n' "$a12_reg_paths_all" | sort -u || true)
 a12_disk_paths=$(find guides -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | sort || true)
 if [ -z "$a12_reg_paths" ]; then
   echo "FAIL: A12 extracted 0 'path:' values from guides/_registry.yml -- pattern drift, not a clean tree"


### PR DESCRIPTION
Closes #644.

## The defect

`generate-readmes.js` rendered its two guide indexes from a hardcoded `['workflow', 'infrastructure', 'reference', 'design']`, written twice, while `guides/_registry.yml` and `CLAUDE.md` both carry five categories. Each literal was followed by `for (const catId of categoryOrder)`, so the one `investigation` guide was iterated over by nothing and appeared in no generated index. It was reachable only by knowing its filename.

No gate saw it, and `check-readmes` could not — by construction rather than by omission. It regenerates with the same literal and diffs the result against the file, so the generator and its check agreed perfectly about a guide neither of them rendered.

## The fix

Both literals now come from `scripts/lib/guide-categories.js`. Order is a **union**: the declared block's key order first, then any category a guide actually uses that the block never declared.

`categoryLabels` at `:283-288` was a **third** hardcoded list of the same four categories, unmentioned in the issue. Deriving `categoryOrder` without it would have rendered the fifth category as `**undefined**`.

The regenerated diff is purely additive — no reordering, no relabeling — which is what confirms the four existing categories render identically.

## The gate

Sharing a helper only stops the two indexes disagreeing with *each other*. So the assertion goes where it can compare against the other side — the registry.

**A11**, four sub-checks:

- **A11a** — every guide entry yields a *usable* category (non-uniqued count vs `- id:` entry count)
- **A11b** — every used category is *declared* in the `categories:` block
- **A11c** — every used category reaches *both* rendered indexes (`## Label` in `guides/README.md`, `**Label**` in `README.md`)
- plus a fail-closed zero-check on the extraction itself

**A12** — `total_guides` vs a disk count, *and* the registry `path:` set vs the disk file set.

`validate-integrity.yml` already triggers on `guides/**` and `scripts/**`, so both fire on exactly the paths they guard.

## Rounds 2 and 3: what the adversarial review changed

The first version had A11 as a single render-coverage check on `guides/README.md`. An adversarial review found **three further routes to #644's exact symptom** — a guide in no generated index, every gate green. A verification pass over the fixes then found a false claim and an untested control. Every finding was reproduced before being fixed:

| Route | Reproduction | Fix |
|---|---|---|
| Empty / deleted / bare `category:` | `category: ""` → 0 occurrences in **both** indexes; A11 saw only the 4 survivors and stayed green | A11a |
| A used category nothing declares | `category: investigatoin` + `update-readmes` → renders `## Investigatoin` / `*investigatoin*`, every gate green. A11's own remediation advice was the laundering step | A11b |
| Root README ungated | Reverted `generateGuidesSection` **alone** → guide gone from `README.md`, still in `guides/README.md`, `check-readmes` exit 0 | A11c |
| `total_guides` counts files, not entries | disk 35 = entries 35 = total 35; A12 never consulted the `guides:` list | A12 path set |
| **A12's own extractions unguarded** | Deleting the `total_guides:` key aborts the script with **no output at all** — A12's FAIL never prints, categories B and C never run | `\|\| true` on both lines |
| **Co-deletion untested** | Whole entry removed → `- id:` and `category:` fall to 34 in lockstep, `total_guides`/disk both 35; A12's path set is the **only** red | envelope case 5 |

Two claims I had written into the source as assertions were false, and both were caught by reading rather than by any gate:

1. `README.md` "is produced by the same shared helper over the same list, so it carries that file's parity" — the helper supplies only the **order**; the loop, the empty-skip and the rendering are separately duplicated.
2. "Every extraction below carries `|| true`" — false for A12's own two lines, sitting five lines above the note tracking that failure class as #647.

Smaller repairs: the "byte-for-byte" correction had reached the envelope header but not case 1's inline comment; the OK line called its number "declared categories" while counting distinct categories in *use*; A11b's key pattern rejected digit-initial categories (`3d-printing` already exists as a skills domain); `a11_declared` had no zero-guard; `tr -d '\r'` ran after the range sed whose anchors are `$`-terminated; the `**Label**` check now scopes to README.md's AUTO:guides block; A12's `sort -u` would have forgiven two entries sharing one path.

The `guide &&` null-guard in `guideCategoryOrder` survived all ten unit cases — a YAML `- ` entry parses to null and would crash the generator. A test now kills that mutant.

A4/A5 have the same entry-list blindness A12 fixed. Filed as #648 rather than widened into this PR.

## Must-go-red

`scripts/envelopes/a11-guide-category-render.mjs`, run against `bash scripts/validate-integrity.sh` — the command CI runs, not an inner script:

```
gate-envelope: 9 killed, 1 survived as documented of 10 case(s).
```

Case 1 restores `guides/README.md` to its pre-fix state (up to one trailing newline; measured delta is 1 byte), so it measures that A11 *would have caught #644* rather than merely that A11 can go red.

**The envelope found three defects that the issue's own acceptance criteria could not.** Two surfaced as `[WRONG-RED]` — the gate went red, but no FAIL line carried the expected message:

1. **A11's extraction aborted the script** (`10e5e126c`). Under `set -euo pipefail`, a bare `a11_cats=$(grep ... | ...)` aborts on no-match: red, no diagnostic, A11's zero-check dead, and A12 plus all of categories B and C never reached. **Both must-go-reds the issue asked for passed on that broken version**, because both mutate the corpus rather than the check. Generalised to the whole script as #647, where a live second instance is recorded: `validate-integrity.sh`'s `FAIL: ... missing required field: intent` is unreachable.
2. **A case `expect` went stale** (`cd4aca935`) when a later round renamed A12's message field. The gate was correct throughout; only the expectation was wrong. A case asserting only "went red" would have passed and told nobody the message a human reads had moved.
3. **A12's own extractions were unguarded** (`7d6f0186e`) — the same class as (1), in the lines this PR had copied from A4/A5. Not reachable by any corpus mutation the envelope had, because the count case keeps the key greppable; only a deletion reaches that path.

The header keeps all three runs rather than collapsing to the final number: a reader deciding whether to trust this envelope should see that it twice caught the gate reporting something other than what it claimed.

The `expect: null` case pins A11's scope as a measurement: it is category-level and does not notice a single guide missing from a rendered category. That is covered by `check-readmes`.

## Correction to the issue's acceptance criteria

AC 3 named `guides/quick-reference.md`. That file has exactly one generated section (`quickref-teams`, lines 59-61) and no per-category guide index; its only guide links are three hand-written ones at `:335-337`. No change to `categoryOrder` can make the guide appear there. Detail in https://github.com/pjt222/agent-almanac/issues/644#issuecomment-5326162906.

AC 3 is met by `README.md` and `guides/README.md`, both of which now list the guide.

## Battery

| | |
|---|---|
| `bash scripts/validate-integrity.sh` | PASSED — `OK: 35 guide entries, 5 declared categories, all rendered in both indexes` |
| `npm run check-readmes` | all files up to date |
| `npm run test:scripts` | 443/443, including 11 cases for the ordering rule |
| `npm run ratchet` | OK — 2 slices, fence 6/6 scanned 3648, diagram 1/1 scanned 72 |
| `npm run gate-envelope -- --spec scripts/envelopes/a11-guide-category-render.mjs` | 9 killed, 1 documented survivor of 10 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw

