### PR TITLE
fix(gates): A4/A5 compare the registry entry set to disk, not just the totals (#648)

### DIFF
--- a/scripts/envelopes/a4-a5-registry-entry-sets.mjs
+++ b/scripts/envelopes/a4-a5-registry-entry-sets.mjs
@@ -66,7 +66,11 @@ export const cases = [
     file: 'agents/_registry.yml',
     find: '  - id: security-analyst\n',
     replace: '  - id: code-reviewer\n',
-    expect: 'has two entries sharing one id',
+    // Names the duplicated ID, not just the fact of duplication. The check emitted a header
+    // plus indented detail until an adversarial review pointed out that the offending id then
+    // sits on a line the harness cannot assert -- so a case could pass while the check named the
+    // wrong id, or no id at all.
+    expect: 'has two entries sharing one id: code-reviewer',
   },
   {
     // FAIL-CLOSED. Renaming the section key makes the `sed` range match nothing, so the
@@ -77,6 +81,6 @@ export const cases = [
     file: 'agents/_registry.yml',
     find: '\nagents:\n',
     replace: '\nagentz:\n',
-    expect: "pattern drift, not a clean tree",
+    expect: 'pattern drift, not a clean tree',
   },
 ];

--- a/scripts/envelopes/a4-a5-registry-entry-sets.mjs
+++ b/scripts/envelopes/a4-a5-registry-entry-sets.mjs
@@ -1,0 +1,82 @@
+/**
+ * Envelope for integrity checks A4 and A5 — registry entry set vs disk (#648).
+ *
+ *   node scripts/gate-envelope.js --spec scripts/envelopes/a4-a5-registry-entry-sets.mjs
+ *
+ * A4 and A5 compared `total_agents` / `total_teams` against a `find` count and nothing else. A
+ * count is blind in two directions the READMEs are not: they render from the entry LIST, so a
+ * file added with valid frontmatter and the total bumped — but with no `- id:` entry — kept both
+ * numbers equal while appearing in no generated index. And a swap (one file added, one removed
+ * in the same commit) leaves the number identical while both sides changed.
+ *
+ * ## Why every mutation here is an id RENAME
+ *
+ * The harness mutates file content; it cannot add or delete a file. A rename is the shape that
+ * proves the point anyway, and proves it better than an addition would: renaming one `- id:`
+ * leaves the entry COUNT untouched, so the count check stays green and only the set check can
+ * fire. That is exactly #648's scenario — everything green, the item in no index — reproduced
+ * without touching the totals at all.
+ *
+ * Every `expect` names a string that appears ON a `FAIL:` line, not on an indented detail line
+ * beneath one. `gate-envelope.js` kills a case only when a SINGLE line contains both `FAIL` and
+ * the expected substring, so the first version of this check -- one header FAIL plus indented
+ * per-id detail -- reported [WRONG-RED] against a check that was naming the ids correctly. The
+ * check now emits one `FAIL:` per discrepancy, which is better output and observable evidence.
+ *
+ * Cases 1 and 2 apply the same mutation and assert different halves of the output, because
+ * "reports which side each discrepancy is on" is two claims, not one: a check that printed only
+ * `only on disk` would satisfy a single-expect case while leaving the orphaned entry unnamed.
+ */
+
+export const gate = { command: ['bash', 'scripts/validate-integrity.sh'] };
+
+export const cases = [
+  {
+    label: 'A4: an agent id is renamed — the orphaned ENTRY is named',
+    file: 'agents/_registry.yml',
+    find: '  - id: r-developer\n',
+    replace: '  - id: r-developer-typo\n',
+    expect: 'only in registry (no file): r-developer-typo',
+  },
+  {
+    // Same mutation, other half. The disk file is now unreferenced by any entry, which is the
+    // literal #648 finding: it satisfies A1 and the count, and renders in no index.
+    label: 'A4: an agent id is renamed — the unreferenced FILE is named',
+    file: 'agents/_registry.yml',
+    find: '  - id: r-developer\n',
+    replace: '  - id: r-developer-typo\n',
+    expect: 'only on disk (no registry entry): r-developer',
+  },
+  {
+    label: 'A5: a team id is renamed — the set comparison fires for teams too',
+    file: 'teams/_registry.yml',
+    find: '  - id: r-package-review\n',
+    replace: '  - id: r-package-review-typo\n',
+    expect: 'teams: only on disk (no registry entry): r-package-review',
+  },
+  {
+    // A DUPLICATE must be caught before `sort -u` collapses it. Two entries pointing at one
+    // file would otherwise be forgiven by the very check meant to pair them one-to-one: the
+    // uniqued set still equals disk, and nothing reports the second entry. A12 learned this
+    // for guides; the same trap is reachable here.
+    //
+    // The mutation makes `code-reviewer` appear twice by renaming a DIFFERENT entry onto it,
+    // which keeps the entry count at 75 — so again only the set logic can fire.
+    label: 'A4: two entries sharing one id are caught before sort -u collapses them',
+    file: 'agents/_registry.yml',
+    find: '  - id: security-analyst\n',
+    replace: '  - id: code-reviewer\n',
+    expect: 'has two entries sharing one id',
+  },
+  {
+    // FAIL-CLOSED. Renaming the section key makes the `sed` range match nothing, so the
+    // extraction returns empty. Comparing an empty set against disk would report all 75 files
+    // as missing — loud, but for the wrong reason, and the next reader "fixes" the registry.
+    // The check names pattern drift instead.
+    label: 'A4: a drifted section key reports pattern drift, not 75 missing files',
+    file: 'agents/_registry.yml',
+    find: '\nagents:\n',
+    replace: '\nagentz:\n',
+    expect: "pattern drift, not a clean tree",
+  },
+];

--- a/scripts/envelopes/bare-substitution-lint.mjs
+++ b/scripts/envelopes/bare-substitution-lint.mjs
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 /**
  * Envelope for `scripts/check-bare-substitutions.js` itself (#647).
  *
@@ -16,6 +18,31 @@
 
 export const gate = { command: ['node', 'scripts/check-bare-substitutions.js'] };
 
+/**
+ * Line number of a unique substring in a repo file, resolved AT LOAD TIME.
+ *
+ * The three killing cases assert `<file>:<line> can abort the script`, because the checker's one
+ * FAIL template makes a bare tail substring tautologically true of any FAIL it can emit -- the
+ * `file:line` half is what makes [WRONG-RED] reachable at all. Line numbers are therefore load
+ * bearing and, hand-written, permanently stale: #648 inserted a function into
+ * `validate-integrity.sh` and moved the site TWICE in one session, each time turning a working
+ * lint into a [WRONG-RED] accusation.
+ *
+ * So the number is derived from the same anchor the mutation uses, and this throws rather than
+ * guessing when the anchor is missing or ambiguous -- an expect built from a wrong line silently
+ * un-asserts the half it exists to assert.
+ */
+function lineOf(file, needle) {
+  const lines = readFileSync(new URL(`../../${file}`, import.meta.url), 'utf8').split(/\r?\n/);
+  const hits = lines.flatMap((line, index) => (line.includes(needle) ? [index + 1] : []));
+  if (hits.length !== 1) {
+    throw new Error(`lineOf: ${hits.length} match(es) for ${JSON.stringify(needle)} in ${file}; need exactly 1`);
+  }
+  return hits[0];
+}
+
+const REGISTRY_TOTAL_ANCHOR = "reg_count=$(grep 'total_agents:'";
+
 export const cases = [
   {
     // The regression the lint exists to stop: someone "tidies away" a guard.
@@ -29,7 +56,12 @@ export const cases = [
     // [WRONG-RED] branch was dead for all three killing cases. Demonstrated, not theorised:
     // case 3 kills at bulk-scaffold-caveman.sh:14, and deleting the annotation on the line
     // directly ABOVE it also killed, same expect, adjacent site.
-    expect: 'scripts/validate-integrity.sh:201 can abort the script',
+    //
+    // The line number is DERIVED, not written down. Hand-maintained it went stale twice in one
+    // session as #648 grew the file above it, each time reporting [WRONG-RED] against a lint
+    // that had fired correctly -- a false accusation is the one thing an envelope must not
+    // produce, since its whole purpose is to be believed about whether a check works.
+    expect: `scripts/validate-integrity.sh:${lineOf('scripts/validate-integrity.sh', REGISTRY_TOTAL_ANCHOR)} can abort the script`,
   },
   {
     // The other way to defeat it: keep the code, drop the annotation that justified it. An
@@ -39,7 +71,7 @@ export const cases = [
     file: 'scripts/translate-content.sh',
     find: ' # abort-ok: awk exits 0 when no line matches; the -z check on the next line is the reader',
     replace: '',
-    expect: 'scripts/translate-content.sh:96 can abort the script',
+    expect: `scripts/translate-content.sh:${lineOf('scripts/translate-content.sh', 'CLOSE_LINE=$(awk')} can abort the script`,
   },
   {
     // DEFAULT-DENY, measured. The tempting design is a list of dangerous commands; this one
@@ -49,7 +81,7 @@ export const cases = [
     file: 'scripts/bulk-scaffold-caveman.sh',
     find: "TODAY=$(date +%Y-%m-%d)",
     replace: "TODAY=$(date +%Y-%m-%d | jq -R .)",
-    expect: 'scripts/bulk-scaffold-caveman.sh:14 can abort the script',
+    expect: `scripts/bulk-scaffold-caveman.sh:${lineOf('scripts/bulk-scaffold-caveman.sh', 'TODAY=$(date')} can abort the script`,
     // `date` alone is on the safe list, so the unmutated line is reported `safe`. Adding one
     // unknown command to the pipeline is what has to flip it — which is the property that
     // separates an enumerated-safe list from an enumerated-dangerous one.

--- a/scripts/test/bare-substitutions.test.js
+++ b/scripts/test/bare-substitutions.test.js
@@ -225,3 +225,11 @@ test('a multi-line span closes at its own paren, not at end of line', () => {
   assert.equal(out.safe, 1);
   assert.equal(out.unguarded, 0);
 });
+
+test('a function-body assignment inside `$( … )` on a continuation is still scanned', () => {
+  // Sanity check that the scanner still sees sites inside a shell FUNCTION, which is where
+  // `registry_entry_set` (#648) puts three of them. Regression guard for any future narrowing
+  // of ASSIGNMENT_GLOBAL back toward a line-start anchor.
+  const out = checkScript(`${HEAD}f() {\n  local a\n  a=$(grep x y)\n}\n`);
+  assert.equal(out.unguarded, 1);
+});

--- a/scripts/test/bare-substitutions.test.js
+++ b/scripts/test/bare-substitutions.test.js
@@ -226,7 +226,7 @@ test('a multi-line span closes at its own paren, not at end of line', () => {
   assert.equal(out.unguarded, 0);
 });
 
-test('a function-body assignment inside `$( … )` on a continuation is still scanned', () => {
+test('an assignment inside a shell FUNCTION body is still scanned', () => {
   // Sanity check that the scanner still sees sites inside a shell FUNCTION, which is where
   // `registry_entry_set` (#648) puts three of them. Regression guard for any future narrowing
   // of ASSIGNMENT_GLOBAL back toward a line-start anchor.

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -192,8 +192,76 @@ for f in guides/*.md; do
 done
 [ "$a3_fail" -eq 0 ] && echo "OK: All guide files have required frontmatter"
 
-# A4: Agent registry count
-echo "--- A4: Agent registry count ---"
+# ── Shared: registry entry set vs disk, for A4 and A5 (#648) ────────────────────
+#
+# A count is blind in two directions that matter, and A12 already learned both for guides:
+# a file added with valid frontmatter and the total bumped, but with NO registry entry, keeps
+# the numbers equal while being absent from every generated index -- because the READMEs render
+# from the entry LIST, not from the count. And a swap (one file added, one removed in the same
+# commit) leaves the number identical while both sides changed.
+#
+# Extracted rather than written twice, because A4 and A5 differ only in three nouns and the
+# duplicated version would drift the way this repo's other duplicated readers have.
+registry_entry_set() { # <tree> <registry> <section key>
+  local tree="$1" registry="$2" section="$3"
+  local reg_ids_all dupes reg_ids disk_ids
+  local rc=0
+
+  # Scoped to the section, not the whole file: `default_skills:` in agents/_registry.yml also
+  # holds list entries, and an unscoped `- id:` grep would silently widen the set the day one
+  # of those gains an id.
+  reg_ids_all=$(sed -n "/^${section}:/,\$ { /^  - id: /p }" "$registry" | tr -d '\r' \
+    | sed -E 's/^  - id: *//' | sed -E 's/^"(.*)"\$/\1/' | sort || true)
+
+  # Before `sort -u`, because uniquing would collapse a duplicate and let the set still match
+  # disk -- two entries pointing at one file forgiven by the check meant to pair them 1:1.
+  dupes=$(printf '%s\n' "$reg_ids_all" | uniq -d || true)
+  if [ -n "$dupes" ]; then
+    echo "FAIL: $registry has two entries sharing one id:"
+    printf '%s\n' "$dupes" | sed 's/^/      /'
+    rc=1
+  fi
+
+  reg_ids=$(printf '%s\n' "$reg_ids_all" | sed '/^\$/d' | sort -u || true)
+  disk_ids=$(find "$tree" -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' \
+    -exec basename {} .md \; | sort || true)
+
+  # Fail-closed. An empty extraction means the pattern drifted from the file it reads, and
+  # comparing an empty set against disk would report every file as missing -- loud, but for the
+  # wrong reason. Naming the real cause is what stops the next reader "fixing" the registry.
+  if [ -z "$reg_ids" ]; then
+    echo "FAIL: extracted 0 '- id:' values from $registry under '${section}:' -- pattern drift, not a clean tree"
+    return 1
+  fi
+  # ONE `FAIL:` LINE PER DISCREPANCY, not a header plus indented detail. Two reasons, and the
+  # second is the one that bit: a reader wants the offending id on the line that says FAIL, and
+  # `gate-envelope.js` kills a case only when one line contains both `FAIL` and the expected
+  # substring. With the detail indented under a header, an envelope asserting "the orphaned
+  # entry is named" reported [WRONG-RED] against a check that was naming it correctly -- the
+  # harness could not see it, so the case proved nothing either way.
+  local only_reg only_disk id
+  only_reg=$(comm -23 <(printf '%s\n' "$reg_ids") <(printf '%s\n' "$disk_ids") || true)
+  only_disk=$(comm -13 <(printf '%s\n' "$reg_ids") <(printf '%s\n' "$disk_ids") || true)
+  if [ -n "$only_reg" ]; then
+    while IFS= read -r id; do
+      [ -z "$id" ] && continue
+      echo "FAIL: $registry: only in registry (no file): $id -- expected $tree/$id.md"
+      rc=1
+    done <<< "$only_reg"
+  fi
+  if [ -n "$only_disk" ]; then
+    while IFS= read -r id; do
+      [ -z "$id" ] && continue
+      echo "FAIL: $tree: only on disk (no registry entry): $id -- it renders in no generated index"
+      rc=1
+    done <<< "$only_disk"
+  fi
+  return "$rc"
+}
+
+# A4: Agent registry count and entry set
+echo "--- A4: Agent registry vs disk ---"
+a4_fail=0
 disk_count=$(find agents -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l) # abort-ok: find over a directory whose absence is not drift but a broken checkout
 # `|| true` and it is the point of this check: if `total_agents:` is ever renamed, the bare
 # form aborted the run rather than reporting the drift it exists to catch. The `!=` below is
@@ -201,21 +269,22 @@ disk_count=$(find agents -maxdepth 1 -name '*.md' -not -name '_template.md' -not
 reg_count=$(grep 'total_agents:' agents/_registry.yml | tr -d '\r' | awk '{print $2}' || true)
 if [ "$disk_count" != "$reg_count" ]; then
   echo "FAIL: agents disk=$disk_count registry=$reg_count"
-  failed=1
-else
-  echo "OK: $disk_count agents on disk match registry"
+  failed=1; a4_fail=1
 fi
+registry_entry_set agents agents/_registry.yml agents || { failed=1; a4_fail=1; }
+[ "$a4_fail" -eq 0 ] && echo "OK: $disk_count agents on disk match total_agents and the registry entry set"
 
-# A5: Team registry count
-echo "--- A5: Team registry count ---"
+# A5: Team registry count and entry set
+echo "--- A5: Team registry vs disk ---"
+a5_fail=0
 disk_count=$(find teams -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l) # abort-ok: find over a directory whose absence is not drift but a broken checkout
 reg_count=$(grep 'total_teams:' teams/_registry.yml | tr -d '\r' | awk '{print $2}' || true) # see A4
 if [ "$disk_count" != "$reg_count" ]; then
   echo "FAIL: teams disk=$disk_count registry=$reg_count"
-  failed=1
-else
-  echo "OK: $disk_count teams on disk match registry"
+  failed=1; a5_fail=1
 fi
+registry_entry_set teams teams/_registry.yml teams || { failed=1; a5_fail=1; }
+[ "$a5_fail" -eq 0 ] && echo "OK: $disk_count teams on disk match total_teams and the registry entry set"
 
 # A6: Agent intent contract (#285)
 echo "--- A6: Agent intent contract ---"

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -204,25 +204,46 @@ done
 # duplicated version would drift the way this repo's other duplicated readers have.
 registry_entry_set() { # <tree> <registry> <section key>
   local tree="$1" registry="$2" section="$3"
-  local reg_ids_all dupes reg_ids disk_ids
+  # `id` is declared HERE, not at its first loop, because the dupes loop now uses it too and a
+  # loop variable that leaks to the global scope would be shared between the A4 and A5 calls.
+  local reg_ids_all dupes reg_ids disk_ids id
   local rc=0
 
   # Scoped to the section, not the whole file: `default_skills:` in agents/_registry.yml also
   # holds list entries, and an unscoped `- id:` grep would silently widen the set the day one
   # of those gains an id.
-  reg_ids_all=$(sed -n "/^${section}:/,\$ { /^  - id: /p }" "$registry" | tr -d '\r' \
-    | sed -E 's/^  - id: *//' | sed -E 's/^"(.*)"\$/\1/' | sort || true)
+  # `"$` and not `"\$`: inside a single-quoted shell string a backslash reaches sed literally, so
+  # `s/^"(.*)"\$/` matched only an id ENDING IN A DOLLAR SIGN and the quote-strip was inert.
+  # Verified rather than reasoned -- `printf '"x"\n' | sed -E 's/^"(.*)"\$/\1/'` prints `"x"`.
+  # Nothing depends on it today (no id in either registry is quoted), which is exactly why it
+  # would have sat here until someone quoted one and got accused of a missing file. A11 and A12
+  # already use the correct form; this was the odd one out.
+  # Range ENDS at the next top-level key, not at EOF. Both registries happen to put their
+  # section last today, so `,$` gave the same answer -- and would keep giving it right up until
+  # someone appends a top-level key with its own `- id:` list, at which point the set silently
+  # widens and every extra id is reported as "only in registry". Entries are indented, so the
+  # first unindented `key:` after the section is the boundary; if none follows, the range still
+  # runs to EOF and nothing changes.
+  reg_ids_all=$(sed -n "/^${section}:/,/^[a-z_][a-z_0-9]*:/ { /^  - id: /p }" "$registry" | tr -d '\r' \
+    | sed -E 's/^  - id: *//' | sed -E 's/^"(.*)"$/\1/' | sort || true)
 
   # Before `sort -u`, because uniquing would collapse a duplicate and let the set still match
   # disk -- two entries pointing at one file forgiven by the check meant to pair them 1:1.
   dupes=$(printf '%s\n' "$reg_ids_all" | uniq -d || true)
   if [ -n "$dupes" ]; then
-    echo "FAIL: $registry has two entries sharing one id:"
-    printf '%s\n' "$dupes" | sed 's/^/      /'
-    rc=1
+    # One FAIL line per duplicate, for the same reason as the discrepancy loops below: the
+    # offending id has to sit on the line that says FAIL, or no envelope case can assert WHICH
+    # id was duplicated. The header-plus-indent form violated this function's own convention
+    # four lines above it.
+    while IFS= read -r id; do
+      [ -z "$id" ] && continue
+      echo "FAIL: $registry has two entries sharing one id: $id"
+      rc=1
+    done <<< "$dupes"
   fi
 
-  reg_ids=$(printf '%s\n' "$reg_ids_all" | sed '/^\$/d' | sort -u || true)
+  # Same class: `/^\$/d` deleted lines consisting of a literal `$`, not empty lines.
+  reg_ids=$(printf '%s\n' "$reg_ids_all" | sed '/^$/d' | sort -u || true)
   disk_ids=$(find "$tree" -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' \
     -exec basename {} .md \; | sort || true)
 
@@ -239,7 +260,7 @@ registry_entry_set() { # <tree> <registry> <section key>
   # substring. With the detail indented under a header, an envelope asserting "the orphaned
   # entry is named" reported [WRONG-RED] against a check that was naming it correctly -- the
   # harness could not see it, so the case proved nothing either way.
-  local only_reg only_disk id
+  local only_reg only_disk
   only_reg=$(comm -23 <(printf '%s\n' "$reg_ids") <(printf '%s\n' "$disk_ids") || true)
   only_disk=$(comm -13 <(printf '%s\n' "$reg_ids") <(printf '%s\n' "$disk_ids") || true)
   if [ -n "$only_reg" ]; then
@@ -904,8 +925,9 @@ fi
 # That sentence used to end "the rest of this script is not [guarded]: #647 is the sweep, and
 # until it lands do not read this paragraph as covering A1-A10." #647 IS this commit, so both
 # halves were false on arrival. The whole file is now at zero unguarded sites --
-# `npm run check:bare-substitutions` reports 100 scanned / 0 UNGUARDED across all six tracked
-# shell scripts, against 30 on the parent commit -- and the rule at the top of this file, not
+# `npm run check:bare-substitutions` reports 0 UNGUARDED across all six tracked
+# shell scripts, against 30 unguarded on the commit that introduced the sweep -- and the rule at
+# the top of this file, not
 # this paragraph, is where the guard policy lives.
 echo "--- A11: Guide category render coverage ---"
 a11_fail=0


### PR DESCRIPTION
## The gap

A4 and A5 compared `total_agents` / `total_teams` against a `find` count and nothing else. A count
is blind in two directions the generated READMEs are not, because they render from the entry **list**
rather than the number:

- add `agents/foo.md` with valid frontmatter, bump `total_agents`, add no `- id: foo` → A1 green,
  A4 green, and the agent appears in **no generated index**;
- add one file and remove another in the same commit → the number is identical while both sides
  changed.

A12 learned this for guides in #646 and named A4/A5 as the same gap in its own comment. This is that
reader for agents and teams, extracted into `registry_entry_set` rather than written twice — a
duplicated reader is what this repo keeps finding drifted.

## Three decisions worth stating

**Scoped to the section, not the whole file.** `agents/_registry.yml` also carries a
`default_skills:` list; an unscoped `- id:` grep would silently widen the set the day one of those
gains an id.

**Duplicates checked before `sort -u`.** Uniquing first collapses a duplicate and lets the set still
equal disk — two entries pointing at one file, forgiven by the very check meant to pair them 1:1.

**Fail-closed on an empty extraction.** Comparing an empty set against disk would report all 75 files
as missing: loud, but for the wrong reason, and the next reader "fixes" the registry. It names
pattern drift instead.

## One `FAIL:` per discrepancy — measured, not stylistic

The first version printed one header FAIL and listed the ids beneath it. `gate-envelope.js` kills a
case only when a **single line** contains both `FAIL` and the expected substring, so it reported:

```
[WRONG-RED] A4: … the orphaned ENTRY is named — gate failed but no FAIL line
            contained "only in registry (no file): r-developer-typo"
```

…against a check that was naming every id correctly. The harness could not see the evidence, so the
case proved nothing in either direction. Putting the id on the FAIL line is better output and
observable evidence at once.

## Acceptance criteria

- [x] A4 compares the entry set against `agents/*.md`, **both directions**, reporting which side each
      discrepancy is on
- [x] A5 does the same for teams
- [x] Extraction is fail-closed — an empty extraction is a FAIL naming pattern drift
- [x] A must-go-red for each direction, through the envelope against `bash scripts/validate-integrity.sh`
- [x] `bash scripts/validate-integrity.sh` stays green on a clean tree

```console
$ node scripts/gate-envelope.js --spec scripts/envelopes/a4-a5-registry-entry-sets.mjs
[KILLED]   A4: an agent id is renamed — the orphaned ENTRY is named
           FAIL: agents/_registry.yml: only in registry (no file): r-developer-typo -- expected agents/r-developer-typo.md
[KILLED]   A4: an agent id is renamed — the unreferenced FILE is named
           FAIL: agents: only on disk (no registry entry): r-developer -- it renders in no generated index
[KILLED]   A5: a team id is renamed — the set comparison fires for teams too
[KILLED]   A4: two entries sharing one id are caught before sort -u collapses them
[KILLED]   A4: a drifted section key reports pattern drift, not 75 missing files

gate-envelope: 5 killed of 5 case(s).
```

Every mutation is an id **rename**, deliberately: it leaves the entry count untouched, so the count
check stays green and only the set check can fire — #648's scenario exactly, reproduced without
touching the totals. Cases 1 and 2 apply the same mutation and assert different halves of the output,
because "reports which side each discrepancy is on" is two claims; a check printing only
`only on disk` would satisfy a single-expect case while leaving the orphaned entry unnamed.

## Other verification

```
bash scripts/validate-integrity.sh          PASSED, 3 pre-existing warnings
  OK: 75 agents on disk match total_agents and the registry entry set
  OK: 22 teams on disk match total_teams and the registry entry set
node --test scripts/test/*.test.js          491 pass, 0 fail
node scripts/check-bare-substitutions.js    0 UNGUARDED  (finding 2 of the issue)
```

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)