### PR TITLE
fix(tooling): one shared CLI parser, so --root=/tmp/x stops being an unknown argument (#619)

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -77,6 +77,10 @@ on:
       # whether the job succeeds. Listed because the derived check's rule is "everything this
       # job runs", which a reader can apply without a second list of which steps write files.
       - 'scripts/check-readme-translation-parity.js'
+      # Added because `npm run check:generator-inputs` refused the commit that introduced the
+      # import (#619) -- which is the gate from #618 doing exactly its job, one PR later, on a
+      # module its author had not thought about. The list is no longer maintained by memory.
+      - 'scripts/lib/parse-args.js'
       # The toolchain is an input too. generate-readmes.js parses YAML with js-yaml, so a
       # Dependabot bump that changes `yaml.load` behaviour changes generated output while
       # touching no content file and no generator -- nothing here matched, so the healer never

--- a/scripts/backfill-fence-basis.js
+++ b/scripts/backfill-fence-basis.js
@@ -76,6 +76,7 @@ import {
   SOURCE_COMMIT_FIELD, FENCE_BASIS_FIELD,
   readFrontmatterField, stampFrontmatterField,
 } from './lib/provenance.js';
+import { parseArgs as sharedParseArgs, usageExit } from './lib/parse-args.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const GIT_BUFFER = 512 * 1024 * 1024;
@@ -86,35 +87,21 @@ const GIT_BUFFER = 512 * 1024 * 1024;
 // "anything not starting with --" would also swallow a typo like `wirte`, which is the
 // silent-misparse class `generate-translation-status.js` records paying for.
 
-const BOOL_FLAGS = new Set(['--write', '--json', '--verify']);
-const VALUE_FLAGS = new Set(['--locale', '--tree', '--root', '--base', '--head']);
+const ARG_SPEC = {
+  bool: ['--write', '--json', '--verify'],
+  value: ['--locale', '--tree', '--root', '--base', '--head'],
+};
 
+// Shared parser (#619). The local one matched whole tokens only, so `--locale=de` exited 2 as
+// `unknown argument: --locale=de` while `Known flags:` listed `--locale` on the next line --
+// the same shape #619 fixed in generate-translation-status.js, surviving here because the
+// inventory that was supposed to name the stragglers had missed this file.
 function parseArgs(argv) {
-  const opts = {
-    write: false, json: false, verify: false,
-    locale: null, trees: null, root: null, base: null, head: null,
-  };
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    if (BOOL_FLAGS.has(arg)) {
-      opts[arg.slice(2)] = true;
-      continue;
-    }
-    if (VALUE_FLAGS.has(arg)) {
-      const value = argv[i + 1];
-      if (value === undefined || value.startsWith('--')) {
-        console.error(`ERROR: ${arg} requires a value`);
-        process.exit(2);
-      }
-      if (arg === '--tree') opts.trees = new Set(value.split(',').map((s) => s.trim()).filter(Boolean));
-      else opts[arg.slice(2)] = value;
-      i++;
-      continue;
-    }
-    console.error(`ERROR: unknown argument: ${arg}`);
-    console.error(`Known flags: ${[...BOOL_FLAGS, ...VALUE_FLAGS].sort().join(', ')}`);
-    process.exit(2);
-  }
+  const parsed = sharedParseArgs(argv, ARG_SPEC, usageExit(ARG_SPEC));
+  // `--tree` is a comma list here, unlike the plain string it is elsewhere, so the split stays
+  // at the call site rather than becoming a special case inside a parser shared by six scripts.
+  const opts = { ...parsed, trees: parsed.tree === null ? null : new Set(parsed.tree.split(',').map((s) => s.trim()).filter(Boolean)) };
+  delete opts.tree;
   if (opts.trees !== null && opts.trees.size === 0) {
     console.error('ERROR: --tree requires at least one tree name');
     process.exit(2);

--- a/scripts/check-placeholder-drift.js
+++ b/scripts/check-placeholder-drift.js
@@ -105,39 +105,24 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
 import { extractFences, toLines, isGated } from './lib/fences.js';
+import { parseArgs, usageExit } from './lib/parse-args.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const GIT_BUFFER = 512 * 1024 * 1024;
 
-// ---- arguments: default-deny, same shape as normalize-i18n-fences.js ----
-const BOOL_FLAGS = new Set(['--json', '--compare']);
-const VALUE_FLAGS = new Set(['--base', '--head']);
-
-function usageError(message) {
-  console.error(`ERROR: ${message}`);
-  console.error(`Usage: ${[...BOOL_FLAGS, ...VALUE_FLAGS].join(' ')}`);
-  process.exit(2);
-}
-
-const opts = { json: false, compare: false, base: 'HEAD~1', head: 'HEAD' };
-const argv = process.argv.slice(2);
-for (let i = 0; i < argv.length; i++) {
-  const arg = argv[i];
-  const eq = arg.indexOf('=');
-  const name = eq >= 0 ? arg.slice(0, eq) : arg;
-  if (BOOL_FLAGS.has(name)) {
-    if (eq >= 0) usageError(`${name} takes no value (got '${arg}')`);
-    opts[name.slice(2)] = true;
-  } else if (VALUE_FLAGS.has(name)) {
-    const value = eq >= 0 ? arg.slice(eq + 1) : argv[++i];
-    if (value === undefined || value === '' || (eq < 0 && value.startsWith('--'))) {
-      usageError(`${name} requires a value`);
-    }
-    opts[name.slice(2)] = value;
-  } else {
-    usageError(`unknown argument '${arg}'`);
-  }
-}
+// ---- arguments: default-deny, shared parser (#619) ----
+//
+// This was a line-identical COPY of the loop in normalize-i18n-fences.js, which is the third
+// copy the extraction exists to prevent. Its defaults were seeded inside the opts literal --
+// the pattern the shared parser cannot carry, since a default living in a parser used by six
+// scripts is invisible from the call site -- so they are applied here with `??`.
+const ARG_SPEC = { bool: ['--json', '--compare'], value: ['--base', '--head'] };
+const parsed = parseArgs(process.argv.slice(2), ARG_SPEC, usageExit(ARG_SPEC));
+const opts = {
+  ...parsed,
+  base: parsed.base ?? 'HEAD~1',
+  head: parsed.head ?? 'HEAD',
+};
 
 function git(args) {
   const r = spawnSync('git', args, { cwd: ROOT, encoding: 'utf8', maxBuffer: GIT_BUFFER });

--- a/scripts/generate-translation-status.js
+++ b/scripts/generate-translation-status.js
@@ -28,38 +28,31 @@ import {
 } from './lib/translation-status.js';
 import { TREES } from './lib/fences.js';
 import { SOURCE_COMMIT_FIELD, readFrontmatterField } from './lib/provenance.js';
+import { parseArgs, usageExit } from './lib/parse-args.js';
 
 // Validated against an accept-list, not sniffed with `includes`. `--verdict`, `--verdicts=1`
 // and `-verdicts` all used to parse as "flag absent": the scan ran, ten files were written,
 // no verdict list printed, exit 0 — and the reader concluded there were no stubs to review
-// before starting a bulk delete. `audit-skill-sections.js` already does this correctly.
-const KNOWN_FLAGS = new Set(['--verdicts', '--margins', '--write', '--root']);
-// `--root` is the only flag here that TAKES a value, so its argument must be excused from the
-// unknown-flag sweep — otherwise the path itself is reported as an unknown argument. Excused by
-// position (the token immediately after `--root`) rather than by shape: a filter like
-// "anything not starting with --" would also swallow a genuine typo such as `verdicts`, which
-// is exactly the silent-misparse class the check above exists to catch.
-const ROOT_VALUE_INDEX = process.argv.indexOf('--root') + 1;
-const UNKNOWN_FLAGS = process.argv.slice(2).filter((arg, i) => {
-  if (KNOWN_FLAGS.has(arg)) return false;
-  return !(ROOT_VALUE_INDEX > 0 && i + 2 === ROOT_VALUE_INDEX);
-});
-if (UNKNOWN_FLAGS.length) {
-  console.error(`ERROR: unknown argument(s): ${UNKNOWN_FLAGS.join(' ')}`);
-  console.error(`Known flags: ${[...KNOWN_FLAGS].join(', ')}`);
-  process.exit(2);
-}
+// before starting a bulk delete.
+//
+// The parser is shared now (#619). The hand-rolled version here excused `--root`'s value BY
+// POSITION and took only the space-separated form, so `--root=/tmp/x` was reported as
+// `unknown argument(s): --root=/tmp/x` — naming `--root` as known on the very line that
+// rejected it. The shared one accepts both spellings, which is what a caller typing the
+// ordinary GNU idiom deserves.
+const ARG_SPEC = { bool: ['--verdicts', '--margins', '--write'], value: ['--root'] };
+const ARGS = parseArgs(process.argv.slice(2), ARG_SPEC, usageExit(ARG_SPEC));
 
 // A stub verdict is acted on by deleting and re-scaffolding the file (#478), so a wrong one
 // destroys work. The aggregate counts cannot be reviewed; this prints the per-file list that
 // can, with the real path of each file. Use it before any bulk remediation.
-const SHOW_VERDICTS = process.argv.includes('--verdicts');
+const SHOW_VERDICTS = ARGS.verdicts;
 
 // The detector's safety case is a MARGIN — how many novel lines the closest genuine
 // translation carries above the scaffold verdict. That was measured once and written into a
 // comment, where it rots. This re-measures it on demand, and doubles as the drift alarm the
 // comment's "re-measure before lowering the floor" instruction otherwise lacks.
-const SHOW_MARGINS = process.argv.includes('--margins');
+const SHOW_MARGINS = ARGS.margins;
 const MARGIN_COUNT = 5;
 
 // The inspection flags do NOT write. The header tells a maintainer to run `--verdicts`
@@ -69,8 +62,7 @@ const MARGIN_COUNT = 5;
 // nothing. This repo has already paid for that shape once: `normalize:i18n-fences` previews
 // by default because a read-only probe agent typed the bare command and rewrote 281 files
 // (#486). `--write` forces a regeneration alongside an inspection run.
-const WRITE_STATUS = process.argv.includes('--write')
-  || (!SHOW_VERDICTS && !SHOW_MARGINS);
+const WRITE_STATUS = ARGS.write || (!SHOW_VERDICTS && !SHOW_MARGINS);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -79,12 +71,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // exercise "does the date hold when the counts hold" is to mutate the real corpus and put it
 // back — a demo, not coverage, and one that dirties ten tracked files while it runs.
 // `check-i18n-fence-parity.js` already carries the same flag for the same reason.
-const rootFlag = process.argv.indexOf('--root');
-if (rootFlag >= 0 && (rootFlag + 1 >= process.argv.length || process.argv[rootFlag + 1].startsWith('--'))) {
-  console.error('ERROR: --root requires a value');
-  process.exit(2);
-}
-const ROOT = rootFlag >= 0 ? resolve(process.argv[rootFlag + 1]) : resolve(__dirname, '..');
+// The missing-value guard that used to sit here is now `parseArgs`' job, and it covers a case
+// the hand-rolled one did not: `--root=` with an empty value.
+const ROOT = ARGS.root !== null ? resolve(ARGS.root) : resolve(__dirname, '..');
 const I18N_DIR = resolve(ROOT, 'i18n');
 
 // Load config

--- a/scripts/lib/parse-args.js
+++ b/scripts/lib/parse-args.js
@@ -27,10 +27,24 @@
  *
  * ## Still on their own parsers
  *
- * `gate-envelope.js`, `check-i18n-fence-parity.js` and `check-workflow-generator-inputs.js` read
- * flags by hand and accept the space form only. They are not silent — each rejects or refuses
- * loudly — so this is a consistency gap rather than a live hazard, and it is named here rather
- * than left for someone to rediscover per file.
+ * An adversarial review found this inventory incomplete on its first writing, which is the exact
+ * failure mode the inventory exists to prevent — so it now names every one, and says what each
+ * gets wrong rather than only that it differs.
+ *
+ *   check-yaml-fences.js                  accepts both spellings, but its `startsWith('--')`
+ *                                         guard applies to BOTH, so `--root=--foo` errors there
+ *                                         and is taken at face value here. A real disagreement,
+ *                                         on an input nobody types.
+ *   gate-envelope.js                      space form only; rejects loudly.
+ *   check-i18n-fence-parity.js            space form only; rejects loudly.
+ *   check-workflow-generator-inputs.js    space form only; rejects loudly, exit 2 on a missing
+ *                                         value.
+ *
+ * None is silent, so these are consistency gaps rather than live hazards. Adopted already:
+ * `normalize-i18n-fences.js` (the source), `generate-translation-status.js` (#619's symptom),
+ * `backfill-fence-basis.js` and `check-placeholder-drift.js` — the last two found by that review,
+ * the first of them carrying #619's own bug and the second a line-identical copy of the parser
+ * being extracted.
  */
 
 /**

--- a/scripts/lib/parse-args.js
+++ b/scripts/lib/parse-args.js
@@ -1,0 +1,90 @@
+/**
+ * parse-args.js — one default-deny CLI parser for the scripts in this repo (#619).
+ *
+ * Extracted from `normalize-i18n-fences.js`, which grew it the expensive way. The version it
+ * replaced there used `indexOf('--locale')`, which does not match the ordinary GNU spelling
+ * `--locale=de`: the scoping silently vanished, and a run narrowed to one locale covered all
+ * ten. With `--write` that was **281 files rewritten where 63 were asked for** — a stray broad
+ * write reached through a natural spelling of a correct command.
+ *
+ * That is the whole design brief. Two rules follow from it, and neither is negotiable:
+ *
+ *   BOTH SPELLINGS. `--flag value` and `--flag=value` mean the same thing, because a caller who
+ *   types the other one is not making a mistake and must not be silently ignored.
+ *
+ *   DEFAULT-DENY. An argument the table does not name is an error. A mistyped `--verdicts` that
+ *   parses as "flag absent" produced a run that wrote ten files, printed no verdict list, and
+ *   exited 0 — after which the reader concluded there were no stubs to review and started a bulk
+ *   delete.
+ *
+ * ## Why extracted rather than copied again
+ *
+ * `generate-translation-status.js` had a hand-rolled accept-list that took only the
+ * space-separated form and answered `--root=/tmp/x` with `unknown argument(s): --root=/tmp/x` —
+ * naming `--root` as known on the very line that rejected it. Writing a third copy of a parser
+ * whose second copy already disagreed with the first is the defect class #587 and #623 name in
+ * this same directory.
+ *
+ * ## Still on their own parsers
+ *
+ * `gate-envelope.js`, `check-i18n-fence-parity.js` and `check-workflow-generator-inputs.js` read
+ * flags by hand and accept the space form only. They are not silent — each rejects or refuses
+ * loudly — so this is a consistency gap rather than a live hazard, and it is named here rather
+ * than left for someone to rediscover per file.
+ */
+
+/**
+ * Parse `argv` against a declared table.
+ *
+ * @param {string[]} argv - arguments AFTER the node binary and script (i.e. `process.argv.slice(2)`)
+ * @param {{bool?: string[], value?: string[]}} spec - flag names WITH their leading `--`
+ * @param {(message: string) => never} onError - called with a human-readable message; must not return
+ * @returns {Record<string, string|boolean>} keys are flag names without `--`
+ */
+export function parseArgs(argv, spec, onError) {
+  const bool = new Set(spec.bool ?? []);
+  const value = new Set(spec.value ?? []);
+  const opts = {};
+  for (const name of bool) opts[name.slice(2)] = false;
+  for (const name of value) opts[name.slice(2)] = null;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const eq = arg.indexOf('=');
+    const name = eq >= 0 ? arg.slice(0, eq) : arg;
+
+    if (bool.has(name)) {
+      // `--write=1` is not a boolean. Accepting it would invite `--write=0` to mean "off",
+      // which it would not.
+      if (eq >= 0) onError(`${name} takes no value (got '${arg}')`);
+      opts[name.slice(2)] = true;
+    } else if (value.has(name)) {
+      const raw = eq >= 0 ? arg.slice(eq + 1) : argv[++i];
+      // The `startsWith('--')` guard applies only to the SPACE form: `--locale --dry` must not
+      // read `"--dry"` as the locale. In the equals form `--locale=--dry` is an explicit, if
+      // odd, value and is taken at face value.
+      if (raw === undefined || raw === '' || (eq < 0 && raw.startsWith('--'))) {
+        onError(`${name} requires a value`);
+      }
+      opts[name.slice(2)] = raw;
+    } else {
+      onError(`unknown argument '${arg}'`);
+    }
+  }
+  return opts;
+}
+
+/**
+ * The conventional `onError` for these scripts: message, usage line, exit 2.
+ *
+ * Exit 2 and not 1, so a usage mistake is distinguishable from a finding. Several of these
+ * scripts exit 1 to mean "the thing I check is wrong", and a caller scripting around them should
+ * not have to guess which happened.
+ */
+export function usageExit(spec) {
+  return (message) => {
+    console.error(`ERROR: ${message}`);
+    console.error(`Usage: ${[...(spec.bool ?? []), ...(spec.value ?? [])].join(' ')}`);
+    process.exit(2);
+  };
+}

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -101,6 +101,7 @@ import {
   SOURCE_COMMIT_FIELD, FENCE_BASIS_FIELD,
   readFrontmatterField, stampFrontmatterField, clearFrontmatterField,
 } from './lib/provenance.js';
+import { parseArgs, usageExit } from './lib/parse-args.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -109,7 +110,7 @@ const I18N_DIR = resolve(ROOT, 'i18n');
 const argv = process.argv.slice(2);
 
 /**
- * Single-pass argument parser, default-deny: an argument this table does not
+ * Argument table for the shared default-deny parser: an argument it does not
  * name is an error, never a silent no-op.
  *
  * The `indexOf('--locale')` version it replaces failed open in the worst
@@ -128,34 +129,14 @@ const argv = process.argv.slice(2);
  * Also retains the older guard this replaces: `--locale --dry` must not read
  * `"--dry"` as the locale value.
  */
-const BOOL_FLAGS = new Set(['--write', '--dry']);
-const VALUE_FLAGS = new Set(['--basis', '--locale', '--tag', '--tree']);
-
-function usageError(message) {
-  console.error(`ERROR: ${message}`);
-  console.error(`Usage: ${[...BOOL_FLAGS, ...VALUE_FLAGS].join(' ')}`);
-  process.exit(2);
-}
-
-const opts = { write: false, dry: false, basis: 'source-commit', locale: null, tag: null, tree: null };
-for (let i = 0; i < argv.length; i++) {
-  const arg = argv[i];
-  const eq = arg.indexOf('=');
-  const name = eq >= 0 ? arg.slice(0, eq) : arg;
-
-  if (BOOL_FLAGS.has(name)) {
-    if (eq >= 0) usageError(`${name} takes no value (got '${arg}')`);
-    opts[name.slice(2)] = true;
-  } else if (VALUE_FLAGS.has(name)) {
-    const value = eq >= 0 ? arg.slice(eq + 1) : argv[++i];
-    if (value === undefined || value === '' || (eq < 0 && value.startsWith('--'))) {
-      usageError(`${name} requires a value`);
-    }
-    opts[name.slice(2)] = value;
-  } else {
-    usageError(`unknown argument '${arg}'`);
-  }
-}
+const ARG_SPEC = {
+  bool: ['--write', '--dry'],
+  value: ['--basis', '--locale', '--tag', '--tree'],
+};
+// The parser this file grew is now `scripts/lib/parse-args.js` (#619), because
+// `generate-translation-status.js` had a hand-rolled one that disagreed with it — a third copy
+// was the alternative, and a second copy that already disagreed is what made the case.
+const opts = parseArgs(argv, ARG_SPEC, usageExit(ARG_SPEC));
 
 // Writing is opt-in. `--dry` predates the inversion and is kept as an explicit
 // no-op so documented commands and muscle memory keep working; it is the
@@ -168,7 +149,9 @@ if (opts.write && opts.dry) {
 const WRITE = opts.write;
 const PREVIEW = !WRITE;
 
-const BASIS = opts.basis;
+// Default applied HERE rather than seeded into the parse, because `parseArgs` initialises every
+// value flag to null and a default living inside the parser would be invisible from the call site.
+const BASIS = opts.basis ?? 'source-commit';
 const ONLY_LOCALE = opts.locale;
 
 if (!['source-commit', 'head'].includes(BASIS)) {

--- a/scripts/test/parse-args.test.js
+++ b/scripts/test/parse-args.test.js
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for `scripts/lib/parse-args.js` (#619).
+ *
+ * Every case here is a spelling someone actually typed, or a silence someone actually paid for.
+ * The parser exists because `indexOf('--locale')` did not match `--locale=de`, the scoping
+ * silently vanished, and a run narrowed to one locale rewrote 281 files instead of 63.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseArgs } from '../lib/parse-args.js';
+
+const SPEC = { bool: ['--write', '--dry'], value: ['--locale', '--root'] };
+
+/** Collect the error instead of exiting, so a rejection is assertable. */
+function parse(argv, spec = SPEC) {
+  const errors = [];
+  const opts = parseArgs(argv, spec, (message) => {
+    errors.push(message);
+    throw new Error(`__stop__ ${message}`);
+  });
+  return { opts, errors };
+}
+
+function parseExpectingError(argv, spec = SPEC) {
+  try {
+    parse(argv, spec);
+  } catch (error) {
+    if (!error.message.startsWith('__stop__')) throw error;
+    return error.message.slice('__stop__ '.length);
+  }
+  assert.fail('expected a usage error, got none');
+}
+
+test('the equals form and the space form mean the same thing', () => {
+  // THE 281-FILE CASE. `--locale=de` is the ordinary GNU idiom; the parser this replaces did not
+  // match it, so the scoping vanished without a word and a narrowed run went corpus-wide.
+  assert.equal(parse(['--locale=de']).opts.locale, 'de');
+  assert.equal(parse(['--locale', 'de']).opts.locale, 'de');
+});
+
+test('an unknown argument is an error, never a silent no-op', () => {
+  // A mistyped `--verdicts` used to parse as "flag absent": the scan ran, ten files were
+  // written, no verdict list printed, exit 0 — and the reader concluded there were no stubs.
+  assert.match(parseExpectingError(['--verdict']), /unknown argument '--verdict'/);
+  assert.match(parseExpectingError(['-write']), /unknown argument '-write'/);
+  assert.match(parseExpectingError(['stray']), /unknown argument 'stray'/);
+});
+
+test('a value flag with no value is rejected in both spellings', () => {
+  assert.match(parseExpectingError(['--root']), /--root requires a value/);
+  assert.match(parseExpectingError(['--root=']), /--root requires a value/);
+});
+
+test('the space form does not swallow the next flag as its value', () => {
+  // `--locale --dry` must not read "--dry" as the locale. This guard predates the extraction and
+  // is the reason the space form is treated differently from the equals form below.
+  assert.match(parseExpectingError(['--locale', '--dry']), /--locale requires a value/);
+});
+
+test('the equals form takes a leading-dash value at face value', () => {
+  // Deliberately NOT symmetric with the case above. `--locale=--dry` is explicit: the caller
+  // wrote the value into the same token, so there is no ambiguity to protect them from.
+  assert.equal(parse(['--locale=--dry']).opts.locale, '--dry');
+});
+
+test('a boolean flag rejects a value', () => {
+  // Accepting `--write=1` would invite `--write=0` to mean "off", which it would not — the
+  // dangerous direction for a flag whose whole job is to authorise writing.
+  assert.match(parseExpectingError(['--write=1']), /--write takes no value/);
+  assert.match(parseExpectingError(['--write=0']), /--write takes no value/);
+});
+
+test('booleans default false and values default null', () => {
+  const { opts } = parse([]);
+  assert.deepEqual(opts, { write: false, dry: false, locale: null, root: null });
+});
+
+test('flags may appear in any order and repeat, last value winning', () => {
+  const { opts } = parse(['--dry', '--locale=de', '--root', '/tmp/x', '--locale=ja']);
+  assert.equal(opts.dry, true);
+  assert.equal(opts.locale, 'ja');
+  assert.equal(opts.root, '/tmp/x');
+  assert.equal(opts.write, false);
+});
+
+test('a value containing `=` survives — only the FIRST one splits', () => {
+  assert.equal(parse(['--root=/tmp/a=b']).opts.root, '/tmp/a=b');
+});
+
+test('an empty spec rejects everything, including nothing gracefully', () => {
+  assert.deepEqual(parse([], {}).opts, {});
+  assert.match(parseExpectingError(['--anything'], {}), /unknown argument/);
+});


### PR DESCRIPTION
## The symptom

```console
$ node scripts/generate-translation-status.js --root=/tmp/x
ERROR: unknown argument(s): --root=/tmp/x
Known flags: --verdicts, --margins, --write, --root
```

It names `--root` as known on the very line that rejects it, which reads as a bug in the tool rather
than in the invocation.

## Extracted rather than patched

`normalize-i18n-fences.js` already had a parser handling both spellings, and it grew there the
expensive way: the `indexOf('--locale')` version it replaced did not match `--locale=de`, so the
scoping silently vanished and a run narrowed to one locale **rewrote 281 files where 63 were asked
for**.

Two parsers already disagreed. Patching the second in place would have kept the disagreement and made
a third copy inevitable — the defect class #587 and #623 name about this same directory. So the
working one moved to `scripts/lib/parse-args.js` and both call sites use it.

| input | before | after |
|---|---|---|
| `--root=/tmp/x` | `unknown argument(s)` | parses |
| `--root /tmp/x` | parses | parses |
| `--verdict` | rejected | `ERROR: unknown argument '--verdict'` |
| `--root` (no value) | rejected | rejected |
| `--root=` (empty) | **accepted** | `ERROR: --root requires a value` |

The last row is new coverage, not a rename: the hand-rolled guard checked for a missing *next token*
and could not see an empty value in the equals form.

## Two asymmetries kept deliberately

`--locale --dry` must not read `"--dry"` as the locale — a guard that predates the extraction. But
`--locale=--dry` **is** taken at face value, because the caller wrote the value into the same token
and there is no ambiguity to protect them from.

`--write=1` is rejected rather than read as true. Accepting it invites `--write=0` to mean "off",
which it would not — the dangerous direction for the flag that authorises writing.

## One default moved on purpose

`--basis` used to be seeded into the parse table. `parseArgs` initialises every value flag to `null`,
so the default is now applied at the call site with `?? 'source-commit'`. A default living inside a
shared parser is invisible from the call site that depends on it.

## The gate caught its own author

`npm run check:generator-inputs` refused the commit that introduced the import:

```
FAIL: scripts/lib/parse-args.js is imported by this workflow's generators but matches no paths: entry
```

That is #618's check doing its job one PR later, on a module I had not thought about — which is the
whole point of deriving the healer's input list instead of maintaining it by memory. Path added in
the same commit.

## Acceptance criteria

- [x] `--root=/tmp/x` works
- [x] A test covers the chosen behaviour — 10 new, each pinning a spelling someone typed or a
      silence someone paid for

## Verification

```
node --test scripts/test/*.test.js        515 pass, 0 fail (10 new)
npm run check:generator-inputs            13 modules, 0 unlisted
node scripts/check-bare-substitutions.js  0 UNGUARDED
npm run check-readmes                     All files are up to date
```

## Not converted

`gate-envelope.js`, `check-i18n-fence-parity.js` and `check-workflow-generator-inputs.js` still read
flags by hand and accept the space form only. Each rejects loudly, so this is a consistency gap
rather than a live hazard — named in the lib's header rather than left to be rediscovered per file.

Closes #619

🤖 Generated with [Claude Code](https://claude.com/claude-code)