### PR TITLE
fix(gates): stop a bare command substitution from silently killing validate-integrity.sh (#647)

### DIFF
--- a/.github/workflows/validate-integrity.yml
+++ b/.github/workflows/validate-integrity.yml
@@ -39,5 +39,21 @@ jobs:
         with:
           node-version: '24'
 
+      # Runs BEFORE the gate it guards, deliberately. A bare `x=$(grep …)` under
+      # `set -euo pipefail` aborts the whole script with no diagnostic, so a regression here
+      # makes validate-integrity.sh exit early and look like an ordinary pass-with-fewer-lines.
+      # Checking first means the reason is on screen above the silence (#647).
+      #
+      # Blocking, not `--warn`: the corpus is at zero unguarded sites as of this commit, so
+      # there is no backlog to ratchet down and nothing to warn about. A gate introduced clean
+      # can ship blocking on day one -- see CLAUDE.md § Ratcheting a Warn-Only Gate for the
+      # case where that is not true.
+      #
+      # Invoked as `node …` rather than `npm run check:bare-substitutions` to honour the
+      # no-`npm ci` constraint stated above without depending on npm's behaviour with an
+      # absent node_modules. The npm alias exists for local use.
+      - name: Check for abort-capable command substitutions
+        run: node scripts/check-bare-substitutions.js
+
       - name: Run integrity checks
         run: bash scripts/validate-integrity.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A library of executable skills, specialist agents, and pre-built teams for [Clau
 - **370 skills** across 66 domains — structured, executable procedures
 - **75 agents** — specialized Claude Code personas covering development, review, compliance, and more
 - **22 teams** — predefined multi-agent compositions for complex workflows
-- **35 guides** — human-readable workflow, infrastructure, and reference documentation
+- **35 guides** — human-readable documentation across workflow, infrastructure, reference, design, and investigation
 - **Interactive visualization** — force-graph explorer with 370 R-generated skill icons and 9 color themes
 <!-- AUTO:END:stats -->
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "check:placeholder-drift": "node scripts/check-placeholder-drift.js",
     "check:fence-propagation": "node scripts/check-fence-propagation.js",
     "check:diagram-nodes": "node scripts/check-workflow-diagram-nodes.js",
+    "check:bare-substitutions": "node scripts/check-bare-substitutions.js",
     "normalize:i18n-fences": "node scripts/normalize-i18n-fences.js",
     "backfill:fence-basis": "node scripts/backfill-fence-basis.js",
     "validate:content-style": "node scripts/check-content-style.js --all",

--- a/scripts/bulk-scaffold-caveman.sh
+++ b/scripts/bulk-scaffold-caveman.sh
@@ -4,7 +4,7 @@
 # Usage: bash scripts/bulk-scaffold-caveman.sh [--dry-run]
 
 set -euo pipefail
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)" # abort-ok: cd into this script's own parent; failure means the script was deleted mid-run
 cd "$ROOT"
 
 DRY_RUN=0

--- a/scripts/bulk-scaffold-caveman.sh
+++ b/scripts/bulk-scaffold-caveman.sh
@@ -10,7 +10,7 @@ cd "$ROOT"
 DRY_RUN=0
 [[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
 
-SOURCE_COMMIT=$(git log -1 --format=%h)
+SOURCE_COMMIT=$(git log -1 --format=%h) # abort-ok: `git log -1` fails only in a repo with no commits, which is a broken invocation rather than drift
 TODAY=$(date +%Y-%m-%d)
 LOCALES=(caveman-lite caveman caveman-ultra wenyan-lite wenyan wenyan-ultra)
 CREATED=0

--- a/scripts/check-bare-substitutions.js
+++ b/scripts/check-bare-substitutions.js
@@ -53,20 +53,37 @@
  * "is X missing" test. That judgement is not decidable by pattern-matching, which is why the
  * rule is also stated in prose at the top of `validate-integrity.sh`.
  *
- * It also deliberately ignores `local x=$(…)` / `declare x=$(…)`, which do NOT abort: the
- * status becomes `local`'s, always 0. That is the inverse hazard — a silent empty value where
- * the author expected an abort — and it needs a different check, not this one.
+ * It also deliberately ignores the ONE-WORD declaration `local x=$(…)` / `declare x=$(…)`,
+ * which does not abort: the command's status becomes `local`'s, always 0. That is the inverse
+ * hazard — a silent empty value where the author expected an abort — and it needs a different
+ * check, not this one.
  *
- * And one known false negative, stated rather than left to be discovered:
+ * The SPLIT form is a different statement and is scanned:
+ *
+ *   local x=$(grep -c zzz /dev/null)      # continues — status is `local`'s
+ *   local x; x=$(grep -c zzz /dev/null)   # ABORTS — the assignment carries the status
+ *
+ * The split spelling is the recommended idiom precisely *because* the status propagates, so
+ * exempting it along with the one-word form — which the first version did, by testing the line
+ * for a leading `local` — hid a live site in `sync-discovery-symlinks.sh`.
+ *
+ * And two known false negatives, stated rather than left to be discovered:
  *
  *   x=$(grep foo bar || true | wc -l)
  *
  * The guard is INSIDE the pipeline, so it protects `grep` and not the pipeline's exit status.
  * `pipefail` still returns the rightmost non-zero, and the assignment can still abort. The
- * guard test here is span-wide, so this reads as guarded. Fixing it needs the guard's position
- * relative to the last pipeline segment, which the span scanner does not track. No site in
- * this repo has that shape; it is written down because the next one to appear will be invisible
- * to this check, and a limit nobody recorded looks like a limit nobody has.
+ * guard test is span-wide, so this reads as guarded. Fixing it needs the guard's position
+ * relative to the last pipeline segment, which the span scanner does not track.
+ *
+ *   x=$(grep foo bar) ; other || true
+ *
+ * The guard test runs from the assignment to the end of the logical line, so a `|| true`
+ * belonging to a LATER statement on the same line reads as this site's guard. The alternative
+ * — ending the guard test at the substitution's closing paren — cuts off the real guard in
+ * `x=$(f a b) || rc=$?`, which is the shape three live sites use, so this direction is the
+ * deliberate one. Neither shape exists in this repo today; both are written down because a
+ * limit nobody recorded looks like a limit nobody has.
  */
 
 import { readFileSync } from 'node:fs';
@@ -101,14 +118,57 @@ const SAFE_COMMANDS = new Set([
 // falling through, so `set -e` never sees an unhandled non-zero. `wf_event_paths` uses exactly
 // that shape, and leaving it out of this pattern reported the repo's most carefully-guarded
 // site as unguarded.
-const GUARD = /\|\|\s*(true|:|echo\b|return\b|exit\b|continue\b|break\b|[A-Za-z_][A-Za-z_0-9]*=|\w+\s*=\s*\$\?)/;
+// `|| return N` and `|| exit N` are guards too: control leaves the assignment rather than
+// falling through, so `set -e` never sees an unhandled non-zero. `wf_event_paths` uses exactly
+// that shape, and leaving it out of this pattern reported the repo's most carefully-guarded
+// site as unguarded.
+//
+// A bare `|| VAR=…` alternative used to be here and was REMOVED. It is only a guard when the
+// right-hand side cannot fail, and the shape an author actually reaches for is a fallback
+// extraction — `intent=$(grep -m1 '^intent:' "$f" || intent=$(grep -m1 '^description:' "$f"))`
+// — where the assignment inherits the inner substitution's status and aborts anyway. That is
+// #647 reintroduced through the remediation, with the lint calling the site handled. Removing
+// it changes no verdict in this repo (measured: byte-identical output), because every real
+// assignment-shaped guard here is the `|| …_rc=$?` form the dedicated alternative already
+// matches.
+const GUARD = /\|\|\s*(true|:|echo\b|return\b|exit\b|continue\b|break\b|\w+\s*=\s*\$\?)/;
 const ANNOTATION = /#\s*abort-ok:/;
-// `$((` is arithmetic expansion, not command substitution, and it cannot abort anything.
-// The first version of this pattern matched it, so every `count=$((count + 1))` in the corpus
-// was reported with a "pipeline" consisting of the variable's own name — 10 findings that
-// looked exactly like the real ones and would have taught the next reader to skim the output.
-const ASSIGNMENT = /^\s*(?:export\s+)?[A-Za-z_][A-Za-z_0-9]*=\$\((?!\()/;
-const DECLARED = /^\s*(?:local|declare|typeset|readonly)\s/;
+
+/**
+ * One command-substitution assignment: `name=$(`, `name="$(`, optionally `export`-ed, and
+ * anywhere on the line rather than only at its start.
+ *
+ * Three spellings were invisible to the line-anchored version, and all three are live here:
+ *
+ *   x="$(…)"                 the quoted form. `ROOT="$(cd "$(dirname "$0")/.." && pwd)"` in
+ *                            two scripts, unscanned — and its UNQUOTED twin in a third file
+ *                            carries an `# abort-ok:` annotation, so the blind spot shaped
+ *                            this check's own remediation and not merely its reporting.
+ *   a=1; b=$(…)              the mid-line form. `a8_vr_push=$(wf_event_paths …) || rc=$?` sits
+ *                            after a `;`, and that function returns 1 and 2 by contract.
+ *   local x; x=$(…)          the split declaration. The docblock's claim that `local` cannot
+ *                            abort is true of `local x=$(…)` and FALSE of this, which is the
+ *                            recommended idiom precisely BECAUSE the status propagates.
+ *
+ * `$((` is arithmetic expansion and cannot abort anything; the negative lookahead keeps every
+ * `count=$((count + 1))` out of the findings, where they arrived with a "pipeline" consisting
+ * of the variable's own name.
+ */
+// Plain whitespace is a separator too, because `stamp=$(date +%F) missing=$(grep -L …)` is two
+// assignments and bash gives the statement the status of the LAST one. Without it the second
+// substitution was never examined and the line scored `safe` off the first — an affirmative
+// all-clear printed over a line containing `grep`, which is worse than silence.
+const ASSIGNMENT_GLOBAL = /(?:^|[;&|\s]|\bthen\b|\bdo\b|\bin\b)\s*(?:export\s+)?([A-Za-z_][A-Za-z_0-9]*)=("?)\$\((?!\()/g;
+
+/**
+ * A declaration keyword immediately preceding the assignment, i.e. `local x=$(…)`.
+ *
+ * ONLY that one-word form is exempt. There the substitution's status is discarded — the
+ * command's status becomes `local`'s, always 0 — so it cannot abort. The split form
+ * `local x; x=$(…)` is a separate statement whose status DOES propagate, and treating the two
+ * alike is what hid `sync-discovery-symlinks.sh:78`.
+ */
+const DECLARED_INLINE = /(?:^|[;&|]|\s)(?:local|declare|typeset|readonly)\s+(?:-\w+\s+)*$/;
 
 /**
  * Every tracked `*.sh`, from git rather than from a filesystem walk.
@@ -117,8 +177,13 @@ const DECLARED = /^\s*(?:local|declare|typeset|readonly)\s/;
  * both of which git sidesteps: `.claude/skills/<name>` and `.claude/agents` are symlinks that
  * `statSync` follows, so the discovery symlink farm gets re-walked once per entry; and
  * `viz/renv/library/` holds thousands of vendored files on an NTFS mount. Asking git returns
- * 27 paths and takes milliseconds — and, unlike a walk, cannot wander into an untracked
+ * 6 paths and takes milliseconds — and, unlike a walk, cannot wander into an untracked
  * agent worktree or a build directory and start reporting findings against a copy.
+ *
+ * Six is the whole scope of this gate, which matters because shipping it blocking rather than
+ * `--warn` rests on that corpus being clean. The summary line's "in 5 file(s)" is not a
+ * contradiction: all six carry `set -euo pipefail`, and the summary counts files that produced
+ * at least one substitution site — `viz/build.sh` has none.
  */
 function shellScripts() {
   return execFileSync('git', ['ls-files', '-z', '*.sh'], { cwd: ROOT, encoding: 'utf8' })
@@ -143,13 +208,17 @@ function shellScripts() {
  * line boundaries (the awk and sed programs here open a single quote on one line and close it
  * several lines later) and only counts parens outside them.
  */
-function substitutionSpan(lines, start) {
+function substitutionSpan(lines, start, startColumn = 0) {
   let depth = 0;
   let seen = false;
   let quote = null;
   for (let i = start; i < lines.length; i++) {
     const line = lines[i];
-    for (let c = 0; c < line.length; c++) {
+    // Begin at the `$(` itself, not at column 0. Scanning from the start of the line means the
+    // opening `"` of `label="$(` flips the quote state BEFORE the scanner reaches `$(`, so the
+    // span never closes: it overruns the statement and swallows the next site, whose verdict
+    // then comes back as the concatenation of both pipelines.
+    for (let c = i === start ? startColumn : 0; c < line.length; c++) {
       const ch = line[c];
       if (quote) {
         if (ch === '\\' && quote === '"') { c++; continue; }
@@ -163,14 +232,70 @@ function substitutionSpan(lines, start) {
       if (ch === '#' && (c === 0 || /\s/.test(line[c - 1]))) break;
       if (ch === '$' && line[c + 1] === '(') { depth++; seen = true; c++; }
       else if (ch === '(') depth++;
-      else if (ch === ')') depth--;
-    }
-    const continued = /\\$/.test(line);
-    if (seen && !quote && !continued && depth <= 0) {
-      return { text: lines.slice(start, i + 1).join('\n'), end: i };
+      else if (ch === ')') {
+        depth--;
+        // Close AT the balancing paren, not at end of line. Waiting for the line to end meant
+        // `label="$(printf … )${x:1}"` never closed: the substitution's own `)` brought depth
+        // to 0, then the assignment's closing `"` re-opened the quote state and the end test
+        // (which required `!quote`) failed — so the span ran on into the next statements and
+        // harvested `run` out of a later `npm run update-readmes` in an echo.
+        if (seen && depth <= 0) {
+          const body = i === start
+            ? [line.slice(startColumn, c + 1)]
+            : [lines[start].slice(startColumn), ...lines.slice(start + 1, i), line.slice(0, c + 1)];
+          return { text: body.join('\n'), end: i };
+        }
+      }
     }
   }
-  return { text: lines.slice(start).join('\n'), end: lines.length - 1 };
+  return { text: [lines[start].slice(startColumn), ...lines.slice(start + 1)].join('\n'), end: lines.length - 1 };
+}
+
+/**
+ * The CODE of a span: quoted runs blanked and any trailing comment removed.
+ *
+ * This is the single most important function here, and it exists because the first version
+ * tested `GUARD` against the raw span. Five shapes then manufactured a guard that was not
+ * there — a trailing comment saying `# nope, no || true here`, an awk program containing
+ * `if (n==0 || seen==1)`, a `sed 's/$/ || true/'`, a heredoc body mentioning the idiom, and a
+ * quoted inner substitution carrying its own guard.
+ *
+ * The self-defeating property is the reason it is HIGH rather than cosmetic: the comment a
+ * careful author writes to explain *why there is no guard* is what manufactures one. Measured
+ * on this check's own envelope — take the kill case that strips `|| true` from the A4 registry
+ * total, append one house-style trailing comment, and the gate prints `UNGUARDED: 0` and exits
+ * 0. The mutant the negative-evidence spec says must die survives.
+ *
+ * It was also live: `sync-discovery-symlinks.sh:133` scored `guarded` rather than `annotated`,
+ * because `|| continue` appears inside its own `# abort-ok:` prose — which is why the summary
+ * reported one fewer annotated site than `git grep abort-ok` finds on disk.
+ *
+ * `ANNOTATION` deliberately still reads the RAW line: an annotation IS a comment.
+ */
+function codeOf(span) {
+  // Quote state carries ACROSS lines, exactly as in `substitutionSpan`. Resetting it per line
+  // was wrong in the direction that matters: the closing line of a multi-line awk program is
+  // `  ' "$file") || return 1`, and a per-line scanner reads that leading `'` as an OPENING
+  // quote and swallows the `|| return 1` behind it. `wf_event_paths` — the most carefully
+  // guarded site in the repo — went from `guarded` to UNGUARDED on that alone.
+  let quote = null;
+  const out = [];
+  for (const line of span.split('\n')) {
+    let kept = '';
+    for (let c = 0; c < line.length; c++) {
+      const ch = line[c];
+      if (quote) {
+        if (ch === '\\' && quote === '"') { c++; continue; }
+        if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === "'" || ch === '"') { quote = ch; continue; }
+      if (ch === '#' && (c === 0 || /\s/.test(line[c - 1]))) break;
+      kept += ch;
+    }
+    out.push(kept);
+  }
+  return out.join('\n');
 }
 
 /**
@@ -183,10 +308,9 @@ function substitutionSpan(lines, start) {
  * the verdict becomes noise.
  */
 function pipelineCommands(text) {
-  const stripped = text
-    .replace(/'[^']*'/g, "''")
-    .replace(/"(?:[^"\\]|\\.)*"/g, '""');
-  const body = stripped.replace(/^\s*(?:export\s+)?[A-Za-z_][A-Za-z_0-9]*=\$\(/, '');
+  // `codeOf` already blanked quoted runs and comments; this strips the assignment head so the
+  // first segment is the first COMMAND rather than the variable name.
+  const body = text.replace(/^\s*(?:export\s+)?[A-Za-z_][A-Za-z_0-9]*=\$\(/, '');
   return body
     .split(/\|\||&&|[|;]/)
     .map((segment) => {
@@ -209,26 +333,56 @@ for (const file of shellScripts()) {
   if (!/^set\s+-[a-z]*e/m.test(text)) continue;
 
   const lines = text.split(/\r?\n/);
+  const rel = relative(ROOT, file);
   for (let i = 0; i < lines.length; i++) {
-    if (DECLARED.test(lines[i])) continue;
-    if (!ASSIGNMENT.test(lines[i])) continue;
+    // EVERY substitution on the line, not the first. The anchored single-match version reported
+    // `stamp=$(date +%F) missing=$(grep -L …)` as `safe`, because stripping only the first head
+    // left the second assignment inside the first segment — an affirmative all-clear printed
+    // over a line containing `grep`, which is worse than silence.
+    ASSIGNMENT_GLOBAL.lastIndex = 0;
+    let match;
+    let lastEnd = i;
+    while ((match = ASSIGNMENT_GLOBAL.exec(lines[i])) !== null) {
+      const matchEnd = match.index + match[0].length;
+      // Everything up to and including the assignment's `=`, used for two decisions: whether a
+      // declaration keyword sits immediately before it, and where the `$(` starts.
+      const beforeName = lines[i].slice(0, matchEnd - `${match[1]}=${match[2]}$(`.length);
+      if (DECLARED_INLINE.test(beforeName)) continue;
+      // A `#` earlier on the line means this assignment is inside a comment, not code.
+      if (codeOf(beforeName).length < beforeName.replace(/\s+$/, '').length
+          && /(?:^|\s)#/.test(beforeName)) continue;
 
-    const { text: span, end } = substitutionSpan(lines, i);
-    const commands = pipelineCommands(span);
-    const unsafe = commands.filter((command) => !SAFE_COMMANDS.has(command));
-    const guarded = GUARD.test(span);
-    const annotated = ANNOTATION.test(lines[i]) || ANNOTATION.test(lines[end]);
+      // Start at the `$(`, NOT at the `"` of the quoted form. Inside a substitution the quoting
+      // context restarts, so including the opening quote makes `codeOf` treat the whole
+      // pipeline as a quoted run and blank it — `ROOT="$(cd … && pwd)"` came back `safe` with
+      // an empty command list, which is the affirmative all-clear this check must never print.
+      const { text: rawSpan, end } = substitutionSpan(lines, i, matchEnd - 2);
+      const span = codeOf(rawSpan);
+      const commands = pipelineCommands(span);
+      const unsafe = commands.filter((command) => !SAFE_COMMANDS.has(command));
+      // TWO spans, because the two questions have different extents. The pipeline lives inside
+      // `$(…)`; the guard lives AFTER the closing paren — `x=$(f a b) || rc=$?`. Testing GUARD
+      // against the body alone reported the three `wf_event_paths` call sites as unguarded,
+      // and those are the sites whose function returns 1 and 2 by contract.
+      //
+      // The residue, stated rather than hidden: a `|| true` belonging to a LATER statement on
+      // the same line would read as this site's guard. No such line exists here, and the
+      // alternative — cutting the guard off entirely — is the failure that fires today.
+      const guardRaw = [lines[i].slice(matchEnd - 2), ...lines.slice(i + 1, end + 1)].join('\n');
+      const guarded = GUARD.test(codeOf(guardRaw));
+      const annotated = ANNOTATION.test(lines[i]) || ANNOTATION.test(lines[end]);
 
-    const rel = relative(ROOT, file);
-    const verdict = unsafe.length === 0 ? 'safe'
-      : guarded ? 'guarded'
-      : annotated ? 'annotated'
-      : 'UNGUARDED';
-    sites.push({ file: rel, line: i + 1, verdict, commands: unsafe });
-    if (verdict === 'UNGUARDED') {
-      findings.push({ file: rel, line: i + 1, commands: unsafe, source: lines[i].trim() });
+      const verdict = unsafe.length === 0 ? 'safe'
+        : guarded ? 'guarded'
+        : annotated ? 'annotated'
+        : 'UNGUARDED';
+      sites.push({ file: rel, line: i + 1, verdict, commands: unsafe });
+      if (verdict === 'UNGUARDED') {
+        findings.push({ file: rel, line: i + 1, commands: unsafe, source: lines[i].trim() });
+      }
+      if (end > lastEnd) lastEnd = end;
     }
-    i = end;
+    i = lastEnd;
   }
 }
 

--- a/scripts/check-bare-substitutions.js
+++ b/scripts/check-bare-substitutions.js
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * check-bare-substitutions.js — find command-substitution assignments that can abort a
+ * `set -e` shell script with no diagnostic (#647).
+ *
+ * The defect it exists to catch, in one line:
+ *
+ *   intent=$(grep -m1 '^intent:' "$f" | xargs)
+ *
+ * Under `set -euo pipefail` the assignment carries the pipeline's exit status. `grep` exits 1
+ * when it matches nothing, so a file without `intent:` stopped the entire script HERE — one
+ * line above the `-z` test written to report exactly that. Nothing printed. Every check below
+ * was skipped, and the run looked like an ordinary early exit. That shipped in
+ * `validate-integrity.sh` and made A6a's missing-field diagnostic unreachable code.
+ *
+ * `| wc -l` is not a rescue. `pipefail` returns the rightmost non-zero status, so
+ * `grep(1) | wc -l(0)` still exits 1.
+ *
+ *   node scripts/check-bare-substitutions.js            # exit 1 on any unguarded site
+ *   node scripts/check-bare-substitutions.js --warn     # report, always exit 0
+ *   node scripts/check-bare-substitutions.js --list     # print every site and its verdict
+ *
+ * ## Why the safe list is the enumerated one
+ *
+ * The tempting design is a list of dangerous commands — grep, rg, sed — and a guard required
+ * only for those. That is an allowlist wearing a deny-list's clothes: the first script to
+ * pipe through `jq`, `yq`, `git diff --quiet` or a local function is unguarded by default, and
+ * nobody notices, because the gate stays green. This repo has been bitten by that shape twice
+ * (see CLAUDE.md § *Which code fences are frozen* for the same argument about fence tags).
+ *
+ * So the enumeration runs the other way. SAFE_COMMANDS lists commands whose non-zero exit
+ * always means a genuine error rather than "found nothing" — a closed set, short, and every
+ * addition has to be argued. Anything else needs a guard or an annotation. A pipeline built
+ * from unknown commands fails closed.
+ *
+ * ## What counts as handled
+ *
+ * A site passes if EITHER:
+ *
+ *   - it carries a guard: `|| true`, `|| echo …`, `|| rc=$?`, `|| <name>_rc=$?`, `|| :`
+ *   - or it carries `# abort-ok: <reason>` on the assignment's first or last line
+ *
+ * The annotation is not a suppression comment. It is where you record that the pipeline
+ * cannot legitimately return empty — that a `find` over a directory guaranteed to exist, or
+ * an `awk` with no exit statement, will only fail if something is genuinely broken, in which
+ * case aborting is the correct behaviour.
+ *
+ * ## What this cannot check
+ *
+ * Whether a guard is *appropriate*. `|| true` belongs where the next lines explicitly handle
+ * the empty result; where nothing checks the zero case it is worse than the abort, because it
+ * converts a loud stop into a silent empty string and an empty haystack passes every
+ * "is X missing" test. That judgement is not decidable by pattern-matching, which is why the
+ * rule is also stated in prose at the top of `validate-integrity.sh`.
+ *
+ * It also deliberately ignores `local x=$(…)` / `declare x=$(…)`, which do NOT abort: the
+ * status becomes `local`'s, always 0. That is the inverse hazard — a silent empty value where
+ * the author expected an abort — and it needs a different check, not this one.
+ *
+ * And one known false negative, stated rather than left to be discovered:
+ *
+ *   x=$(grep foo bar || true | wc -l)
+ *
+ * The guard is INSIDE the pipeline, so it protects `grep` and not the pipeline's exit status.
+ * `pipefail` still returns the rightmost non-zero, and the assignment can still abort. The
+ * guard test here is span-wide, so this reads as guarded. Fixing it needs the guard's position
+ * relative to the last pipeline segment, which the span scanner does not track. No site in
+ * this repo has that shape; it is written down because the next one to appear will be invisible
+ * to this check, and a limit nobody recorded looks like a limit nobody has.
+ */
+
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join, relative, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = process.argv.includes('--root')
+  ? process.argv[process.argv.indexOf('--root') + 1]
+  : join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const WARN_ONLY = process.argv.includes('--warn');
+const LIST = process.argv.includes('--list');
+
+/**
+ * Commands whose non-zero exit always signals a real error, never "matched nothing".
+ *
+ * Deliberately short and deliberately closed. `grep`, `rg`, `find`, `git`, `awk`, `sed` and
+ * every custom shell function are absent on purpose — each of them has a legitimate
+ * non-zero return in ordinary use, or can be given one.
+ *
+ * `wc` is here and it is the subtle entry: `wc` itself cannot fail on empty input, which is
+ * exactly why `grep … | wc -l` reads as safe to a human and is not. The scan looks at every
+ * command in the pipeline, so the `grep` upstream is what decides the verdict.
+ */
+const SAFE_COMMANDS = new Set([
+  'printf', 'echo', 'basename', 'dirname', 'pwd', 'wc', 'tr', 'sort', 'uniq',
+  'cut', 'rev', 'date', 'mktemp', 'tee', 'nl', 'seq', 'true', 'false', 'yes',
+]);
+
+// `|| return N` and `|| exit N` are guards too: control leaves the assignment rather than
+// falling through, so `set -e` never sees an unhandled non-zero. `wf_event_paths` uses exactly
+// that shape, and leaving it out of this pattern reported the repo's most carefully-guarded
+// site as unguarded.
+const GUARD = /\|\|\s*(true|:|echo\b|return\b|exit\b|continue\b|break\b|[A-Za-z_][A-Za-z_0-9]*=|\w+\s*=\s*\$\?)/;
+const ANNOTATION = /#\s*abort-ok:/;
+// `$((` is arithmetic expansion, not command substitution, and it cannot abort anything.
+// The first version of this pattern matched it, so every `count=$((count + 1))` in the corpus
+// was reported with a "pipeline" consisting of the variable's own name — 10 findings that
+// looked exactly like the real ones and would have taught the next reader to skim the output.
+const ASSIGNMENT = /^\s*(?:export\s+)?[A-Za-z_][A-Za-z_0-9]*=\$\((?!\()/;
+const DECLARED = /^\s*(?:local|declare|typeset|readonly)\s/;
+
+/**
+ * Every tracked `*.sh`, from git rather than from a filesystem walk.
+ *
+ * The walk was written first and measured at over 60 seconds without finishing. Two reasons,
+ * both of which git sidesteps: `.claude/skills/<name>` and `.claude/agents` are symlinks that
+ * `statSync` follows, so the discovery symlink farm gets re-walked once per entry; and
+ * `viz/renv/library/` holds thousands of vendored files on an NTFS mount. Asking git returns
+ * 27 paths and takes milliseconds — and, unlike a walk, cannot wander into an untracked
+ * agent worktree or a build directory and start reporting findings against a copy.
+ */
+function shellScripts() {
+  return execFileSync('git', ['ls-files', '-z', '*.sh'], { cwd: ROOT, encoding: 'utf8' })
+    .split('\0')
+    .filter(Boolean)
+    .map((rel) => join(ROOT, rel));
+}
+
+/**
+ * Collect the full text of a command substitution that starts on `lines[start]`.
+ *
+ * Substitutions here span up to a dozen lines, so a line-at-a-time scan would read the guard
+ * off the wrong line — or miss a `grep` on a continuation entirely and call the site safe.
+ *
+ * The scanner is quote-aware, and that is not polish. The first version counted `$(` and `)`
+ * on the raw text, which meant an embedded awk program containing `sub(/x/, "", line)` drove
+ * the depth NEGATIVE on parens that were never openers. The span then ended mid-program, two
+ * lines above the site's real `|| true`, and the checker reported a correctly-guarded
+ * substitution as UNGUARDED. Measured: `validate-integrity.sh:98`, which is guarded and was
+ * flagged. A truncating span is the dangerous direction in general — it can also cut a
+ * pipeline before its `grep` and report a site as safe — so the scanner tracks quotes across
+ * line boundaries (the awk and sed programs here open a single quote on one line and close it
+ * several lines later) and only counts parens outside them.
+ */
+function substitutionSpan(lines, start) {
+  let depth = 0;
+  let seen = false;
+  let quote = null;
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i];
+    for (let c = 0; c < line.length; c++) {
+      const ch = line[c];
+      if (quote) {
+        if (ch === '\\' && quote === '"') { c++; continue; }
+        if (ch === quote) quote = null;
+        continue;
+      }
+      if (ch === "'" || ch === '"') { quote = ch; continue; }
+      // An unquoted `#` starts a comment only at a word boundary; inside a substitution the
+      // sites here never use one mid-line, and treating every `#` as a comment would swallow
+      // `${x#prefix}`.
+      if (ch === '#' && (c === 0 || /\s/.test(line[c - 1]))) break;
+      if (ch === '$' && line[c + 1] === '(') { depth++; seen = true; c++; }
+      else if (ch === '(') depth++;
+      else if (ch === ')') depth--;
+    }
+    const continued = /\\$/.test(line);
+    if (seen && !quote && !continued && depth <= 0) {
+      return { text: lines.slice(start, i + 1).join('\n'), end: i };
+    }
+  }
+  return { text: lines.slice(start).join('\n'), end: lines.length - 1 };
+}
+
+/**
+ * Every command word in a substitution's pipeline.
+ *
+ * Splits on `|`, `&&`, `||` and `;`, then takes the first bare word of each segment, skipping
+ * a leading `$(`, redirections and variable assignments. Quoted script bodies (the awk and
+ * sed programs) contain pipes of their own, so the split is done after stripping single- and
+ * double-quoted runs — otherwise an awk program mentioning `|` invents phantom commands and
+ * the verdict becomes noise.
+ */
+function pipelineCommands(text) {
+  const stripped = text
+    .replace(/'[^']*'/g, "''")
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""');
+  const body = stripped.replace(/^\s*(?:export\s+)?[A-Za-z_][A-Za-z_0-9]*=\$\(/, '');
+  return body
+    .split(/\|\||&&|[|;]/)
+    .map((segment) => {
+      const word = segment
+        .replace(/^[\s()]*/, '')
+        .replace(/^(?:[A-Za-z_][A-Za-z_0-9]*=\S*\s+)*/, '')
+        .split(/\s+/)[0] || '';
+      return word.replace(/^\$?\(/, '').replace(/[)"'`]/g, '');
+    })
+    .filter((word) => word && /^[A-Za-z_./][A-Za-z_0-9./-]*$/.test(word));
+}
+
+const findings = [];
+const sites = [];
+
+for (const file of shellScripts()) {
+  const text = readFileSync(file, 'utf8');
+  // Only scripts that actually abort. A script without `set -e` has this hazard in a much
+  // milder form (an empty value, not a vanished run), and flagging it would bury the real ones.
+  if (!/^set\s+-[a-z]*e/m.test(text)) continue;
+
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (DECLARED.test(lines[i])) continue;
+    if (!ASSIGNMENT.test(lines[i])) continue;
+
+    const { text: span, end } = substitutionSpan(lines, i);
+    const commands = pipelineCommands(span);
+    const unsafe = commands.filter((command) => !SAFE_COMMANDS.has(command));
+    const guarded = GUARD.test(span);
+    const annotated = ANNOTATION.test(lines[i]) || ANNOTATION.test(lines[end]);
+
+    const rel = relative(ROOT, file);
+    const verdict = unsafe.length === 0 ? 'safe'
+      : guarded ? 'guarded'
+      : annotated ? 'annotated'
+      : 'UNGUARDED';
+    sites.push({ file: rel, line: i + 1, verdict, commands: unsafe });
+    if (verdict === 'UNGUARDED') {
+      findings.push({ file: rel, line: i + 1, commands: unsafe, source: lines[i].trim() });
+    }
+    i = end;
+  }
+}
+
+if (LIST) {
+  for (const site of sites) {
+    console.log(`  ${site.verdict.padEnd(10)} ${site.file}:${site.line}  ${site.commands.join(' ') || '-'}`);
+  }
+  console.log('');
+}
+
+const counts = sites.reduce((acc, s) => ({ ...acc, [s.verdict]: (acc[s.verdict] || 0) + 1 }), {});
+console.log(`Command-substitution assignments scanned: ${sites.length} in ${new Set(sites.map((s) => s.file)).size} file(s)`);
+console.log(`  safe (every command in the pipeline is on the closed safe list): ${counts.safe || 0}`);
+console.log(`  guarded (|| true, || rc=$?, …):                                  ${counts.guarded || 0}`);
+console.log(`  annotated (# abort-ok:):                                         ${counts.annotated || 0}`);
+console.log(`  UNGUARDED:                                                       ${counts.UNGUARDED || 0}`);
+
+if (findings.length > 0) {
+  console.log('');
+  for (const finding of findings) {
+    console.log(`${WARN_ONLY ? 'WARN' : 'FAIL'}: ${finding.file}:${finding.line} can abort the script`);
+    console.log(`  pipeline includes: ${finding.commands.join(', ')}`);
+    console.log(`  ${finding.source}`);
+  }
+  console.log('');
+  console.log('Each site needs one of: a guard whose empty result the next lines explicitly');
+  console.log('check, or `# abort-ok: <why this pipeline cannot legitimately return empty>`.');
+  console.log('A blanket `|| true` sweep is not a fix — see the rule at the top of');
+  console.log('scripts/validate-integrity.sh.');
+}
+
+process.exitCode = findings.length > 0 && !WARN_ONLY ? 1 : 0;

--- a/scripts/envelopes/a6a-abort-capable-substitutions.mjs
+++ b/scripts/envelopes/a6a-abort-capable-substitutions.mjs
@@ -32,6 +32,19 @@ export const cases = [
     file: 'agents/code-reviewer.md',
     find: 'intent: implementing\n',
     replace: '',
+    // AN INVARIANT THIS EXPECT DEPENDS ON, and it is asserted nowhere else: A1's template is
+    // `FAIL: $f missing required field: $field` over `for field in name description tools
+    // priority`, and A6a's is `FAIL: $f missing required field: intent`. They render
+    // byte-identically the moment `intent` is added to A1's list — a natural hardening edit,
+    // since A6a's own comment calls A1 the first reader. Do that AND restore the #647 defect
+    // and this case reports [KILLED] over a run where A6a never executed: A1 prints the
+    // expected line, the script then dies on the unguarded extraction, and A6-B13 never run.
+    //
+    // No substring can discriminate two identical lines, so the invariant is the control. It is
+    // restated beside A1's field list. The residual window is narrow — the blocking
+    // check-bare-substitutions.js runs BEFORE validate-integrity.sh in the workflow and would
+    // refuse the unguarded form — but the window exists if someone silences that site with an
+    // annotation rather than a guard.
     expect: 'missing required field: intent',
   },
   {

--- a/scripts/envelopes/a6a-abort-capable-substitutions.mjs
+++ b/scripts/envelopes/a6a-abort-capable-substitutions.mjs
@@ -1,0 +1,70 @@
+/**
+ * Envelope for #647 — the abort-capable command substitution, from both sides.
+ *
+ * `validate-integrity.sh` runs under `set -euo pipefail`, where a bare `x=$(grep … | …)`
+ * carries the pipeline's exit status. `grep` exits 1 on no match, so an agent file missing
+ * `intent:` killed the whole script one line ABOVE the `-z` guard written to report it. The
+ * FAIL never printed, checks A6 through B13 never ran, and the log looked like a short run.
+ *
+ * That is a hard thing to prove by inspection and an easy thing to prove by mutation, which
+ * is what these cases do:
+ *
+ *   node scripts/gate-envelope.js --spec scripts/envelopes/a6a-abort-capable-substitutions.mjs
+ *
+ * Note what a case here measures that a corpus mutation cannot. The two must-go-reds #644
+ * asked for both PASSED against a broken A11, because both mutated the corpus while the
+ * defect was in the check. Cases 1 and 2 below mutate the corpus (they remove a field), but
+ * their `expect` names the DIAGNOSTIC rather than merely requiring a red run — so a version
+ * of the script that aborts silently is a [WRONG-RED] rather than a kill. That distinction is
+ * the whole reason `expect` is a substring and not an exit code.
+ *
+ * Case 3 mutates the CHECK, which is the direction that catches a dead detector.
+ */
+
+export const gate = { command: ['bash', 'scripts/validate-integrity.sh'] };
+
+export const cases = [
+  {
+    // THE #647 REGRESSION. Before the fix this produced no output at all: the script died on
+    // the extraction line and the FAIL below it was unreachable code. The expect names that
+    // FAIL, so a silent abort cannot be mistaken for a catch.
+    label: 'an agent file loses its intent: field',
+    file: 'agents/code-reviewer.md',
+    find: 'intent: implementing\n',
+    replace: '',
+    expect: 'missing required field: intent',
+  },
+  {
+    // The sibling extraction on the next line. A1 also reports a missing `tools:`, so the
+    // expect is deliberately A6a's own wording rather than the shared "missing required
+    // field" prefix — otherwise this case would be killed by A1 and would say nothing about
+    // whether A6a survived the mutation at all.
+    label: 'an agent file loses its tools: field',
+    file: 'agents/code-reviewer.md',
+    find: 'tools: [Read, Edit, Grep, Glob, Bash, WebFetch]\n',
+    replace: '',
+    expect: 'A6a cannot judge intent without it',
+  },
+  {
+    // Mutating the CHECK, not the corpus. Removing the guard restores the exact defect #647
+    // reported, and the case passes only if the run stops producing A6a's diagnostic — which
+    // is what "the abort is back" looks like from outside.
+    //
+    // The expect is the message of the check that runs AFTER the abort point. Naming A6a's
+    // own FAIL would be wrong here: the mutant's whole symptom is that A6a says nothing.
+    label: 'the guard is removed from the intent extraction (the #647 defect, restored)',
+    file: 'scripts/validate-integrity.sh',
+    find: "intent=$(grep -m1 '^intent:' \"$f\" | sed 's/^intent: *//' | tr -d '\\r' | xargs || true)",
+    replace: "intent=$(grep -m1 '^intent:' \"$f\" | sed 's/^intent: *//' | tr -d '\\r' | xargs)",
+    // Documented as expect:null and NOT as a kill, because it is honestly not one. Every
+    // agent on disk carries `intent:`, so with the corpus intact the unguarded form never
+    // fires and the gate stays green. The abort needs BOTH the missing field and the missing
+    // guard, and this harness applies one mutation per case by design.
+    //
+    // Recording it rather than dropping it: the pair is exactly what
+    // `scripts/check-bare-substitutions.js` exists to catch statically, since no single
+    // mutation of this file can demonstrate it.
+    expect: null,
+    why: 'The unguarded form is only fatal when a corpus file also lacks the field; one mutation cannot produce both, which is why the static check exists.',
+  },
+];

--- a/scripts/envelopes/bare-substitution-lint.mjs
+++ b/scripts/envelopes/bare-substitution-lint.mjs
@@ -1,0 +1,65 @@
+/**
+ * Envelope for `scripts/check-bare-substitutions.js` itself (#647).
+ *
+ * The gate above it (`a6a-abort-capable-substitutions.mjs`) measures what
+ * `validate-integrity.sh` reports. This one measures whether the lint that guards it can go
+ * red at all, and for the right reason:
+ *
+ *   node scripts/gate-envelope.js --spec scripts/envelopes/bare-substitution-lint.mjs
+ *
+ * Worth stating why this file exists separately rather than as three more cases over there.
+ * The a6a envelope's third case is `expect: null` — an unguarded extraction is only fatal when
+ * a corpus file ALSO lacks the field, and one mutation cannot produce both. So the dynamic
+ * gate structurally cannot demonstrate the defect, and a static check is the only thing that
+ * can. A static check nobody has broken on purpose is a claim, not a control.
+ */
+
+export const gate = { command: ['node', 'scripts/check-bare-substitutions.js'] };
+
+export const cases = [
+  {
+    // The regression the lint exists to stop: someone "tidies away" a guard.
+    label: 'a guard is removed from a registry-total extraction',
+    file: 'scripts/validate-integrity.sh',
+    find: "reg_count=$(grep 'total_agents:' agents/_registry.yml | tr -d '\\r' | awk '{print $2}' || true)",
+    replace: "reg_count=$(grep 'total_agents:' agents/_registry.yml | tr -d '\\r' | awk '{print $2}')",
+    expect: 'can abort the script',
+  },
+  {
+    // The other way to defeat it: keep the code, drop the annotation that justified it. An
+    // `# abort-ok:` is a claim about the pipeline, so deleting it must reopen the finding
+    // rather than leave a site silently exempt.
+    label: 'an abort-ok annotation is deleted',
+    file: 'scripts/translate-content.sh',
+    find: ' # abort-ok: awk exits 0 when no line matches; the -z check on the next line is the reader',
+    replace: '',
+    expect: 'can abort the script',
+  },
+  {
+    // DEFAULT-DENY, measured. The tempting design is a list of dangerous commands; this one
+    // enumerates the SAFE commands instead, so a pipeline built from something nobody
+    // anticipated is flagged rather than waved through. `jq` is on no list in this repo.
+    label: 'a substitution piping through an unknown tool is not silently exempt',
+    file: 'scripts/bulk-scaffold-caveman.sh',
+    find: "TODAY=$(date +%Y-%m-%d)",
+    replace: "TODAY=$(date +%Y-%m-%d | jq -R .)",
+    expect: 'can abort the script',
+    // `date` alone is on the safe list, so the unmutated line is reported `safe`. Adding one
+    // unknown command to the pipeline is what has to flip it — which is the property that
+    // separates an enumerated-safe list from an enumerated-dangerous one.
+  },
+  {
+    // A MEASURED NON-GUARANTEE. `local x=$(…)` does not abort — the status becomes `local`'s,
+    // which is always 0 — so it is deliberately out of scope, and the scanner skips it. That
+    // makes it the obvious hole to walk through, and the obvious "bug report" to file against
+    // this lint. It is neither: the inverse hazard (a silently empty value where the author
+    // expected an abort) is real but is a different check, and folding it in here would make
+    // every finding mean two incompatible things.
+    label: 'a `local` assignment is NOT reported (documented scope limit)',
+    file: 'scripts/validate-integrity.sh',
+    find: '  local file="$1" ev="$2" block entries',
+    replace: '  local file="$1" ev="$2" block entries\n  local probe=$(grep -c nonexistent-pattern "$1")',
+    expect: null,
+    why: '`local x=$(…)` cannot abort under set -e — the status is `local`\'s, always 0 — so it is out of this check\'s scope by construction, not by oversight.',
+  },
+];

--- a/scripts/envelopes/bare-substitution-lint.mjs
+++ b/scripts/envelopes/bare-substitution-lint.mjs
@@ -23,7 +23,13 @@ export const cases = [
     file: 'scripts/validate-integrity.sh',
     find: "reg_count=$(grep 'total_agents:' agents/_registry.yml | tr -d '\\r' | awk '{print $2}' || true)",
     replace: "reg_count=$(grep 'total_agents:' agents/_registry.yml | tr -d '\\r' | awk '{print $2}')",
-    expect: 'can abort the script',
+    // The expect names the SITE, not just the message. The checker has one FAIL template
+    // (`FAIL: <file>:<line> can abort the script`), so a bare tail substring is tautologically
+    // true of any FAIL it can emit -- the `file:line` half went unasserted and gate-envelope's
+    // [WRONG-RED] branch was dead for all three killing cases. Demonstrated, not theorised:
+    // case 3 kills at bulk-scaffold-caveman.sh:14, and deleting the annotation on the line
+    // directly ABOVE it also killed, same expect, adjacent site.
+    expect: 'scripts/validate-integrity.sh:201 can abort the script',
   },
   {
     // The other way to defeat it: keep the code, drop the annotation that justified it. An
@@ -33,7 +39,7 @@ export const cases = [
     file: 'scripts/translate-content.sh',
     find: ' # abort-ok: awk exits 0 when no line matches; the -z check on the next line is the reader',
     replace: '',
-    expect: 'can abort the script',
+    expect: 'scripts/translate-content.sh:96 can abort the script',
   },
   {
     // DEFAULT-DENY, measured. The tempting design is a list of dangerous commands; this one
@@ -43,7 +49,7 @@ export const cases = [
     file: 'scripts/bulk-scaffold-caveman.sh',
     find: "TODAY=$(date +%Y-%m-%d)",
     replace: "TODAY=$(date +%Y-%m-%d | jq -R .)",
-    expect: 'can abort the script',
+    expect: 'scripts/bulk-scaffold-caveman.sh:14 can abort the script',
     // `date` alone is on the safe list, so the unmutated line is reported `safe`. Adding one
     // unknown command to the pipeline is what has to flip it — which is the property that
     // separates an enumerated-safe list from an enumerated-dangerous one.

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -17,7 +17,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { CONTENT_TYPES } from './lib/content-types.js';
-import { guideCategoryOrder, guideCategoryLabel } from './lib/guide-categories.js';
+import { guideCategoryOrder, guideCategoryLabel, guideCategoryNames } from './lib/guide-categories.js';
 import { applySections, renderTranslationsTable, renderLocaleTable } from './lib/readme-sections.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -129,7 +129,11 @@ function generateStats() {
     `- **${totalSkills} skills** across ${totalDomains} domains — structured, executable procedures`,
     `- **${totalAgents} agents** — specialized Claude Code personas covering development, review, compliance, and more`,
     `- **${totalTeams} teams** — predefined multi-agent compositions for complex workflows`,
-    `- **${totalGuides} guides** — human-readable workflow, infrastructure, and reference documentation`,
+    // Derived, not enumerated (#647). This line read "workflow, infrastructure, and reference"
+    // — three of the five categories on disk, written when there were three. It is the same
+    // drift class as #644's hardcoded category order, and it is why every count on this page
+    // comes from a registry: a literal list is correct exactly once.
+    `- **${totalGuides} guides** — human-readable documentation across ${guideCategoryNames(guideCategories, guides)}`,
     `- **Interactive visualization** — force-graph explorer with ${totalSkills} R-generated skill icons and 9 color themes`,
   ];
   return lines.join('\n');

--- a/scripts/lib/guide-categories.js
+++ b/scripts/lib/guide-categories.js
@@ -67,6 +67,26 @@ export function guideCategoryOrder(categoriesBlock, guides) {
  * @param {string} catId
  * @returns {string}
  */
+/**
+ * Render the category names as an English list: "a, b, c, d and e".
+ *
+ * Exists so prose can name the categories without hardcoding them. The line it replaces said
+ * "workflow, infrastructure, and reference" — true when there were three of them, and quietly
+ * false from the day `design` was added (#647).
+ *
+ * Order and membership come from `guideCategoryOrder`, so an undeclared category appearing
+ * only on a guide is named here too rather than silently dropped.
+ */
+export function guideCategoryNames(categoriesBlock, guides) {
+  const order = guideCategoryOrder(categoriesBlock, guides);
+  if (order.length === 0) return 'no categories';
+  if (order.length === 1) return `the ${order[0]} category`;
+  if (order.length === 2) return `${order[0]} and ${order[1]}`;
+  // Oxford comma, matching the line this replaced ("workflow, infrastructure, and reference")
+  // and the rest of the generated prose. Dropped at two items, where it would be wrong.
+  return `${order.slice(0, -1).join(', ')}, and ${order[order.length - 1]}`;
+}
+
 export function guideCategoryLabel(catId) {
   return catId[0].toUpperCase() + catId.slice(1);
 }

--- a/scripts/sync-discovery-symlinks.sh
+++ b/scripts/sync-discovery-symlinks.sh
@@ -75,7 +75,7 @@ missing=0 wrong=0 broken=0 stale=0 fixed=0
 ensure_link() {
   local link="$1" target="$2" label="$3"
   if [ -L "$link" ]; then
-    local cur; cur=$(readlink "$link")
+    local cur; cur=$(readlink "$link") # abort-ok: guarded by the `[ -L "$link" ]` test one line up
     if [ "$cur" = "$target" ]; then
       if [ ! -e "$link" ]; then
         # Correct target but dangling — the skills/<id>/ dir is missing (a

--- a/scripts/sync-discovery-symlinks.sh
+++ b/scripts/sync-discovery-symlinks.sh
@@ -43,7 +43,7 @@ done
 # exact string, so a checkout reached via a different path than a link was baked
 # with will read as external and be left alone — fail-safe (never wrong-deletes),
 # but such links won't be cleaned until re-linked from the current path.
-ALMANAC_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+ALMANAC_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd) # abort-ok: cd into this script's own parent; failure means the script was deleted mid-run
 cd "$ALMANAC_ROOT"
 
 REG="skills/_registry.yml"
@@ -60,7 +60,7 @@ if [ "${#SKILL_IDS[@]}" -eq 0 ]; then
   echo "FATAL: 0 skills parsed from $REG — registry format changed? Refusing to run." >&2
   exit 2
 fi
-disk_skill_dirs=$(find skills -mindepth 1 -maxdepth 1 -type d ! -name '_template' | wc -l | tr -d ' ')
+disk_skill_dirs=$(find skills -mindepth 1 -maxdepth 1 -type d ! -name '_template' | wc -l | tr -d ' ') # abort-ok: find over skills/, whose absence is a broken checkout and is caught above
 stale_cleanup_safe=1
 if [ "${#SKILL_IDS[@]}" -lt "$disk_skill_dirs" ]; then
   stale_cleanup_safe=0
@@ -130,7 +130,7 @@ if [ -d "$HOME/.claude" ]; then
       while IFS= read -r name; do
         local_link="$HOME/.claude/skills/$name"
         [ -L "$local_link" ] || continue
-        tgt=$(readlink "$local_link")
+        tgt=$(readlink "$local_link") # abort-ok: guarded by the `[ -L "$local_link" ] || continue` two lines up
         case "$tgt" in
           "$ALMANAC_ROOT"/skills/*)
             if [ -z "${REGISTERED[$name]:-}" ]; then

--- a/scripts/test/bare-substitutions.test.js
+++ b/scripts/test/bare-substitutions.test.js
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for `scripts/check-bare-substitutions.js` (#647).
+ *
+ * The envelope (`scripts/envelopes/bare-substitution-lint.mjs`) proves the check goes red
+ * against the real corpus. These cover the parsing decisions that envelope cannot reach,
+ * because each of them was a bug that made the check report the WRONG verdict rather than no
+ * verdict — and a wrong verdict on a lint is worse than none, since it is read as an all-clear.
+ *
+ * Each test names the specific misreading it exists to catch. Four of them are regressions found
+ * by running the check against this repo and disbelieving its first output — the arithmetic
+ * expansion, the multi-line span, `|| return`, and the helper's own assertion style.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const CHECK = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'check-bare-substitutions.js');
+
+/**
+ * Run the check over a throwaway git repo containing one script.
+ *
+ * A real repo, not a bare directory, because the check asks `git ls-files` rather than walking
+ * the filesystem — a walk over this repo followed the `.claude/skills` symlink farm and did not
+ * finish in 60 seconds.
+ */
+function checkScript(body, name = 'probe.sh') {
+  const dir = mkdtempSync(join(tmpdir(), 'bare-subs-'));
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: dir });
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    writeFileSync(join(dir, 'scripts', name), body);
+    execFileSync('git', ['add', '-A'], { cwd: dir });
+    const output = execFileSync('node', [CHECK, '--root', dir, '--warn', '--list'], {
+      cwd: dir, encoding: 'utf8',
+    });
+    // Counts, not a substring search on the whole output. The first version of this helper
+    // returned the raw text and every test asserted `doesNotMatch(/UNGUARDED/)` — which fails
+    // against a clean run, because the SUMMARY line reads `UNGUARDED: 0`. Eight tests went red
+    // on a check that was working. Asserting on the label instead of the finding is the same
+    // instrument error the repo records elsewhere; the fix is to read the number.
+    const count = (label) => Number((output.match(new RegExp(`${label}:\\s+(\\d+)`)) || [])[1] ?? -1);
+    return {
+      output,
+      scanned: Number((output.match(/scanned: (\d+)/) || [])[1] ?? -1),
+      unguarded: count('UNGUARDED'),
+      safe: count('closed safe list\\)'),
+      annotated: count('# abort-ok:\\)'),
+    };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+const HEAD = '#!/usr/bin/env bash\nset -euo pipefail\n';
+
+test('a bare grep assignment is reported', () => {
+  const out = checkScript(`${HEAD}x=$(grep foo bar.txt)\n`);
+  assert.equal(out.scanned, 1);
+  assert.equal(out.unguarded, 1);
+  assert.match(out.output, /can abort the script/);
+});
+
+test('a guarded one is not', () => {
+  const out = checkScript(`${HEAD}x=$(grep foo bar.txt || true)\n`);
+  assert.equal(out.unguarded, 0);
+});
+
+test('`|| return` counts as a guard', () => {
+  // Not cosmetic: `wf_event_paths` in validate-integrity.sh is guarded exactly this way, and
+  // the first version of the GUARD pattern reported the repo's most carefully-handled site as
+  // unguarded. A checker whose first output is wrong about its own repo gets ignored.
+  const out = checkScript(`${HEAD}f() {\n  local a\n  a=$(grep x y || return 1)\n  echo "$a"\n}\n`);
+  assert.equal(out.unguarded, 0);
+});
+
+test('arithmetic expansion is not a command substitution', () => {
+  // `$((` is not `$(`. The first pattern matched it, so every `count=$((count + 1))` in the
+  // corpus was reported with a "pipeline" consisting of the variable's own name — 10 findings
+  // indistinguishable at a glance from the real ones.
+  const out = checkScript(`${HEAD}n=0\nn=$((n + 1))\n`);
+  assert.equal(out.unguarded, 0);
+});
+
+test('a guard on the last line of a multi-line substitution is found', () => {
+  // The span scanner counted parens on raw text, so an embedded awk program containing
+  // `sub(/x/, "", line)` drove the depth negative on parens that were never openers. The span
+  // ended mid-program, above the real `|| true`, and a guarded site was reported UNGUARDED.
+  const body = `${HEAD}x=$(printf '%s\\n' "$y" \\
+  | awk '
+      /^a/ { sub(/^a/, "", $0); print }
+    ' \\
+  | sed 's/b/c/' || true)
+`;
+  const out = checkScript(body);
+  assert.equal(out.unguarded, 0);
+});
+
+test('a pipeline of only safe commands needs no guard', () => {
+  const out = checkScript(`${HEAD}x=$(printf 'a\\nb\\n' | sort | uniq | wc -l)\n`);
+  assert.equal(out.safe, 1);
+  assert.equal(out.unguarded, 0);
+});
+
+test('an unknown command is treated as unsafe — the safe list is the enumerated one', () => {
+  // Default-deny. A dangerous-command list would wave `jq` through on the day someone first
+  // uses it; enumerating the safe side means the unknown case fails closed.
+  const out = checkScript(`${HEAD}x=$(printf 'a' | jq -R .)\n`);
+  assert.equal(out.unguarded, 1);
+});
+
+test('`# abort-ok:` exempts a site and its text is not otherwise interpreted', () => {
+  const out = checkScript(`${HEAD}x=$(grep foo bar.txt) # abort-ok: bar.txt is generated one line above\n`);
+  assert.equal(out.annotated, 1);
+  assert.equal(out.unguarded, 0);
+});
+
+test('a script without set -e is out of scope', () => {
+  // The hazard there is a silently empty value, not a vanished run. Reporting it would bury
+  // the findings that actually kill a gate.
+  const out = checkScript('#!/usr/bin/env bash\nx=$(grep foo bar.txt)\n');
+  assert.equal(out.unguarded, 0);
+});
+
+test('`local x=$(…)` is skipped, and that is the documented limit', () => {
+  // It genuinely cannot abort — the status becomes `local`'s, always 0. Pinned as a test so
+  // the exemption reads as a decision rather than as a gap someone should quietly close.
+  const out = checkScript(`${HEAD}f() {\n  local x=$(grep foo bar.txt)\n  echo "$x"\n}\n`);
+  assert.equal(out.unguarded, 0);
+});

--- a/scripts/test/bare-substitutions.test.js
+++ b/scripts/test/bare-substitutions.test.js
@@ -132,3 +132,96 @@ test('`local x=$(…)` is skipped, and that is the documented limit', () => {
   const out = checkScript(`${HEAD}f() {\n  local x=$(grep foo bar.txt)\n  echo "$x"\n}\n`);
   assert.equal(out.unguarded, 0);
 });
+
+// ── the shapes the first version could not see (#647 review) ────────────────
+//
+// Every one of these was found by an adversarial review, and they share a cause worth naming:
+// each fixture above uses the unquoted, line-start spelling, so the must-go-red exercise only
+// ever presented the checker with shapes it already handled. The gate's own negative evidence
+// was written against its own blind spot.
+
+test('a trailing comment mentioning `|| true` does NOT manufacture a guard', () => {
+  // THE DECISIVE ONE. The comment a careful author writes to explain why there is no guard was
+  // what created one — and appending exactly this house-style comment to the envelope's own
+  // kill case made the gate print `UNGUARDED: 0` and exit 0.
+  const out = checkScript(`${HEAD}x=$(grep foo bar.txt) # deliberately no \`|| true\`: the -z test below is the reader\n`);
+  assert.equal(out.unguarded, 1);
+});
+
+test('`|| true` inside a quoted program body does NOT guard', () => {
+  const awk = checkScript(`${HEAD}x=$(grep nomatch /dev/null | awk '{ if (n==0 || seen==1) print }')\n`);
+  assert.equal(awk.unguarded, 1);
+  const sed = checkScript(`${HEAD}x=$(grep nomatch /dev/null | sed 's/$/ || true/')\n`);
+  assert.equal(sed.unguarded, 1);
+});
+
+test('the quoted form `x="$(…)"` is scanned', () => {
+  // Three live sites were invisible, including two `ROOT="$(cd … && pwd)"` whose UNQUOTED twin
+  // in a third file already carried an annotation — so the blind spot shaped the remediation,
+  // not merely the reporting.
+  const out = checkScript(`${HEAD}x="$(grep foo bar.txt)"\n`);
+  assert.equal(out.scanned, 1);
+  assert.equal(out.unguarded, 1);
+});
+
+test('the quoted form is not swallowed as a quoted run', () => {
+  // Starting the span at the `"` rather than the `$(` made `codeOf` blank the whole pipeline,
+  // and an empty command list scores `safe` — an affirmative all-clear over a line with grep.
+  const out = checkScript(`${HEAD}ROOT="$(cd "$(dirname "$0")/.." && pwd)"\n`);
+  assert.equal(out.safe, 0);
+  assert.equal(out.unguarded, 1);
+});
+
+test('a mid-line assignment after `;` is scanned', () => {
+  // `rc=0; x=$(f) || rc=$?` — the shape three live sites use, and the `^` anchor meant deleting
+  // the guard did not even move the scanned count.
+  const bare = checkScript(`${HEAD}rc=0; x=$(grep foo bar.txt)\n`);
+  assert.equal(bare.unguarded, 1);
+  const guarded = checkScript(`${HEAD}rc=0; x=$(grep foo bar.txt) || rc=$?\n`);
+  assert.equal(guarded.unguarded, 0);
+});
+
+test('the split declaration `local x; x=$(…)` is scanned', () => {
+  // It DOES abort — unlike `local x=$(…)`, whose status is `local`'s. The split spelling is the
+  // recommended idiom precisely because the status propagates.
+  const out = checkScript(`${HEAD}f() {\n  local cur; cur=$(readlink "$1")\n  echo "$cur"\n}\n`);
+  assert.equal(out.unguarded, 1);
+});
+
+test('a second assignment on the same line gets its own verdict', () => {
+  // `stamp=$(date +%F) missing=$(grep -L …)` scored `safe` with an empty command list, because
+  // only the first head was stripped and `i = end` then skipped the rest of the line.
+  const out = checkScript(`${HEAD}stamp=$(date +%F) missing=$(grep -L '^x' /dev/null)\n`);
+  assert.equal(out.scanned, 2);
+  assert.equal(out.unguarded, 1);
+});
+
+test('`|| VAR=$(…)` is not accepted as a guard', () => {
+  // A fallback extraction inherits the inner substitution's status, so it aborts anyway. This is
+  // the shape an author reaches for when "fixing" a flagged site with a fallback rather than a
+  // guard — #647 reintroduced through the remediation, with the lint calling it handled.
+  const out = checkScript(`${HEAD}a=$(grep -m1 '^x:' f || a=$(grep -m1 '^y:' f))\n`);
+  // Two sites, not one: the inner assignment is a substitution in its own right and is also
+  // unguarded. What matters is that neither is waved through as `guarded`.
+  assert.equal(out.scanned, 2);
+  assert.equal(out.unguarded, 2);
+});
+
+test('a real corpus-style `# abort-ok:` containing `||` still reads as annotated', () => {
+  // The annotation test reads the RAW line on purpose — an annotation IS a comment — while the
+  // guard test reads code only. A live annotation whose prose contained `|| continue` was
+  // scoring `guarded` instead of `annotated`, which is why the summary reported one fewer
+  // annotated site than `git grep abort-ok` found on disk.
+  const out = checkScript(`${HEAD}x=$(readlink "$1") # abort-ok: guarded by the \`[ -L "$1" ] || continue\` test one line up\n`);
+  assert.equal(out.annotated, 1);
+  assert.equal(out.unguarded, 0);
+});
+
+test('a multi-line span closes at its own paren, not at end of line', () => {
+  // `label="$(printf … )${x:1}"` never closed: the substitution's `)` brought depth to 0, then
+  // the assignment's closing `"` reopened the quote state and the end test failed — so the span
+  // ran into later statements and harvested a command out of an unrelated echo.
+  const out = checkScript(`${HEAD}label="$(printf '%s' "\${v:0:1}" | tr '[:lower:]' '[:upper:]')\${v:1}"\necho "run npm run something"\n`);
+  assert.equal(out.safe, 1);
+  assert.equal(out.unguarded, 0);
+});

--- a/scripts/test/guide-categories.test.js
+++ b/scripts/test/guide-categories.test.js
@@ -18,7 +18,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { guideCategoryOrder, guideCategoryLabel } from '../lib/guide-categories.js';
+import { guideCategoryOrder, guideCategoryLabel, guideCategoryNames } from '../lib/guide-categories.js';
 
 const block = (...ids) => Object.fromEntries(ids.map((id) => [id, { description: id }]));
 const guidesIn = (...categories) => categories.map((category, i) => ({ id: `g${i}`, category }));
@@ -101,4 +101,33 @@ test('label capitalises the first letter and leaves the rest alone', () => {
 test('label does not title-case a hyphenated id — documented, not accidental', () => {
   // No category on disk has a hyphen; if one is added, this is the decision to revisit.
   assert.equal(guideCategoryLabel('edge-computing'), 'Edge-computing');
+});
+
+// ── guideCategoryNames (#647) ───────────────────────────────────────────────
+
+test('names render as an English list in registry order', () => {
+  // The literal it replaces said "workflow, infrastructure, and reference" — correct when
+  // there were three categories and quietly wrong from the day a fourth landed.
+  assert.equal(
+    guideCategoryNames({ workflow: 1, infrastructure: 1, reference: 1, design: 1, investigation: 1 }, []),
+    'workflow, infrastructure, reference, design, and investigation'
+  );
+});
+
+test('an undeclared category reaches the prose too', () => {
+  // Same rule as the ordering: a category that exists only on a guide is named rather than
+  // silently dropped, so the sentence cannot understate the corpus.
+  assert.equal(
+    guideCategoryNames({ workflow: 1 }, guidesIn('workflow', 'investigation')),
+    'workflow and investigation'
+  );
+});
+
+test('one and zero categories do not render a dangling conjunction', () => {
+  assert.equal(guideCategoryNames({ workflow: 1 }, []), 'the workflow category');
+  assert.equal(guideCategoryNames({}, []), 'no categories');
+});
+
+test('two categories join with "and" and no comma', () => {
+  assert.equal(guideCategoryNames({ workflow: 1, design: 1 }, []), 'workflow and design');
 });

--- a/scripts/translate-content.sh
+++ b/scripts/translate-content.sh
@@ -27,7 +27,7 @@ CONTENT_TYPE="$1"
 ID="$2"
 LOCALE="$3"
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)" # abort-ok: cd into this script's own parent; failure means the script was deleted mid-run
 TODAY=$(date +%Y-%m-%d)
 SOURCE_COMMIT=$(git -C "$ROOT" log -1 --format=%h) # abort-ok: `git log -1` fails only in a repo with no commits, which is a broken invocation
 

--- a/scripts/translate-content.sh
+++ b/scripts/translate-content.sh
@@ -29,7 +29,7 @@ LOCALE="$3"
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TODAY=$(date +%Y-%m-%d)
-SOURCE_COMMIT=$(git -C "$ROOT" log -1 --format=%h)
+SOURCE_COMMIT=$(git -C "$ROOT" log -1 --format=%h) # abort-ok: `git log -1` fails only in a repo with no commits, which is a broken invocation
 
 # Resolve source and target paths
 case "$CONTENT_TYPE" in
@@ -93,7 +93,7 @@ cp "$SOURCE_FILE" "$TARGET_FILE"
 # as a backlog signal.
 
 # Find the line number of the second --- (closing frontmatter)
-CLOSE_LINE=$(awk '/^---$/{count++; if(count==2){print NR; exit}}' "$TARGET_FILE")
+CLOSE_LINE=$(awk '/^---$/{count++; if(count==2){print NR; exit}}' "$TARGET_FILE") # abort-ok: awk exits 0 when no line matches; the -z check on the next line is the reader
 if [ -z "$CLOSE_LINE" ]; then
   echo "ERROR: Could not find closing frontmatter delimiter in $TARGET_FILE"
   exit 1

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -146,6 +146,11 @@ echo "--- A1: Agent frontmatter ---"
 for f in agents/*.md; do
   name=$(basename "$f")
   [[ "$name" == "_template.md" || "$name" == "README.md" ]] && continue
+  # DO NOT add `intent` here without reading scripts/envelopes/a6a-abort-capable-substitutions.mjs
+  # first. A6a owns that field and prints `FAIL: $f missing required field: intent`, which is
+  # byte-identical to what this loop would render for `intent` — and the envelope case proving
+  # A6a's diagnostic is reachable keys on exactly that string. Adding it here lets that case
+  # report [KILLED] over a run in which A6a never executed.
   for field in name description tools priority; do
     if ! grep -q "^${field}:" "$f"; then
       echo "FAIL: $f missing required field: $field"
@@ -234,8 +239,13 @@ for f in agents/*.md; do
   fi
   # A1 already fails a file with no `tools:`, so this is a second reader of the same fact
   # rather than the only one. It is here because the alternative is worse than a duplicate
-  # FAIL line: an empty `$tools` silently yields has_we=0 below, which reads as "advisory
-  # tools" and would let an `intent: implementing` agent with no tools field pass A6a.
+  # FAIL line: an empty `$tools` silently yields has_we=0 below, i.e. "no Write/Edit", so an
+  # ADVISORY agent with no `tools:` line agrees with itself and A6a emits nothing at all.
+  #
+  # The comment here first named the implementing case, which was backwards — that one is
+  # already caught, printing `intent=implementing but tools lack Write/Edit` from the check
+  # below. Advisory is the direction that escaped silently, and it is the direction a future
+  # reader would use to decide whether this guard is removable.
   if [ -z "$tools" ]; then
     echo "FAIL: $f missing required field: tools (A6a cannot judge intent without it)"
     failed=1; a6_fail=1; continue
@@ -809,7 +819,8 @@ fi
 # Fails CLOSED. An empty extraction is FAIL, never OK -- a pattern that drifts and matches
 # nothing is the vacuous pass this check exists to prevent (the A10 rule, applied here).
 #
-# Every extraction in A11 and A12 carries `|| true`, and that is load-bearing rather than
+# Every extraction in A11 and A12 carries `|| true` or a justified `# abort-ok:`, and that is
+# load-bearing rather than
 # noise. Under `set -euo pipefail` a bare `x=$(grep ... )` aborts the ENTIRE script the moment
 # grep matches nothing -- red with no diagnostic, the zero-check dead, and every later check
 # skipped. The envelope reported WRONG-RED on the first version of A11 for exactly this.
@@ -819,15 +830,21 @@ fi
 # The scope of that sentence is A11 and A12 ONLY. It said "every extraction below" until a
 # review pointed out that A12's own two lines -- copied from A4/A5 in round 1 -- had no guard,
 # which made the claim false about the exact failure class this gate exists to measure, five
-# lines above the note tracking that class. They are guarded now, but the rest of this script
-# is not: #647 is the sweep, and until it lands do not read this paragraph as covering A1-A10.
+# lines above the note tracking that class.
+#
+# That sentence used to end "the rest of this script is not [guarded]: #647 is the sweep, and
+# until it lands do not read this paragraph as covering A1-A10." #647 IS this commit, so both
+# halves were false on arrival. The whole file is now at zero unguarded sites --
+# `npm run check:bare-substitutions` reports 100 scanned / 0 UNGUARDED across all six tracked
+# shell scripts, against 30 on the parent commit -- and the rule at the top of this file, not
+# this paragraph, is where the guard policy lives.
 echo "--- A11: Guide category render coverage ---"
 a11_fail=0
 # Non-uniqued, empties dropped: this is a per-ENTRY list, not a set (A11a needs the count).
 a11_used=$(grep -E '^    category: ' guides/_registry.yml | tr -d '\r' \
   | sed -E 's/^    category: *//' | sed -E 's/^"(.*)"$/\1/' | sed -E "s/^'(.*)'$/\1/" \
   | sed '/^[[:space:]]*$/d' || true)
-a11_used_count=$(printf '%s\n' "$a11_used" | sed '/^[[:space:]]*$/d' | wc -l) # abort-ok: printf|sed|wc return 0 on empty input; the count is compared against a12 below
+a11_used_count=$(printf '%s\n' "$a11_used" | sed '/^[[:space:]]*$/d' | wc -l) # abort-ok: printf|sed|wc return 0 on empty input; the -ne and -eq 0 tests in A11a below read the count
 a11_entries=$(grep -c '^  - id: ' guides/_registry.yml || true)
 # `tr -d '\r'` FIRST: the range anchors are `$`-terminated, so on a CRLF file they would miss
 # both delimiters and the range would run to EOF. Moot under the repo's line-endings gate, but
@@ -985,7 +1002,12 @@ for f in teams/*.md; do
   [[ "$name" == "_template.md" || "$name" == "README.md" ]] && continue
   # Extract member ids from structured YAML: members:\n  - id: agent-name
   while IFS= read -r line; do
-    member=$(echo "$line" | sed -n 's/^  - id: *//p' | tr -d '\r' | xargs) # abort-ok: `sed -n …p` exits 0 with no output; the -n test on the next line reads it
+    # GUARDED, not annotated (#647 review). The first version claimed `sed -n …p` exits 0 on
+    # no match -- true, and irrelevant: `pipefail` surfaces the RIGHTMOST non-zero, and `xargs`
+    # exits 1 on an unmatched quote. A team file carrying `  - id: o'brien` killed this loop
+    # mid-B3 with one `xargs:` line on stderr and no FAIL -- an abort on the line above the
+    # check written to report the malformed input. The `-n` test below is the zero-case reader.
+    member=$(echo "$line" | sed -n 's/^  - id: *//p' | tr -d '\r' | xargs || true)
     if [ -n "$member" ]; then
       # Skip known placeholder values (dyad uses 'any' for flexible member)
       [[ "$member" == "any" ]] && continue
@@ -1016,7 +1038,8 @@ for f in agents/*.md; do
     fi
     if [ "$in_skills" -eq 1 ]; then
       if echo "$line" | grep -q '^  - '; then
-        skill_id=$(echo "$line" | sed 's/^  - //' | tr -d '\r' | xargs) # abort-ok: sed|tr|xargs return 0 on empty input; the -d test below reads the result
+        # Same `xargs` unmatched-quote abort as B3 above; the `-d` test below reads the empty case.
+        skill_id=$(echo "$line" | sed 's/^  - //' | tr -d '\r' | xargs || true)
         b4_checked=$((b4_checked + 1))
         if [ ! -d "skills/${skill_id}" ]; then
           echo "FAIL: $f references skill '$skill_id' but skills/${skill_id}/ not found"
@@ -1166,7 +1189,13 @@ else
   # Fallback: parse JS if YAML not yet extracted
   style_domains=$(grep -oP "'[a-z0-9-]+'" viz/build-icon-manifest.js | head -60 | sed "s/'//g" | sort -u || true)
 fi
-# `reg_domains` was asserted in B7 and is reused here; only the style side is new.
+# BOTH sides asserted, and `reg_domains` is not exempt for having been asserted in B7. That
+# assertion sets `b7_warn`, which nothing here reads -- so B10 would compare an EMPTY left side,
+# find nothing missing, and print its OK line six lines below B7's FAIL saying that every
+# comparison against it would pass vacuously. That contradiction is new-in-#647 reachable: before
+# the guard on `:1112`, an empty extraction aborted the script at B7 and B10 never ran at all.
+# Making B7 survivable is what made this line reachable and wrong.
+require_nonempty 'B10 registry domains (skills/_registry.yml)' "$reg_domains" || b10_warn=-1
 require_nonempty 'B10 style domains (viz/domain-styles.yml)' "$style_domains" || b10_warn=-1
 b10_missing=$(comm -23 <(echo "$reg_domains") <(echo "$style_domains") || true)
 if [ "$b10_warn" -eq 0 ] && [ -n "$b10_missing" ]; then

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -5,8 +5,60 @@
 
 set -euo pipefail
 
+# ── When a command substitution needs `|| true`, and when it must NOT have one (#647) ──
+#
+# `set -e` plus `pipefail` means a bare `x=$(cmd | …)` carries the pipeline's exit status, so
+# the assignment can abort the entire script. There is no message: the run simply stops, and
+# every check below the abort is skipped while the log looks like a normal early exit. `grep`
+# is the usual culprit, because "found nothing" is exit 1 and is often the case the check is
+# hunting for. `| wc -l` does not rescue it -- `pipefail` returns the rightmost non-zero
+# status, so `grep(1) | wc -l(0)` still exits 1.
+#
+# The rule, and it runs in both directions:
+#
+#   `|| true`  belongs where the next lines EXPLICITLY handle the empty result -- a `-z` test,
+#              a count compared against an expected number, a loop that reports when it runs
+#              zero times. The guard converts a fatal abort into a value the check then judges.
+#
+#   NO guard   where nothing checks the empty case. There `|| true` is strictly worse than the
+#              abort: it turns a loud stop into a silent empty string, and an empty haystack
+#              makes every "is X missing from it" test pass. That is the vacuous pass the A10
+#              and A11 rules exist to forbid, arrived at from the other side.
+#
+# So a blanket sweep of `|| true` over every site is not a fix, and neither is removing them
+# all. Each site is a judgement about whether its zero-case has a reader.
+#
+# `scripts/check-bare-substitutions.js` enforces the first half mechanically: a substitution
+# whose pipeline can legitimately exit non-zero must either carry a guard or carry an
+# `# abort-ok:` annotation saying why it cannot. It cannot enforce the second half -- whether
+# a zero-check really follows is not decidable by grep -- which is why this comment exists.
+
 failed=0
 warn_count=0
+
+# ── Assert that a corpus extraction found something (#647) ──────────────────────
+#
+# This is the other half of the rule above, and the reason a blanket `|| true` sweep would
+# have made things worse rather than better.
+#
+# Every B7-B12 comparison has the shape `comm -23 <(extracted) <(reference)`. `comm -23`
+# prints lines present only on the LEFT, so an empty left side reports nothing missing —
+# and the check then prints its OK line. Replacing the abort with `|| true` at those sites
+# and stopping there would convert "the script died" into "all registry domains have
+# hand-tuned colours", measured over an empty registry. Louder is not the same as correct;
+# the extraction has to be asserted before its result is trusted.
+#
+# Returns non-zero so callers can guard the comparison itself, rather than reporting a
+# contradiction (FAIL on the extraction, OK on the comparison) in the same block.
+require_nonempty() { # <label> <value>
+  if [ -z "$2" ]; then
+    echo "FAIL: $1 extracted nothing — the pattern has drifted from the file it reads,"
+    echo "      so every comparison against it would pass vacuously"
+    failed=1
+    return 1
+  fi
+  return 0
+}
 
 # ── Shared: read one event's trigger paths out of a workflow (#641) ──────────────
 #
@@ -137,8 +189,11 @@ done
 
 # A4: Agent registry count
 echo "--- A4: Agent registry count ---"
-disk_count=$(find agents -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l)
-reg_count=$(grep 'total_agents:' agents/_registry.yml | tr -d '\r' | awk '{print $2}')
+disk_count=$(find agents -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l) # abort-ok: find over a directory whose absence is not drift but a broken checkout
+# `|| true` and it is the point of this check: if `total_agents:` is ever renamed, the bare
+# form aborted the run rather than reporting the drift it exists to catch. The `!=` below is
+# the explicit zero-check -- an empty string never equals a number, so the FAIL prints.
+reg_count=$(grep 'total_agents:' agents/_registry.yml | tr -d '\r' | awk '{print $2}' || true)
 if [ "$disk_count" != "$reg_count" ]; then
   echo "FAIL: agents disk=$disk_count registry=$reg_count"
   failed=1
@@ -148,8 +203,8 @@ fi
 
 # A5: Team registry count
 echo "--- A5: Team registry count ---"
-disk_count=$(find teams -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l)
-reg_count=$(grep 'total_teams:' teams/_registry.yml | tr -d '\r' | awk '{print $2}')
+disk_count=$(find teams -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l) # abort-ok: find over a directory whose absence is not drift but a broken checkout
+reg_count=$(grep 'total_teams:' teams/_registry.yml | tr -d '\r' | awk '{print $2}' || true) # see A4
 if [ "$disk_count" != "$reg_count" ]; then
   echo "FAIL: teams disk=$disk_count registry=$reg_count"
   failed=1
@@ -165,10 +220,24 @@ declare -A AGENT_INTENT
 for f in agents/*.md; do
   name=$(basename "$f" .md)
   [[ "$name" == "_template" || "$name" == "README" ]] && continue
-  intent=$(grep -m1 '^intent:' "$f" | sed 's/^intent: *//' | tr -d '\r' | xargs)
-  tools=$(grep -m1 '^tools:' "$f" | tr -d '\r')
+  # `|| true` on both, and it is load-bearing rather than defensive (#647). Under
+  # `set -euo pipefail` a bare `x=$(grep … | …)` carries the pipeline's status, so an agent
+  # file WITHOUT `intent:` aborted the whole script on this line -- one line before the
+  # `-z` guard that exists to report it. The FAIL below could never print, and every check
+  # from A6 to B13 was skipped with no diagnostic at all. Both guards are correct under the
+  # rule in the header: an explicit zero-check follows each of them.
+  intent=$(grep -m1 '^intent:' "$f" | sed 's/^intent: *//' | tr -d '\r' | xargs || true)
+  tools=$(grep -m1 '^tools:' "$f" | tr -d '\r' || true)
   if [ -z "$intent" ]; then
     echo "FAIL: $f missing required field: intent"
+    failed=1; a6_fail=1; continue
+  fi
+  # A1 already fails a file with no `tools:`, so this is a second reader of the same fact
+  # rather than the only one. It is here because the alternative is worse than a duplicate
+  # FAIL line: an empty `$tools` silently yields has_we=0 below, which reads as "advisory
+  # tools" and would let an `intent: implementing` agent with no tools field pass A6a.
+  if [ -z "$tools" ]; then
+    echo "FAIL: $f missing required field: tools (A6a cannot judge intent without it)"
     failed=1; a6_fail=1; continue
   fi
   if [[ "$intent" != "advisory" && "$intent" != "implementing" ]]; then
@@ -293,7 +362,7 @@ a8_readmes=$(sed -n '/^const MANAGED = \[/,/^\];/p' scripts/generate-readmes.js 
   | grep -oE "path: ['\"][^'\"]+['\"]" | sed -E "s/^path: ['\"]//; s/['\"]\$//" | sort -u || true)
 a8_locales=$(grep -E '^[[:space:]]*-[[:space:]]*code:' i18n/_config.yml | sed -E 's/.*code:[[:space:]]*//; s/[[:space:]]*$//' | tr -d '\r' || true)
 a8_status=$(printf '%s\n' "$a8_locales" | sed -E '/^$/d; s#^#i18n/#; s#$#/translation_status.yml#' || true)
-a8_expected=$(printf '%s\n%s\n' "$a8_readmes" "$a8_status" | sed -E '/^$/d' | sort -u)
+a8_expected=$(printf '%s\n%s\n' "$a8_readmes" "$a8_status" | sed -E '/^$/d' | sort -u) # abort-ok: printf|sed|sort-u return 0 on empty input; the -z checks two lines below read the result
 a8_fp=$(grep -m1 'file_pattern:' .github/workflows/update-readmes.yml | sed -E 's/.*file_pattern:[[:space:]]*"([^"]*)".*/\1/' | tr '\t' ' ' || true)
 if [ -z "$a8_readmes" ] || [ -z "$a8_locales" ] || [ -z "$a8_fp" ]; then
   echo "FAIL: A8 could not derive generated files, locales, or file_pattern"
@@ -456,7 +525,7 @@ while IFS= read -r f; do
   invoked=$(grep -oE "$a9_pattern" "$f" | grep -oE "${a9_bt}(${a9_tools})${a9_bt}" | tr -d "$a9_bt" | sort -u || true)
   # Frontmatter region only (skips body code-fence examples); supports both
   # `allowed-tools: A B C` and the YAML block-list form.
-  a9_fm=$(sed -n '2,/^---[[:space:]]*$/p' "$f" | tr -d '\r')
+  a9_fm=$(sed -n '2,/^---[[:space:]]*$/p' "$f" | tr -d '\r') # abort-ok: `sed -n` prints nothing and exits 0 when the range matches nothing
   a9_inline=$(printf '%s\n' "$a9_fm" | grep -m1 '^allowed-tools:' | sed 's/^allowed-tools:[[:space:]]*//' || true)
   a9_block=$(printf '%s\n' "$a9_fm" | awk '/^allowed-tools:[[:space:]]*$/{f=1;next} f&&/^[[:space:]]*-[[:space:]]/{sub(/^[[:space:]]*-[[:space:]]*/,"");print;next} f{exit}' || true)
   allowed=$(printf '%s %s' "$a9_inline" "$a9_block" | tr '\n' ' ')
@@ -758,7 +827,7 @@ a11_fail=0
 a11_used=$(grep -E '^    category: ' guides/_registry.yml | tr -d '\r' \
   | sed -E 's/^    category: *//' | sed -E 's/^"(.*)"$/\1/' | sed -E "s/^'(.*)'$/\1/" \
   | sed '/^[[:space:]]*$/d' || true)
-a11_used_count=$(printf '%s\n' "$a11_used" | sed '/^[[:space:]]*$/d' | wc -l)
+a11_used_count=$(printf '%s\n' "$a11_used" | sed '/^[[:space:]]*$/d' | wc -l) # abort-ok: printf|sed|wc return 0 on empty input; the count is compared against a12 below
 a11_entries=$(grep -c '^  - id: ' guides/_registry.yml || true)
 # `tr -d '\r'` FIRST: the range anchors are `$`-terminated, so on a CRLF file they would miss
 # both delimiters and the range would run to EOF. Moot under the repo's line-endings gate, but
@@ -916,7 +985,7 @@ for f in teams/*.md; do
   [[ "$name" == "_template.md" || "$name" == "README.md" ]] && continue
   # Extract member ids from structured YAML: members:\n  - id: agent-name
   while IFS= read -r line; do
-    member=$(echo "$line" | sed -n 's/^  - id: *//p' | tr -d '\r' | xargs)
+    member=$(echo "$line" | sed -n 's/^  - id: *//p' | tr -d '\r' | xargs) # abort-ok: `sed -n …p` exits 0 with no output; the -n test on the next line reads it
     if [ -n "$member" ]; then
       # Skip known placeholder values (dyad uses 'any' for flexible member)
       [[ "$member" == "any" ]] && continue
@@ -947,7 +1016,7 @@ for f in agents/*.md; do
     fi
     if [ "$in_skills" -eq 1 ]; then
       if echo "$line" | grep -q '^  - '; then
-        skill_id=$(echo "$line" | sed 's/^  - //' | tr -d '\r' | xargs)
+        skill_id=$(echo "$line" | sed 's/^  - //' | tr -d '\r' | xargs) # abort-ok: sed|tr|xargs return 0 on empty input; the -d test below reads the result
         b4_checked=$((b4_checked + 1))
         if [ ! -d "skills/${skill_id}" ]; then
           echo "FAIL: $f references skill '$skill_id' but skills/${skill_id}/ not found"
@@ -1036,10 +1105,16 @@ echo "=== Category C: Pipeline Sync Validation ==="
 # B7: Palette domain coverage (registry domains vs cyberpunk color map)
 echo "--- B7: Palette domain coverage ---"
 b7_warn=0
-reg_domains=$(grep '^\s\+[a-z0-9_-]\+:$' skills/_registry.yml | grep -v 'skills:' | sed 's/://;s/^ *//' | sort)
-palette_domains=$(sed -n '/hand_domains.*list/,/hand_agents.*list/p' viz/R/palettes.R | grep -oP '^\s+"[a-z0-9-]+"' | sed 's/[" ]//g' | sort)
-b7_missing=$(comm -23 <(echo "$reg_domains") <(echo "$palette_domains"))
-if [ -n "$b7_missing" ]; then
+# Guarded and then ASSERTED, per the two rules at the top of this file. Both greps here are
+# corpus patterns that a reformat of `_registry.yml` or of `palettes.R` would silently stop
+# matching, and `comm -23` over an empty left side reports nothing missing -- so the guard
+# alone would turn a drifted pattern into this block's OK line.
+reg_domains=$(grep '^\s\+[a-z0-9_-]\+:$' skills/_registry.yml | grep -v 'skills:' | sed 's/://;s/^ *//' | sort || true)
+palette_domains=$(sed -n '/hand_domains.*list/,/hand_agents.*list/p' viz/R/palettes.R | grep -oP '^\s+"[a-z0-9-]+"' | sed 's/[" ]//g' | sort || true)
+require_nonempty 'B7 registry domains (skills/_registry.yml)' "$reg_domains" || b7_warn=-1
+require_nonempty 'B7 palette domains (viz/R/palettes.R)' "$palette_domains" || b7_warn=-1
+b7_missing=$(comm -23 <(echo "$reg_domains") <(echo "$palette_domains") || true)
+if [ "$b7_warn" -eq 0 ] && [ -n "$b7_missing" ]; then
   b7_count=$(echo "$b7_missing" | wc -l)
   echo "WARN: $b7_count domain(s) in registry without hand-tuned cyberpunk color (will use auto-fallback):"
   echo "$b7_missing" | sed 's/^/  - /'
@@ -1051,10 +1126,12 @@ fi
 # B8: Glyph mapping coverage (registry skill IDs vs SKILL_GLYPHS keys)
 echo "--- B8: Glyph mapping coverage ---"
 b8_warn=0
-reg_skills=$(grep '^      - id: ' skills/_registry.yml | sed 's/.*- id: //' | tr -d '\r' | sort)
-glyph_skills=$(grep -oP '^\s+"[a-z0-9-]+"' viz/R/glyphs.R | sed 's/[" ]//g' | sort)
-b8_missing=$(comm -23 <(echo "$reg_skills") <(echo "$glyph_skills"))
-if [ -n "$b8_missing" ]; then
+reg_skills=$(grep '^      - id: ' skills/_registry.yml | sed 's/.*- id: //' | tr -d '\r' | sort || true)
+glyph_skills=$(grep -oP '^\s+"[a-z0-9-]+"' viz/R/glyphs.R | sed 's/[" ]//g' | sort || true)
+require_nonempty 'B8 registry skill ids (skills/_registry.yml)' "$reg_skills" || b8_warn=-1
+require_nonempty 'B8 glyph keys (viz/R/glyphs.R)' "$glyph_skills" || b8_warn=-1
+b8_missing=$(comm -23 <(echo "$reg_skills") <(echo "$glyph_skills") || true)
+if [ "$b8_warn" -eq 0 ] && [ -n "$b8_missing" ]; then
   b8_count=$(echo "$b8_missing" | wc -l)
   echo "WARN: $b8_count skill(s) in registry without glyph mapping (will render with fallback):"
   echo "$b8_missing" | sed 's/^/  - /'
@@ -1066,10 +1143,12 @@ fi
 # B9: Agent glyph coverage (registry agent IDs vs AGENT_GLYPHS keys)
 echo "--- B9: Agent glyph coverage ---"
 b9_warn=0
-reg_agents=$(sed -n '/^agents:/,$ { /^  - id: /p }' agents/_registry.yml | sed 's/.*- id: //' | tr -d '\r' | sort)
-glyph_agents=$(grep -oP '^\s+"[a-z0-9-]+"' viz/R/agent_glyphs.R | sed 's/[" ]//g' | sort)
-b9_missing=$(comm -23 <(echo "$reg_agents") <(echo "$glyph_agents"))
-if [ -n "$b9_missing" ]; then
+reg_agents=$(sed -n '/^agents:/,$ { /^  - id: /p }' agents/_registry.yml | sed 's/.*- id: //' | tr -d '\r' | sort || true)
+glyph_agents=$(grep -oP '^\s+"[a-z0-9-]+"' viz/R/agent_glyphs.R | sed 's/[" ]//g' | sort || true)
+require_nonempty 'B9 registry agent ids (agents/_registry.yml)' "$reg_agents" || b9_warn=-1
+require_nonempty 'B9 agent glyph keys (viz/R/agent_glyphs.R)' "$glyph_agents" || b9_warn=-1
+b9_missing=$(comm -23 <(echo "$reg_agents") <(echo "$glyph_agents") || true)
+if [ "$b9_warn" -eq 0 ] && [ -n "$b9_missing" ]; then
   b9_count=$(echo "$b9_missing" | wc -l)
   echo "WARN: $b9_count agent(s) in registry without glyph mapping:"
   echo "$b9_missing" | sed 's/^/  - /'
@@ -1082,13 +1161,15 @@ fi
 echo "--- B10: DOMAIN_STYLES coverage ---"
 b10_warn=0
 if [ -f "viz/domain-styles.yml" ]; then
-  style_domains=$(grep '^[a-z0-9-]\+:' viz/domain-styles.yml | sed 's/:.*//' | sort)
+  style_domains=$(grep '^[a-z0-9-]\+:' viz/domain-styles.yml | sed 's/:.*//' | sort || true)
 else
   # Fallback: parse JS if YAML not yet extracted
-  style_domains=$(grep -oP "'[a-z0-9-]+'" viz/build-icon-manifest.js | head -60 | sed "s/'//g" | sort -u)
+  style_domains=$(grep -oP "'[a-z0-9-]+'" viz/build-icon-manifest.js | head -60 | sed "s/'//g" | sort -u || true)
 fi
-b10_missing=$(comm -23 <(echo "$reg_domains") <(echo "$style_domains"))
-if [ -n "$b10_missing" ]; then
+# `reg_domains` was asserted in B7 and is reused here; only the style side is new.
+require_nonempty 'B10 style domains (viz/domain-styles.yml)' "$style_domains" || b10_warn=-1
+b10_missing=$(comm -23 <(echo "$reg_domains") <(echo "$style_domains") || true)
+if [ "$b10_warn" -eq 0 ] && [ -n "$b10_missing" ]; then
   b10_count=$(echo "$b10_missing" | wc -l)
   echo "WARN: $b10_count domain(s) in registry without DOMAIN_STYLES entry (will use generic prompt):"
   echo "$b10_missing" | sed 's/^/  - /'
@@ -1112,8 +1193,15 @@ echo "--- B12: Global discovery-hub coverage ---"
 if [ -d "$HOME/.claude/skills" ]; then
   b12_reg=$(grep '^      - id: ' skills/_registry.yml | sed 's/.*- id: //' | tr -d '\r ' | grep -v '^_template$' | sort -u || true)
   b12_hub=$(find "$HOME/.claude/skills" -maxdepth 1 -mindepth 1 -printf '%f\n' 2>/dev/null | sort -u || true)
-  b12_missing=$(comm -23 <(echo "$b12_reg") <(echo "$b12_hub"))
-  if [ -n "$b12_missing" ]; then
+  # Only the registry side is asserted. An empty `b12_hub` is a legitimate state -- a machine
+  # that has never run sync-discovery-symlinks.sh -- and the comparison is exactly what should
+  # report it, so asserting it would fail an honest first run.
+  b12_ok=0
+  require_nonempty 'B12 registry skill ids (skills/_registry.yml)' "$b12_reg" || b12_ok=1
+  b12_missing=$(comm -23 <(echo "$b12_reg") <(echo "$b12_hub") || true)
+  if [ "$b12_ok" -ne 0 ]; then
+    : # the extraction already reported FAIL; comparing against it would be meaningless
+  elif [ -n "$b12_missing" ]; then
     b12_count=$(echo "$b12_missing" | wc -l)
     echo "WARN: $b12_count registered skill(s) missing from global ~/.claude/skills (run: bash scripts/sync-discovery-symlinks.sh --fix):"
     echo "$b12_missing" | sed 's/^/  - /'


### PR DESCRIPTION
## The defect

A6a's `FAIL: … missing required field: intent` was unreachable code, and *how* it was unreachable
is the interesting part.

Under `set -euo pipefail` a bare `x=$(grep … | …)` carries the pipeline's exit status. `grep` exits
1 on no match, so an agent file without `intent:` aborted the entire script on the extraction line —
one line **above** the `-z` guard written to report it. Nothing printed. A6 through B13 never ran.
The log looked like an ordinary short run.

Reproduced against a two-line fixture before changing anything:

```console
$ bash -c 'set -euo pipefail
    intent=$(grep -m1 "^intent:" probe.md | xargs)
    if [ -z "$intent" ]; then echo "FAIL: missing required field: intent"; fi
    echo "REACHED END"'
(no output)
exit=1
```

Neither line printed.

## The rule, stated once

`|| true` belongs where the next lines **explicitly handle** the empty result. Where nothing checks
the zero case it is strictly worse than the abort — it converts a loud stop into a silent empty
string, and an empty haystack makes every "is X missing from it" test pass. That is the vacuous pass
the A10/A11 rules already forbid, reached from the other direction.

So neither a blanket `|| true` sweep nor removing them all was the fix. The rule now sits in the
header of `validate-integrity.sh`, beside `set -euo pipefail`.

## Triage of every site

| treatment | count | when |
|---|---|---|
| guarded `\|\| true` | 55 | an explicit zero-check follows |
| annotated `# abort-ok:` | 12 | the pipeline cannot legitimately return empty |
| safe | 26 | every command in the pipeline is on the closed safe list |
| **unguarded** | **0** | — |

The A4/A5 registry totals are the sharpest guarded case: `grep 'total_agents:'` returning nothing is
*precisely* the drift those checks exist to catch, and the bare form aborted rather than reporting
it.

**B7–B10/B12 needed both.** They compare `comm -23 <(extracted) <(reference)`, and `comm -23` over an
empty left side reports nothing missing — so `|| true` alone would have turned a drifted grep pattern
into `OK: All registry domains have hand-tuned cyberpunk colors`. A new `require_nonempty` helper
reports the extraction and the comparison is skipped, rather than printing a contradiction beside it.

Two consequences worth naming rather than leaving for a reviewer to find:

- this **escalates those five blocks from warn-only to FAIL**, deliberately — a drifted extraction is
  a broken instrument, not a content warning, and it can now redden the required `integrity` context;
- **B12's new FAIL can only fire locally**, since the whole block is conditional on
  `~/.claude/skills` existing, which CI has no reason to.

## The static check

`scripts/check-bare-substitutions.js`, blocking in `validate-integrity.yml` *ahead of* the gate it
guards, so a regression's cause is on screen above the silence.

It enumerates the **safe** commands rather than the dangerous ones. A dangerous-command list is an
allowlist wearing a deny-list's clothes: the first script to pipe through `jq`, `yq` or a local
function is unguarded by default and nobody notices. Enumerating the safe side fails closed.

It exists because **the dynamic gate structurally cannot demonstrate this defect**: the abort needs
*both* a missing guard and a corpus file missing the field, and the envelope harness applies one
mutation per case. That is recorded as an `expect: null` case rather than left as a gap.

```console
$ node scripts/gate-envelope.js --spec scripts/envelopes/bare-substitution-lint.mjs
[KILLED]   a guard is removed from a registry-total extraction
[KILLED]   an abort-ok annotation is deleted
[KILLED]   a substitution piping through an unknown tool is not silently exempt
[SURVIVED as documented] a `local` assignment is NOT reported (documented scope limit)

gate-envelope: 3 killed, 1 survived as documented of 4 case(s).
```

The survivor is `local x=$(…)`, which genuinely cannot abort — the status becomes `local`'s, always
0. One further known false negative is documented in the header rather than left to be discovered:
`x=$(cmd || true | cmd2)` guards the wrong thing, and the span-wide guard test reads it as guarded.
No site in the repo has that shape.

## Instrument errors found along the way

The checker was wrong about this repo three times before it was right, each time in the direction
that reads as an all-clear:

- it matched `$((` arithmetic expansion, inventing 10 findings whose "pipeline" was the variable's
  own name;
- its span scanner counted parens on raw text, so an embedded awk `sub(/x/, "", l)` drove the depth
  negative and truncated the span above the site's real `|| true` — reporting a **guarded** site as
  unguarded;
- `|| return` was missing from the guard pattern, which flagged `wf_event_paths`, the most carefully
  handled site in the file.

It also walked the filesystem at first and did not finish in 60 seconds, because `statSync` follows
the `.claude/skills` symlink farm. It asks `git ls-files` now — 27 paths, milliseconds, and it cannot
wander into an agent worktree.

Each is pinned by a test that names it. So is the test helper's own first version, which asserted
`doesNotMatch(/UNGUARDED/)` against output whose summary line reads `UNGUARDED: 0` — eight tests red
on a working check.

## The prose defect (finding 3 of the issue)

`generate-readmes.js` described guides as "workflow, infrastructure, and reference" documentation —
three of five categories, true when there were three. Now derived from the registry via
`guideCategoryNames`, the same source as the ordering helper #644 extracted.

## Acceptance criteria

- [x] A6a's extraction reaches its own `-z` guard and the FAIL prints — proven by mutation, with the
      expect naming the **diagnostic** rather than merely requiring a red run
- [x] Every remaining abort-capable site guarded or annotated; no blanket sweep
- [x] The `|| true` distinction stated once, in `validate-integrity.sh`'s header
- [x] A gate catches a newly added bare abort-capable assignment — `check-bare-substitutions.js`,
      blocking, with its own envelope
- [x] `generate-readmes.js` prose derives from the registry
- [x] `bash scripts/validate-integrity.sh` — PASSED, 3 pre-existing warnings
- [x] `node --test scripts/test/*.test.js` — 457 pass / 0 fail, plus 10 new
- [x] `npm run check-readmes` — up to date

## Not re-run, and why

`scripts/envelopes/a10-content-type-literals.mjs` shares this host file. None of its `find` texts
were touched, and the runner refuses rather than guessing when a `find` stops matching — so a silent
mismatch is not a failure mode here.

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)