### PR TITLE
ci: make the core validators requirable as status checks (#641)

### DIFF
--- a/.github/workflows/ci-node-cli.yml
+++ b/.github/workflows/ci-node-cli.yml
@@ -1,27 +1,11 @@
 name: CI Node CLI
 on:
+  # No `paths:` filter, deliberately (#641): a REQUIRED status check that does not run sits on
+  # "Expected — waiting for status to be reported" and refuses the merge forever, so only an
+  # unfiltered workflow can be required.
   push:
     branches: [main]
-    paths:
-      - 'cli/**'
-      # CLI tests are registry-derived (#307): registry changes must re-run them.
-      - 'skills/_registry.yml'
-      - 'agents/_registry.yml'
-      - 'teams/_registry.yml'
-      - 'guides/_registry.yml'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/ci-node-cli.yml'
   pull_request:
-    paths:
-      - 'cli/**'
-      - 'skills/_registry.yml'
-      - 'agents/_registry.yml'
-      - 'teams/_registry.yml'
-      - 'guides/_registry.yml'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/ci-node-cli.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -1,18 +1,11 @@
 name: CI Scripts
 on:
+  # No `paths:` filter, deliberately (#641): a REQUIRED status check that does not run sits on
+  # "Expected — waiting for status to be reported" and refuses the merge forever, so only an
+  # unfiltered workflow can be required.
   push:
     branches: [main]
-    paths:
-      - 'scripts/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/ci-scripts.yml'
   pull_request:
-    paths:
-      - 'scripts/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/ci-scripts.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/validate-integrity.yml
+++ b/.github/workflows/validate-integrity.yml
@@ -1,68 +1,31 @@
 name: Validate Integrity
 on:
+  # No `paths:` filter, deliberately (#641). This job is a REQUIRED status check, and a
+  # required check that does not run is not "skipped" -- it sits on "Expected — waiting for
+  # status to be reported" and refuses the merge forever. Only an unfiltered workflow can be
+  # required, which is why `validate-line-endings.yml` was the only one that ever worked as one.
+  #
+  # The filter this replaces was a curated 19-entry list whose every addition was argued (see
+  # git history for the rationale of each). Every one of those arguments was a special case of
+  # "this job must run when X changes"; running on everything is the general case, and it also
+  # retires the whole class of bug where an input is added to a check and nobody adds its path
+  # here. A10d used to enforce that listing and now reads the absent filter as universal
+  # coverage -- see `wf_event_paths` in scripts/validate-integrity.sh.
+  #
+  # Cost measured on PR #646: this job takes ~1m to run. Unconditional is affordable.
   push:
     branches: [main]
-    paths:
-      - 'agents/**'
-      - 'teams/**'
-      - 'guides/**'
-      - 'skills/**'
-      - 'workflows/**'
-      - 'scripts/**'
-      - '.claude/**'
-      - '.github/workflows/update-readmes.yml'
-      # B13 compares root README.md against i18n/*/translation_status.yml, and
-      # this job is its only PR-level caller. Without README.md here, a hand
-      # edit to the very table the gate guards merges with every check green.
-      # Self-listed for the same reason: a PR that drops this job's setup-node
-      # step (or its own paths) must not be able to bypass the job.
-      - 'README.md'
-      - '.github/workflows/validate-integrity.yml'
-      # A10 asserts this workflow's `for content_type in` loops against the
-      # CONTENT_TYPES SSOT, so a PR editing only it must not bypass the check
-      # that guards it. A10 enforces this listing rather than trusting it.
-      - '.github/workflows/validate-translations.yml'
-      # A8 derives its expected translation_status set from i18n/_config.yml and
-      # B6 reads i18n/*/ — without this, a new-locale PR bypasses both (#362).
-      - 'i18n/**'
-      - 'viz/R/glyphs.R'
-      - 'viz/R/agent_glyphs.R'
-      - 'viz/R/palettes.R'
-      - 'viz/domain-styles.yml'
-      - 'viz/agent-styles.yml'
-      - 'viz/team-styles.yml'
-      - 'viz/build-icon-manifest.js'
   pull_request:
-    paths:
-      - 'agents/**'
-      - 'teams/**'
-      - 'guides/**'
-      - 'skills/**'
-      - 'workflows/**'
-      - 'scripts/**'
-      - '.claude/**'
-      - '.github/workflows/update-readmes.yml'
-      - 'README.md'
-      - '.github/workflows/validate-integrity.yml'
-      # A10 asserts this workflow's `for content_type in` loops against the
-      # CONTENT_TYPES SSOT, so a PR editing only it must not bypass the check
-      # that guards it. A10 enforces this listing rather than trusting it.
-      - '.github/workflows/validate-translations.yml'
-      - 'i18n/**'
-      - 'viz/R/glyphs.R'
-      - 'viz/R/agent_glyphs.R'
-      - 'viz/R/palettes.R'
-      - 'viz/domain-styles.yml'
-      - 'viz/agent-styles.yml'
-      - 'viz/team-styles.yml'
-      - 'viz/build-icon-manifest.js'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  validate:
+  # Job id is the status-check CONTEXT name. It was `validate`, which four workflows shared --
+  # integrity, skills, tests and translations -- so the four were one indistinguishable name and
+  # none of them could be required individually (#641).
+  integrity:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,57 +1,20 @@
 name: Validate Skills
 on:
+  # No `paths:` filter, deliberately (#641): a REQUIRED status check that does not run sits on
+  # "Expected — waiting for status to be reported" and refuses the merge forever, so only an
+  # unfiltered workflow can be required.
   push:
     branches: [main]
-    paths:
-      - 'skills/**'
-      - 'i18n/**'
-      - 'agents/**'
-      - 'teams/**'
-      - 'guides/**'
-      - 'scripts/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'debt-ratchet.yml'
-      - '.github/workflows/validate-skills.yml'
-      # The viz PUT annotations and the diagram generated from them (#590). This
-      # workflow is where `npm run ratchet` runs, and the ratchet is the only
-      # thing that can turn the warn-only node-parity gate red — so a PR that
-      # deletes an annotation must trigger THIS workflow or the slice is
-      # bypassable by construction. Deliberately not a bare `viz/**`: locales,
-      # icons and generated PNGs live there and none of them move the node set.
-      # Both a root-level and a nested glob per extension, because `viz/**/*.js`
-      # alone is not reliably matched against `viz/build-data.js`.
-      - 'viz/*.js'
-      - 'viz/**/*.js'
-      - 'viz/*.R'
-      - 'viz/**/*.R'
-      - 'viz/public/data/workflow.mmd'
   pull_request:
-    paths:
-      - 'skills/**'
-      - 'i18n/**'
-      - 'agents/**'
-      - 'teams/**'
-      - 'guides/**'
-      - 'scripts/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'debt-ratchet.yml'
-      - '.github/workflows/validate-skills.yml'
-      # See the push block above: without these, deleting a PUT annotation is a
-      # change the ratchet never runs on.
-      - 'viz/*.js'
-      - 'viz/**/*.js'
-      - 'viz/*.R'
-      - 'viz/**/*.R'
-      - 'viz/public/data/workflow.mmd'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  validate:
+  # Job id is the status-check CONTEXT name. It was `validate`, shared by four workflows, so
+  # none of them could be required individually (#641).
+  skills:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/validate-tests.yml
+++ b/.github/workflows/validate-tests.yml
@@ -14,7 +14,11 @@ permissions:
   contents: read
 
 jobs:
-  validate:
+  # Renamed off the shared `validate` context (#641). This job keeps its paths filter and is
+  # deliberately NOT a required check: it reports on too few PRs to be required without an
+  # unfiltered trigger, and unfiltering it was not in scope. The rename is still needed so the
+  # PR page names it, and so it CAN be required later without renaming under a live ruleset.
+  tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/validate-translations.yml
+++ b/.github/workflows/validate-translations.yml
@@ -11,7 +11,11 @@ permissions:
   contents: read
 
 jobs:
-  validate:
+  # Renamed off the shared `validate` context (#641). This job keeps its paths filter and is
+  # deliberately NOT a required check: it reports on too few PRs to be required without an
+  # unfiltered trigger, and unfiltering it was not in scope. The rename is still needed so the
+  # PR page names it, and so it CAN be required later without renaming under a live ruleset.
+  translations:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/scripts/envelopes/a10-content-type-literals.mjs
+++ b/scripts/envelopes/a10-content-type-literals.mjs
@@ -42,7 +42,12 @@ export const cases = [
     // instead yield an EMPTY list, caught one guard earlier by a different message — which is
     // how this case was mis-specified on its first writing.
     label: 'NESTING names a tree the SSOT does not have',
-    file: 'scripts/check-i18n-fence-parity.js',
+    // File corrected 2026-08-18: `NESTING` moved to scripts/lib/i18n-targets.js in #552
+    // (9ad1b4019), and this case kept naming its old home. It has been silently INCONCLUSIVE
+    // ever since — pre-existing rot, found only by running the envelope while working on #641.
+    // The envelope is deliberately not in CI, which is exactly how a fixture rots unnoticed;
+    // the count guard is what turns that rot into a visible refusal rather than a false pass.
+    file: 'scripts/lib/i18n-targets.js',
     find: 'const NESTING = { skills: true, agents: false, teams: false, guides: false };',
     replace: 'const NESTING = { workflows: true, agents: false, teams: false, guides: false };',
     expect: 'derived no nested trees',
@@ -121,23 +126,13 @@ export const cases = [
     replace: "find guides -name 'SKILL.md' -exec",
     expect: "B5's SKILL.md find walks",
   },
-  {
-    // A10d: the gate must be able to fire on the files it reads. Found by reading the CI job log
-    // rather than the check's green — .github/workflows/validate-translations.yml was outside
-    // validate-integrity.yml's trigger paths, so a PR editing only it bypassed A10 entirely.
-    label: 'the trigger path for a file A10 reads is removed',
-    file: '.github/workflows/validate-integrity.yml',
-    // The two-line form matches ONCE, in the `pull_request` block: the `push` block carries the
-    // A8/#362 comment between the same two entries. An earlier version of this case claimed the
-    // blocks were "identical" and declared `sites: 2`; the count guard rejected it, which is the
-    // point of naming the number instead of accepting whatever is there.
-    //
-    // Targeting pull_request alone is also the more precise mutation, since that is the only
-    // list A10d reads.
-    find: "      - '.github/workflows/validate-translations.yml'\n      - 'i18n/**'",
-    replace: "      - 'i18n/**'",
-    expect: 'does not run on changes to it',
-  },
+  // REMOVED 2026-08-18 (#641): 'the trigger path for a file A10 reads is removed'.
+  // The property it measured no longer exists — validate-integrity.yml lost its paths filter so
+  // the job could become a required status check, leaving no per-input path entry to delete.
+  // A10d's successor property (an ABSENT filter reads as universal, a broken or empty one does
+  // NOT) is covered by the two A10d cases at the end of this file. Recorded as a removal rather
+  // than deleted quietly: a case that vanishes looks identical in the tally to one that never
+  // existed, and this file's whole job is to be readable as a record.
   {
     // THE DOCUMENTED LIMIT, measured rather than asserted. Co-deletion removes the loop's nested
     // branch AND its list entry in one edit, leaving a well-formed flat loop with no signal in
@@ -163,5 +158,29 @@ export const cases = [
     ].join('\n'),
     expect: null,
     why: "A10's one non-guarantee: co-deletion erases the signal the per-site rule keys on, and one full loop still remains so the counter is satisfied.",
+  },
+  {
+    // A10d's THREE-state reader (#641). #641 removed this workflow's paths filter so the job
+    // could become a required status check, and taught A10d that an absent filter means
+    // universal coverage. The danger in that teaching is folding a BROKEN parse into the same
+    // "universal" verdict — a drifted pattern would then report the strongest possible coverage
+    // while having read nothing, which is the vacuous pass this whole file exists to measure.
+    //
+    // Here the `paths:` key is present and yields zero entries. That is state 2, and it must
+    // FAIL rather than be mistaken for state "no filter at all".
+    label: 'A10d: a paths: key that yields no entries is NOT universal coverage',
+    file: '.github/workflows/validate-integrity.yml',
+    find: '  pull_request:\n  workflow_dispatch:',
+    replace: '  pull_request:\n    paths:\n  workflow_dispatch:',
+    expect: 'trigger coverage UNCHECKED',
+  },
+  {
+    // The other failure state: no pull_request block at all. Distinct from an empty filter and
+    // from no filter, and equally must not read as universal.
+    label: 'A10d: a missing pull_request block is NOT universal coverage',
+    file: '.github/workflows/validate-integrity.yml',
+    find: '  pull_request:\n  workflow_dispatch:',
+    replace: '  workflow_dispatch:',
+    expect: 'trigger coverage UNCHECKED',
   },
 ];

--- a/scripts/envelopes/a10-content-type-literals.mjs
+++ b/scripts/envelopes/a10-content-type-literals.mjs
@@ -129,10 +129,14 @@ export const cases = [
   // REMOVED 2026-08-18 (#641): 'the trigger path for a file A10 reads is removed'.
   // The property it measured no longer exists — validate-integrity.yml lost its paths filter so
   // the job could become a required status check, leaving no per-input path entry to delete.
-  // A10d's successor property (an ABSENT filter reads as universal, a broken or empty one does
-  // NOT) is covered by the two A10d cases at the end of this file. Recorded as a removal rather
-  // than deleted quietly: a case that vanishes looks identical in the tally to one that never
-  // existed, and this file's whole job is to be readable as a record.
+  // Its branch is NOT gone, though, and an adversarial review caught that this comment first
+  // claimed otherwise: `a10_covered` still runs whenever a filter is present, and re-adding a
+  // scoped filter is the realistic regression once everyone notices every PR runs everything.
+  // The last of the four A10d cases at the end of this file restores that coverage by
+  // reintroducing a filter that misses one input. The other three cover the states the helper
+  // must not read as universal: empty paths (rc=2), no event block (rc=1), paths-ignore (rc=3).
+  // Recorded as a removal rather than deleted quietly: a case that vanishes looks identical in
+  // the tally to one that never existed, and this file's whole job is to be read as a record.
   {
     // THE DOCUMENTED LIMIT, measured rather than asserted. Co-deletion removes the loop's nested
     // branch AND its list entry in one edit, leaving a well-formed flat loop with no signal in
@@ -172,7 +176,9 @@ export const cases = [
     file: '.github/workflows/validate-integrity.yml',
     find: '  pull_request:\n  workflow_dispatch:',
     replace: '  pull_request:\n    paths:\n  workflow_dispatch:',
-    expect: 'trigger coverage UNCHECKED',
+    // The rc is IN the expect on purpose. Sharing one substring across the states would let a
+    // helper that collapsed them all to a single rc kill every case and tell nobody.
+    expect: '(rc=2) -- trigger coverage UNCHECKED',
   },
   {
     // The other failure state: no pull_request block at all. Distinct from an empty filter and
@@ -181,6 +187,32 @@ export const cases = [
     file: '.github/workflows/validate-integrity.yml',
     find: '  pull_request:\n  workflow_dispatch:',
     replace: '  workflow_dispatch:',
-    expect: 'trigger coverage UNCHECKED',
+    expect: '(rc=1) -- trigger coverage UNCHECKED',
+  },
+  {
+    // `paths-ignore:` is a real filter, and the `-` defeats a `^    paths:` test. The first
+    // version of wf_event_paths decided UNIVERSAL by the ABSENCE of that pattern, so this shape
+    // returned "runs on everything" with rc 0 — measured, not theorised. It reproduces both
+    // halves of #641 at once: a required check silently stops reporting on the excluded PRs and
+    // hangs them on "Expected", while A10d reports full coverage. No workflow uses it today,
+    // which is exactly why it needs a case rather than a reader's vigilance.
+    label: 'A10d: a paths-ignore filter is NOT universal coverage',
+    file: '.github/workflows/validate-integrity.yml',
+    find: '  pull_request:\n  workflow_dispatch:',
+    replace: "  pull_request:\n    paths-ignore:\n      - 'dreams/**'\n  workflow_dispatch:",
+    expect: '(rc=3) -- trigger coverage UNCHECKED',
+  },
+  {
+    // A10d's THIRD live branch: a present, non-empty list that fails to cover an A10 input.
+    // #641 removed the filter, and the case that used to cover this branch went with it — but
+    // the branch is still live code, and it is the realistic regression: someone re-adds a
+    // scoped filter after noticing every PR now runs everything. `scripts/**` covers four of
+    // the five A10 inputs through a10_covered's `*/**` arm and misses the fifth, which also
+    // pins that glob semantics rather than leaving it as unexercised code.
+    label: 'A10d: a reintroduced paths filter that misses an A10 input goes red',
+    file: '.github/workflows/validate-integrity.yml',
+    find: '  pull_request:\n  workflow_dispatch:',
+    replace: "  pull_request:\n    paths:\n      - 'scripts/**'\n  workflow_dispatch:",
+    expect: 'does not run on changes to it',
   },
 ];

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -42,7 +42,27 @@ wf_event_paths() { # <workflow file> <event key>
     END { if (!found) exit 9 }
   ' "$file") || return 1
 
+  # UNIVERSAL is the strongest verdict this function can return, so it is reached only on
+  # positive evidence that the event carries no filtering key -- never as the fallback for
+  # "nothing matched my pattern". The first version decided it by the ABSENCE of `^    paths:`,
+  # which made every shape the parser did not understand read as "runs on everything":
+  # `paths-ignore:` (a real filter, and the `-` defeats the pattern) and a `paths:` key at any
+  # other indent both returned __UNIVERSAL__ with rc 0. Measured, before this guard existed.
+  #
+  # That is the same default-open defect as folding a broken parse into a pass, aimed at the one
+  # verdict where it does most damage: a `paths-ignore:` added to a REQUIRED workflow would stop
+  # it reporting on the excluded PRs -- hanging them on "Expected" forever, the exact #641
+  # symptom -- while A10d printed "carries no paths filter, every input covered".
+  #
+  # rc 3 therefore means "this event is filtered by something I could not fully read". Fail
+  # closed and name it, rather than guessing in the permissive direction.
+  if printf '%s\n' "$block" | grep -qE '^[[:space:]]+paths-ignore:'; then
+    return 3
+  fi
   if ! printf '%s\n' "$block" | grep -qE '^    paths:'; then
+    if printf '%s\n' "$block" | grep -qE '^[[:space:]]+paths:'; then
+      return 3
+    fi
     printf '__UNIVERSAL__\n'
     return 0
   fi

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -8,6 +8,65 @@ set -euo pipefail
 failed=0
 warn_count=0
 
+# ── Shared: read one event's trigger paths out of a workflow (#641) ──────────────
+#
+# Two checks need this and each had its own `sed` range: A8c over validate-readmes.yml and
+# A10d over validate-integrity.yml. Both ranges were terminated by whatever key happened to
+# come next in that file (`schedule:` in one, `workflow_dispatch:` in the other), so each was
+# silently coupled to the unrelated ordering of its target's `on:` block.
+#
+# THREE outcomes, and keeping them distinct is the whole point:
+#
+#   __UNIVERSAL__   the event block exists and declares no `paths:` key, so the workflow runs
+#                   on every change. Coverage is total -- strictly stronger than any list.
+#   path entries    a `paths:` filter is present; the caller decides what it must cover.
+#   non-zero exit   the event block is absent (1), or `paths:` is present and yields nothing (2).
+#
+# The middle failure state is the one that matters. Folding "parse produced nothing" into
+# "universal" would convert a drifted pattern into a silent all-clear -- the vacuous pass this
+# family of checks exists to prevent, and the exact shape that shipped twice in #646.
+#
+# Both YAML sequence forms are handled because both are in use here: block form in
+# validate-integrity.yml, flow form (`paths: ['a', 'b']`) in validate-tests.yml. The previous
+# `sed` parses matched only block form, so a legal retag to flow form would have read as empty.
+wf_event_paths() { # <workflow file> <event key>
+  local file="$1" ev="$2" block entries
+  block=$(awk -v ev="$ev" '
+    /^  [A-Za-z_-]+:/ {
+      key = $0; sub(/^  /, "", key); sub(/:.*$/, "", key)
+      inev = (key == ev)
+      if (inev) { found = 1 }
+      next
+    }
+    inev { print }
+    END { if (!found) exit 9 }
+  ' "$file") || return 1
+
+  if ! printf '%s\n' "$block" | grep -qE '^    paths:'; then
+    printf '__UNIVERSAL__\n'
+    return 0
+  fi
+
+  entries=$(printf '%s\n' "$block" \
+    | awk '
+        /^    paths:[[:space:]]*\[/ {
+          line = $0
+          sub(/^[^[]*\[/, "", line); sub(/\].*$/, "", line)
+          n = split(line, parts, ",")
+          for (i = 1; i <= n; i++) { gsub(/^[[:space:]]+|[[:space:]]+$/, "", parts[i]); if (parts[i] != "") print parts[i] }
+          next
+        }
+        /^    paths:/ { inp = 1; next }
+        inp && /^      - / { print; next }
+        inp && /^    [A-Za-z_-]+:/ { inp = 0 }
+      ' \
+    | sed -E "s/^      - //; s/^['\"]//; s/['\"]$//" \
+    | sed '/^$/d' || true)
+
+  [ -z "$entries" ] && return 2
+  printf '%s\n' "$entries"
+}
+
 echo "=== Category A: Static Validation ==="
 
 # A1: Validate agent frontmatter
@@ -308,25 +367,39 @@ else
     echo "FAIL: $a8_vr is missing, so the generated-README staleness gate cannot run (#563)"
     failed=1; a8_fail=1
   else
-    # Each `paths:` block, flattened to its quoted entries, one block per line.
-    a8_vr_push=$(sed -n "/^  push:/,/^  pull_request:/p" "$a8_vr" | grep -oE "^      - '[^']+'" | sed -E "s/^      - '//; s/'$//" | sort -u)
-    a8_vr_pr=$(sed -n "/^  pull_request:/,/^  schedule:/p" "$a8_vr" | grep -oE "^      - '[^']+'" | sed -E "s/^      - '//; s/'$//" | sort -u)
-    if [ -z "$a8_vr_push" ] || [ -z "$a8_vr_pr" ]; then
-      echo "FAIL: A8c could not parse the paths blocks of $a8_vr (parse broke, not a pass)"
+    # Read through the shared helper, which distinguishes "no filter" from "parse broke".
+    # An unfiltered event gates every path there is, which satisfies #563's requirement more
+    # strongly than any list can -- so it is accepted, and the per-output containment below is
+    # skipped for that event rather than being run against an empty list and passing vacuously.
+    # `|| rc=$?`, never `; rc=$?`. A bare assignment carries its command's exit status, so
+    # under `set -euo pipefail` a non-zero return ABORTS the script at this line -- red with no
+    # diagnostic and every later check skipped. That is the #647 class, and the first version of
+    # this very fix shipped it: the envelope reported WRONG-RED because the FAIL below never ran.
+    a8_vr_push_rc=0; a8_vr_push=$(wf_event_paths "$a8_vr" push) || a8_vr_push_rc=$?
+    a8_vr_pr_rc=0; a8_vr_pr=$(wf_event_paths "$a8_vr" pull_request) || a8_vr_pr_rc=$?
+    if [ "$a8_vr_push_rc" -ne 0 ] || [ "$a8_vr_pr_rc" -ne 0 ]; then
+      echo "FAIL: A8c could not parse the paths blocks of $a8_vr (rc push=$a8_vr_push_rc pr=$a8_vr_pr_rc; parse broke or a paths: key is empty -- not a pass)"
       failed=1; a8_fail=1
     else
+      # Both events must gate the same set, or the gate fires on one event and not the other.
+      # Two universals agree; a universal opposite a list does not, and that asymmetry is worth
+      # reporting rather than silently treating the superset as good enough.
       if [ "$a8_vr_push" != "$a8_vr_pr" ]; then
         echo "FAIL: $a8_vr push and pull_request paths differ -- the gate would fire on one event and not the other:"
         diff <(printf '%s\n' "$a8_vr_push") <(printf '%s\n' "$a8_vr_pr") | sed 's/^/  /' || true
         failed=1; a8_fail=1
       fi
-      while IFS= read -r f; do
-        [ -z "$f" ] && continue
-        if ! printf '%s\n' "$a8_vr_push" | grep -Fxq "$f"; then
-          echo "FAIL: MANAGED output '$f' is missing from $a8_vr paths (hand edits to it would not be gated -- #563)"
-          failed=1; a8_fail=1
-        fi
-      done <<< "$a8_readmes"
+      if [ "$a8_vr_push" = "__UNIVERSAL__" ]; then
+        echo "  A8c: $a8_vr carries no paths filter -- it runs on every change, so every MANAGED output is gated by construction"
+      else
+        while IFS= read -r f; do
+          [ -z "$f" ] && continue
+          if ! printf '%s\n' "$a8_vr_push" | grep -Fxq "$f"; then
+            echo "FAIL: MANAGED output '$f' is missing from $a8_vr paths (hand edits to it would not be gated -- #563)"
+            failed=1; a8_fail=1
+          fi
+        done <<< "$a8_readmes"
+      fi
     fi
   fi
 
@@ -549,8 +622,8 @@ else
   #
   # The source list below is hardcoded and inherently so: it is the set of files A10 opens, which
   # only A10 knows. Adding a read without adding it here is the one drift this cannot see.
-  a10_paths=$(sed -n '/^  pull_request:/,/^  workflow_dispatch:/p' .github/workflows/validate-integrity.yml \
-    | grep -E '^      - ' | sed -E "s/^      - //; s/^['\"]//; s/['\"]\$//" || true)
+  # `|| rc=$?` for the reason spelled out at A8c: a bare assignment would abort the script here.
+  a10_paths_rc=0; a10_paths=$(wf_event_paths .github/workflows/validate-integrity.yml pull_request) || a10_paths_rc=$?
   a10_covered() { # <repo-relative path> -> 0 when some pull_request path entry matches it
     while IFS= read -r a10_pat; do
       [ -z "$a10_pat" ] && continue
@@ -561,9 +634,18 @@ else
     done <<< "$a10_paths"
     return 1
   }
-  if [ -z "$a10_paths" ]; then
-    echo "FAIL: A10 could not read validate-integrity.yml's pull_request paths -- trigger coverage UNCHECKED"
+  if [ "$a10_paths_rc" -ne 0 ]; then
+    # rc 1 = no pull_request block at all; rc 2 = a paths: key that yielded nothing. Neither is
+    # "runs on everything": an unreadable filter leaves trigger coverage UNKNOWN, and reporting
+    # unknown as universal is how a drifted pattern becomes a silent all-clear.
+    echo "FAIL: A10 could not read validate-integrity.yml's pull_request paths (rc=$a10_paths_rc) -- trigger coverage UNCHECKED"
     failed=1; a10_fail=1
+  elif [ "$a10_paths" = "__UNIVERSAL__" ]; then
+    # No paths filter: the workflow runs on every change, so every input A10 reads is covered.
+    # This is the state #641 put it in so the job could become a required status check -- a
+    # path-filtered workflow does not report on PRs outside its filter, and a required check
+    # that never reports leaves the PR on "Expected" and refuses the merge forever.
+    echo "  A10d: validate-integrity.yml carries no paths filter -- it runs on every change, so every A10 input is covered"
   else
     for a10_src in scripts/lib/content-types.js scripts/lib/i18n-targets.js \
                    scripts/validate-integrity.sh scripts/translate-content.sh \


### PR DESCRIPTION
Advances #641. The ruleset flip is a follow-up API action, deliberately not in this PR — see **Sequencing** below.

## What was actually true

Re-derived from the API on 2026-08-18, not taken from the issue:

```
19037588  protect-main-refs     deletion, non_fast_forward      bypass: (none)
19036109  require-line-endings  required_status_checks:         bypass: DeployKey/always,
                                  [line-endings]                        User 47758568/always
```

`47758568` is `pjt222` — the only collaborator, and the only human who merges here. Rulesets do not auto-exempt admins, so this is explicit. **No check refuses any merge today, including `line-endings`.** The issue understates itself.

## Two blockers the issue did not know about

**1. The context names collided.** Four workflows named their job `validate`. Required checks match by context name, so those four were one indistinguishable name — AC 2's "`validate` (validate-skills), `validate` (validate-integrity)" is not expressible. Renamed to `integrity`, `skills`, `tests`, `translations`. Nothing referenced the old ids: no `needs:`, no `workflow_run`, no badge (both address workflow *files*), no ruleset entry.

**2. A path-filtered workflow cannot be a required check.** It does not report outside its filter, and a required check that never reports sits on `Expected — waiting for status to be reported` and refuses the merge *forever*. `validate-line-endings.yml` is the only unfiltered workflow, which is precisely why it is the only one that ever worked as a required check. Measured: `main@cf363baa` carries **two** check runs named `validate`, not four.

So the filters come off the four workflows whose jobs become required. Their jobs run in 10s–69s; unconditional is affordable.

## Scope reduction, stated rather than silent

`readmes` was in the agreed set and is **not** in this PR. `validate-readmes.yml` filters on its *output* set deliberately — its own comment records that triggering on inputs "would fail every ordinary content PR for not having run a generator the docs say CI runs for you, which is a contract change wearing a bug fix's clothes."

Requiring it would force every registry-touching PR to regenerate before merge, inverting the reason the auto-commit healer exists. That is a contract change, and not this PR's to make. `tests` and `translations` are renamed but stay filtered and unrequired for the same reason at lower stakes.

## The gate collision

Removing `validate-integrity.yml`'s filter broke the repo's own check: **A10d parsed that workflow's `pull_request` paths** and failed closed on reading none. **A8c** did the same for `validate-readmes.yml`. Both now go through one shared `wf_event_paths` helper with **three** outcomes:

| Outcome | Meaning |
|---|---|
| `__UNIVERSAL__` | event block present, no `paths:` key — runs on everything, coverage total |
| path entries | a filter is present; the caller decides what it must cover |
| non-zero exit | no such event block (1), or a `paths:` key yielding nothing (2) |

Keeping the middle state distinct is the whole point. Folding a broken parse into "universal" converts a drifted pattern into the strongest possible all-clear — the vacuous pass this family of checks exists to prevent.

The helper also replaces two `sed` ranges each terminated by whatever key happened to follow in its target (`schedule:` in one, `workflow_dispatch:` in the other), and reads **both** YAML sequence forms. The old parses matched block form only, so the flow form already in use in `validate-tests.yml` would have read as empty — found by testing the helper against all fifteen workflows rather than the two it was written for.

## Must-go-red

```
[KILLED] A10d: a paths: key that yields no entries is NOT universal coverage
         FAIL: ... (rc=2) -- trigger coverage UNCHECKED
[KILLED] A10d: a missing pull_request block is NOT universal coverage
         FAIL: ... (rc=1) -- trigger coverage UNCHECKED
gate-envelope: 2 killed of 2 case(s).
```

**The first version of this change failed that envelope as `WRONG-RED`.** `a10_paths=$(wf_event_paths ...)` is a bare assignment whose command can exit non-zero, which under `set -euo pipefail` aborts the script with no diagnostic — the #647 class, written into the very fix that documents it. Both call sites now use `|| rc=$?`.

Running the envelope also surfaced **pre-existing rot in the envelope itself**: the NESTING case still named `scripts/check-i18n-fence-parity.js`, though NESTING moved to `scripts/lib/i18n-targets.js` in #552 (`9ad1b4019`). Silently INCONCLUSIVE ever since. The envelope is deliberately not in CI, which is how a fixture rots unnoticed; the count guard turns that into a refusal rather than a false pass. One case is removed rather than deleted quietly — the property it measured no longer exists once the filter is gone.

## Sequencing

The ruleset change is an API action, not a diff, and must land **after** this merges. Flipping it first would leave every open PR (#512, #624, #256) reporting the old context names and hanging on `Expected`.

After merge, the follow-up covers the rest of #641's ACs: add the required-checks rule for `line-endings`, `integrity`, `skills`, `scripts-test`, `cli-test`; record why `readmes`/`tests`/`translations` are excluded, and why **CodeQL is excluded** (per #643, default-setup runs are `event: dynamic` and cannot be rerun — a 503'd required CodeQL would brick the PR until a new push); verify by dropping the User bypass, confirming a failing check refuses the merge, and restoring it; then the `CLAUDE.md` sentence distinguishing "the step exits non-zero" from "the merge is refused".

## Battery

| | |
|---|---|
| `bash scripts/validate-integrity.sh` | PASSED — `A10d: validate-integrity.yml carries no paths filter -- ... every A10 input is covered` |
| `npm run ratchet` | OK — 2 slices; advisory-gate inventory is keyed on workflow file path, so the renames do not move it |
| `npm run test:scripts` | 443/443 |
| `npm run check-readmes` | up to date |
| `gate-envelope --spec a10-content-type-literals.mjs --only A10d` | 2 killed of 2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw