### PR TITLE
TEST (do not merge): verify required status checks refuse a merge (#641)

### DIFF
--- a/guides/_registry.yml
+++ b/guides/_registry.yml
@@ -2,7 +2,7 @@
 # Machine-readable catalog of all guide documents in this library.
 # Keep in sync with the actual guide files on disk.
 
-total_guides: 35
+total_guides: 36
 version: "1.0"
 last_updated: "2026-07-16"
 


### PR DESCRIPTION
Throwaway verification PR for #641. **Do not merge — close after checking.**

Bumps `total_guides` to 36 against 35 guides on disk, so integrity check A12 fails and the required `integrity` context goes red.

Verifying two things:
1. **Every required context actually reports here.** A typo in a context name would leave the PR on `Expected` forever and brick every future PR — this is the check for that.
2. **A red required check refuses the merge.**