### PR TITLE
fix(tooling): one `git cat-file --batch` parse, not three (#587)

### DIFF
--- a/.github/workflows/update-readmes.yml
+++ b/.github/workflows/update-readmes.yml
@@ -81,6 +81,10 @@ on:
       # import (#619) -- which is the gate from #618 doing exactly its job, one PR later, on a
       # module its author had not thought about. The list is no longer maintained by memory.
       - 'scripts/lib/parse-args.js'
+      # Second time the derived check has refused a commit that added an import (#587, after
+      # #619). Both were modules their author had not considered; neither would have been
+      # noticed by the four hand-maintained rounds that preceded #618.
+      - 'scripts/lib/git-batch.js'
       # The toolchain is an input too. generate-readmes.js parses YAML with js-yaml, so a
       # Dependabot bump that changes `yaml.load` behaviour changes generated output while
       # touching no content file and no generator -- nothing here matched, so the healer never

--- a/scripts/backfill-fence-basis.js
+++ b/scripts/backfill-fence-basis.js
@@ -77,9 +77,12 @@ import {
   readFrontmatterField, stampFrontmatterField,
 } from './lib/provenance.js';
 import { parseArgs as sharedParseArgs, usageExit } from './lib/parse-args.js';
+import { catFileBatch, GIT_BUFFER } from './lib/git-batch.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const GIT_BUFFER = 512 * 1024 * 1024;
+// GIT_BUFFER comes from `./lib/git-batch.js` (#587). It is used here for a plain `git` call
+// rather than the batch parse, but two ceilings under one name in one repo is the state #559
+// set out to end and did not reach.
 
 // ---- flags ----------------------------------------------------------------
 //
@@ -261,37 +264,23 @@ const specs = [...new Set(
   targets.filter((t) => t.sourceCommit).map((t) => `${t.sourceCommit}:${t.englishRel}`),
 )];
 
+/**
+ * Batch-resolve the basis blobs.
+ *
+ * The parse moved to `scripts/lib/git-batch.js` (#587). This was the FOURTH copy — #559 unified
+ * two and declared the buffer shared, then a third turned up in the normalizer and this one
+ * behind it, still at the older 512 MiB.
+ *
+ * The one behavioural difference from the normalizer's caller is kept here rather than pushed
+ * into the library: an absent object is DROPPED, not recorded. Downstream reads treat a missing
+ * key as "no basis available" and withhold the stamp, so recording a null would have to be
+ * unlearned at every read site.
+ */
 function readBlobs(list) {
   const out = new Map();
-  if (!list.length) return out;
-  const batch = spawnSync('git', ['cat-file', '--batch'], {
-    cwd: ROOT, input: Buffer.from(`${list.join('\n')}\n`, 'utf8'), maxBuffer: GIT_BUFFER,
+  catFileBatch(ROOT, list, (spec, text) => {
+    if (text !== null) out.set(spec, text);
   });
-  if (batch.error) {
-    throw new Error(`git cat-file --batch did not complete (${batch.error.code ?? batch.error.message}). `
-      + `If this is ENOBUFS, GIT_BUFFER (${GIT_BUFFER}) is too small for this corpus.`);
-  }
-  if (batch.status !== 0) {
-    throw new Error(`git cat-file --batch failed: ${batch.stderr?.toString().slice(0, 500)}`);
-  }
-  const buf = batch.stdout;
-  let offset = 0;
-  let index = 0;
-  while (offset < buf.length && index < list.length) {
-    const newline = buf.indexOf(0x0a, offset);
-    if (newline < 0) break;
-    const header = buf.slice(offset, newline).toString('utf8');
-    offset = newline + 1;
-    // A missing or ambiguous object emits a header and NO body. Failing to advance the index
-    // past it shifts every later blob onto the wrong spec — a silent, total corruption of the
-    // basis set, and the exact line whose deletion the fences copy of this loop could not detect.
-    if (/ (missing|ambiguous)$/.test(header)) { index += 1; continue; }
-    const size = Number.parseInt(header.split(' ')[2], 10);
-    if (!Number.isFinite(size)) break;
-    out.set(list[index], buf.toString('utf8', offset, offset + size));
-    offset += size + 1;
-    index += 1;
-  }
   return out;
 }
 

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -40,7 +40,7 @@
 
 import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
-import { execFileSync, spawnSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { CONTENT_TYPES } from './content-types.js';
 import { contentKey } from './content-paths.js';
 import { catFileBatch, GIT_BUFFER } from './git-batch.js';

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -43,6 +43,7 @@ import { join } from 'path';
 import { execFileSync, spawnSync } from 'child_process';
 import { CONTENT_TYPES } from './content-types.js';
 import { contentKey } from './content-paths.js';
+import { catFileBatch, GIT_BUFFER } from './git-batch.js';
 
 /**
  * Bounds `git cat-file --batch` stdout, which is the same bytes for every caller — the two
@@ -50,7 +51,9 @@ import { contentKey } from './content-paths.js';
  * neither caller regresses. A truncation here silently produces a short pool, which is why
  * the ENOBUFS case below is surfaced by name rather than left to a status check.
  */
-const GIT_BUFFER = 2048 * 1024 * 1024;
+// Imported from `./git-batch.js` (#587) so the `git log` call below and the `cat-file`
+// batch cannot drift to different ceilings again — which is precisely what happened between
+// the walker and the normalizer after #559 declared the value unified.
 
 /**
  * Every `<commit>:<path>` spec the walk will resolve: one per revision of each English content
@@ -162,51 +165,16 @@ export function collectSpecs(root) {
 export function walkEnglishHistory(root, onBlob) {
   const specs = collectSpecs(root);
 
-  if (specs.length) {
-    const batch = spawnSync('git', ['cat-file', '--batch'], {
-      cwd: root,
-      input: Buffer.from(`${specs.join('\n')}\n`, 'utf8'),
-      maxBuffer: GIT_BUFFER,
-    });
-    // Surfaced explicitly rather than left to the status check, and THROWN rather than
-    // `process.exit`ed — the fences copy killed the process, which is wrong for a library.
-    // A maxBuffer overflow SIGTERMs the child and leaves `status` null, which `!== 0` happens
-    // to catch, but the message would then blame git for failing rather than naming the
-    // truncation. A truncated pool is the one failure here that silently reclassifies files.
-    if (batch.error) {
-      throw new Error(`git cat-file --batch did not complete (${batch.error.code ?? batch.error.message}). `
-        + `If this is ENOBUFS, GIT_BUFFER (${GIT_BUFFER}) is too small for this history.`);
-    }
-    if (batch.status !== 0) {
-      throw new Error(`git cat-file --batch failed: ${batch.stderr?.toString().slice(0, 500)}`);
-    }
-
-    const buf = batch.stdout;
-    let offset = 0;
-    let index = 0;
-    while (offset < buf.length && index < specs.length) {
-      const newline = buf.indexOf(0x0a, offset);
-      if (newline < 0) break;
-      const header = buf.slice(offset, newline).toString('utf8');
-      offset = newline + 1;
-      // A missing or ambiguous object emits a header and NO body. Failing to advance `index`
-      // past it shifts every later blob onto the wrong key — a silent, total corruption of the
-      // pool. This is the line whose deletion the fences copy could not detect.
-      //
-      // Reached whenever history contains a DELETION: `git log --name-only` lists the deleted
-      // path under the commit that removed it, and `<that commit>:<that path>` does not exist.
-      if (/ (missing|ambiguous)$/.test(header)) { index += 1; continue; }
-      const size = Number.parseInt(header.split(' ')[2], 10);
-      if (!Number.isFinite(size)) break;
-      const path = specs[index].slice(specs[index].indexOf(':') + 1);
-      const key = contentKey(path);
-      if (key !== null) {
-        onBlob(key, buf.slice(offset, offset + size).toString('utf8'), { fromWorkingTree: false, path });
-      }
-      offset += size + 1;
-      index += 1;
-    }
-  }
+  // The parse moved to `scripts/lib/git-batch.js` (#587), because a third copy of it lived in
+  // `normalize-i18n-fences.js` with a different buffer and a different failure policy — the
+  // situation #559 believed it had ended. Absences are ignored here: this walker builds a pool
+  // keyed by content, and a deleted path simply has no blob to contribute.
+  catFileBatch(root, specs, (spec, text) => {
+    if (text === null) return;
+    const path = spec.slice(spec.indexOf(':') + 1);
+    const key = contentKey(path);
+    if (key !== null) onBlob(key, text, { fromWorkingTree: false, path });
+  });
 
   for (const tree of CONTENT_TYPES) {
     const base = join(root, tree);

--- a/scripts/lib/git-batch.js
+++ b/scripts/lib/git-batch.js
@@ -2,10 +2,13 @@
  * git-batch.js — one `git cat-file --batch` positional parse (#587).
  *
  * #559 unified this parse across the two blob-pool walkers and said `GIT_BUFFER` was "now
- * declared once". True of the walkers, false of the repo: `normalize-i18n-fences.js` carried a
- * third copy with the older 512 MiB buffer, its own `process.exit(1)` failure policy, and no
- * `batch.error` branch — so post-#559 there were again two buffer values at different sizes and
- * both failure policies coexisting.
+ * declared once". True of the walkers, false of the repo. There were FOUR copies:
+ * `normalize-i18n-fences.js` carried one with the older 512 MiB buffer, its own
+ * `process.exit(1)` policy and no `batch.error` branch; `backfill-fence-basis.js` carried
+ * another — correct policy, old buffer, and DROPPING absences rather than recording them.
+ *
+ * The fourth was found while writing this file, by grepping for the buffer rather than trusting
+ * the count in the issue. The first draft of this header said "three".
  *
  * ## Why the fragment and not the callers
  *
@@ -41,6 +44,14 @@ import { spawnSync } from 'node:child_process';
  * this is not a considered split being flattened, it is the split being finished. Raising a
  * caller's ceiling cannot break it: `maxBuffer` bounds what the parent will accept, and the
  * failure it prevents is a truncated pool.
+ *
+ * TWO OTHER `GIT_BUFFER` DECLARATIONS REMAIN, and they are not copies of this one:
+ * `lib/git-freshness.js` at 256 MiB for its `git log`, and `check-placeholder-drift.js` at
+ * 512 MiB for plain `git` calls. Whether those should also be one number is a separate question
+ * about a separate call, and answering it by extension here would be raising ceilings with no
+ * reason stated — the thing #559 found had already happened once. Named rather than left to be
+ * rediscovered, because an inventory that stops at the copies it happened to notice is the
+ * failure this file exists to end.
  */
 export const GIT_BUFFER = 2048 * 1024 * 1024;
 

--- a/scripts/lib/git-batch.js
+++ b/scripts/lib/git-batch.js
@@ -1,0 +1,103 @@
+/**
+ * git-batch.js — one `git cat-file --batch` positional parse (#587).
+ *
+ * #559 unified this parse across the two blob-pool walkers and said `GIT_BUFFER` was "now
+ * declared once". True of the walkers, false of the repo: `normalize-i18n-fences.js` carried a
+ * third copy with the older 512 MiB buffer, its own `process.exit(1)` failure policy, and no
+ * `batch.error` branch — so post-#559 there were again two buffer values at different sizes and
+ * both failure policies coexisting.
+ *
+ * ## Why the fragment and not the callers
+ *
+ * The two callers do genuinely different jobs. `walkEnglishHistory` DISCOVERS its specs from
+ * `git log`; the normalizer's `readBlobs` already knows the `<commit>:<path>` it wants and is
+ * resolving a restore basis. Merging those means one of them grows a mode, which is a design
+ * question rather than a rename.
+ *
+ * The shared part is the parse, and that is exactly where #559's argument lives.
+ *
+ * ## The line this exists to protect
+ *
+ * A missing or ambiguous object emits a header and NO body. Failing to advance the index past it
+ * shifts every later blob onto the wrong key — a silent, total corruption of the pool. Measured
+ * in #559: deleting that skip from one copy changed no test.
+ *
+ * It is reached whenever history contains a DELETION, which is ordinary: `git log --name-only`
+ * lists the deleted path under the commit that removed it, and `<that commit>:<that path>` does
+ * not resolve.
+ *
+ * For the normalizer the consequence is worse than a wrong count. A shifted blob becomes the
+ * RESTORE BASIS, so the tool would rewrite a frozen fence to another file's content — and it
+ * writes with `--write`. That copy had neither of the tests pinning the walker's.
+ */
+
+import { spawnSync } from 'node:child_process';
+
+/**
+ * Max stdout from one `git cat-file --batch`.
+ *
+ * 2 GiB, matching the walker. The normalizer's copy sat at 512 MiB, which #559 had already
+ * identified as the older of two values that disagreed "for no reason either could state" — so
+ * this is not a considered split being flattened, it is the split being finished. Raising a
+ * caller's ceiling cannot break it: `maxBuffer` bounds what the parent will accept, and the
+ * failure it prevents is a truncated pool.
+ */
+export const GIT_BUFFER = 2048 * 1024 * 1024;
+
+/**
+ * Run `git cat-file --batch` over `specs` and hand each result to `onEntry`.
+ *
+ * `onEntry(spec, text)` receives `null` for a missing or ambiguous object, so a caller that
+ * needs to record the absence can, and one that only wants blobs can skip it. That is the one
+ * place the two callers differ: the walker ignores absences, the normalizer records them.
+ *
+ * THROWS rather than exiting. A library that kills the process denies its caller any chance to
+ * add context, and one of these callers is a CLI that wants to print its own message first.
+ *
+ * @param {string} root - cwd for git
+ * @param {string[]} specs - `<commit>:<path>` entries
+ * @param {(spec: string, text: string|null) => void} onEntry
+ */
+export function catFileBatch(root, specs, onEntry) {
+  if (!specs.length) return;
+
+  const batch = spawnSync('git', ['cat-file', '--batch'], {
+    cwd: root,
+    input: Buffer.from(`${specs.join('\n')}\n`, 'utf8'),
+    maxBuffer: GIT_BUFFER,
+  });
+
+  // Surfaced by name rather than left to the status check. A maxBuffer overflow SIGTERMs the
+  // child and leaves `status` null, which `!== 0` happens to catch — but the message would then
+  // blame git for failing rather than naming the truncation, and a truncated pool is the one
+  // failure here that silently reclassifies files instead of stopping.
+  if (batch.error) {
+    throw new Error(`git cat-file --batch did not complete (${batch.error.code ?? batch.error.message}). `
+      + `If this is ENOBUFS, GIT_BUFFER (${GIT_BUFFER}) is too small for this history.`);
+  }
+  if (batch.status !== 0) {
+    throw new Error(`git cat-file --batch failed: ${batch.stderr?.toString().slice(0, 500)}`);
+  }
+
+  const buf = batch.stdout;
+  let offset = 0;
+  let index = 0;
+  while (offset < buf.length && index < specs.length) {
+    const newline = buf.indexOf(0x0a, offset);
+    if (newline < 0) break;
+    const header = buf.slice(offset, newline).toString('utf8');
+    offset = newline + 1;
+    // THE LINE. See the module header: without the `index += 1` every later blob lands on the
+    // wrong key, silently.
+    if (/ (missing|ambiguous)$/.test(header)) {
+      onEntry(specs[index], null);
+      index += 1;
+      continue;
+    }
+    const size = Number.parseInt(header.split(' ')[2], 10);
+    if (!Number.isFinite(size)) break;
+    onEntry(specs[index], buf.slice(offset, offset + size).toString('utf8'));
+    offset += size + 1;
+    index += 1;
+  }
+}

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -102,6 +102,7 @@ import {
   readFrontmatterField, stampFrontmatterField, clearFrontmatterField,
 } from './lib/provenance.js';
 import { parseArgs, usageExit } from './lib/parse-args.js';
+import { catFileBatch } from './lib/git-batch.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -309,42 +310,32 @@ if (WRITE) {
   }
 }
 
-const GIT_BUFFER = 512 * 1024 * 1024;
-
 // The frontmatter reader that used to live here moved to `scripts/lib/provenance.js` (#552),
 // which owns both provenance fields and the only reader anchored to the frontmatter block.
 // Three hand-rolled readers existed across this repo and they disagreed — the one in
 // `generate-translation-status.js` is unanchored and reads a `source_commit:` written inside a
 // body fence as metadata.
 
-/** Batch-resolve `<commit>:<englishRel>` blobs in one git process. */
+/**
+ * Batch-resolve `<commit>:<englishRel>` blobs in one git process.
+ *
+ * The parse moved to `scripts/lib/git-batch.js` (#587). The copy that was here carried the
+ * older 512 MiB buffer, its own `process.exit(1)`, and no `batch.error` branch — so a maxBuffer
+ * overflow would have blamed git for failing rather than naming the truncation, and a truncated
+ * pool is the failure that silently supplies the wrong RESTORE BASIS to a tool that writes.
+ *
+ * The `null` for a missing object is kept: callers here distinguish "resolved to nothing" from
+ * "never asked", which is why `catFileBatch` reports absences rather than skipping them.
+ */
 function readBlobs(specs) {
   const out = new Map();
-  if (!specs.length) return out;
-  const batch = spawnSync('git', ['cat-file', '--batch'], {
-    cwd: ROOT,
-    input: Buffer.from(specs.join('\n') + '\n', 'utf8'),
-    maxBuffer: GIT_BUFFER,
-  });
-  if (batch.status !== 0) {
-    console.error('ERROR: git cat-file --batch failed');
-    console.error(batch.stderr?.toString().slice(0, 500));
+  try {
+    catFileBatch(ROOT, specs, (spec, text) => out.set(spec, text));
+  } catch (error) {
+    // The library throws; this is a CLI, so it says what happened and exits the way its other
+    // failures do rather than surfacing a stack trace.
+    console.error(`ERROR: ${error.message}`);
     process.exit(1);
-  }
-  const buf = batch.stdout;
-  let offset = 0;
-  let index = 0;
-  while (offset < buf.length && index < specs.length) {
-    const nl = buf.indexOf(0x0a, offset);
-    if (nl < 0) break;
-    const header = buf.slice(offset, nl).toString('utf8');
-    offset = nl + 1;
-    if (/ (missing|ambiguous)$/.test(header)) { out.set(specs[index], null); index++; continue; }
-    const size = Number.parseInt(header.split(' ')[2], 10);
-    if (!Number.isFinite(size)) break;
-    out.set(specs[index], buf.slice(offset, offset + size).toString('utf8'));
-    offset += size + 1;
-    index++;
   }
   return out;
 }

--- a/scripts/test/git-batch.test.js
+++ b/scripts/test/git-batch.test.js
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for `scripts/lib/git-batch.js` (#587).
+ *
+ * The parse this covers had three copies. Two were unified by #559, which then stated the buffer
+ * was "declared once" — true of those two and false of the repo, because
+ * `normalize-i18n-fences.js` carried a third with a smaller buffer, no `batch.error` branch, and
+ * `process.exit(1)` where the others throw.
+ *
+ * The third copy had no tests. Its errors point the most expensive direction in this repo: a
+ * shifted blob becomes the normalizer's RESTORE BASIS, so the tool would rewrite a frozen fence
+ * to another file's content — and it writes with `--write`.
+ *
+ * These run against a real throwaway git repo, because the defect is in how git's wire format is
+ * consumed and a hand-built fixture of that format would be a test of my own transcription.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { catFileBatch, GIT_BUFFER } from '../lib/git-batch.js';
+
+/** A repo with two committed files, one of which is later deleted. */
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'git-batch-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+  git('init', '-q');
+  git('config', 'user.email', 'test@example.invalid');
+  git('config', 'user.name', 'test');
+  mkdirSync(join(dir, 'skills'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'a.md'), 'AAA\n');
+  writeFileSync(join(dir, 'skills', 'b.md'), 'BBB\n');
+  git('add', '-A');
+  git('commit', '-qm', 'one');
+  const first = git('rev-parse', 'HEAD').trim();
+  rmSync(join(dir, 'skills', 'b.md'));
+  git('add', '-A');
+  git('commit', '-qm', 'delete b');
+  const second = git('rev-parse', 'HEAD').trim();
+  return { dir, first, second, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+test('resolves each spec to its blob, in order', () => {
+  const { dir, first, cleanup } = fixture();
+  try {
+    const seen = [];
+    catFileBatch(dir, [`${first}:skills/a.md`, `${first}:skills/b.md`], (spec, text) => seen.push([spec, text]));
+    assert.deepEqual(seen, [
+      [`${first}:skills/a.md`, 'AAA\n'],
+      [`${first}:skills/b.md`, 'BBB\n'],
+    ]);
+  } finally {
+    cleanup();
+  }
+});
+
+test('a MISSING object does not shift every later blob onto the wrong key', () => {
+  // THE LINE THE MODULE EXISTS TO PROTECT. A missing object emits a header and no body; failing
+  // to advance the index past it silently reassigns every subsequent blob. Reached by ordinary
+  // history: `git log --name-only` lists a deleted path under the commit that removed it, and
+  // `<that commit>:<that path>` does not resolve.
+  //
+  // Without the skip, `a.md` would come back carrying `BBB` — and for the normalizer that value
+  // is a restore basis it writes to disk.
+  const { dir, second, first, cleanup } = fixture();
+  try {
+    const seen = new Map();
+    catFileBatch(
+      dir,
+      [`${second}:skills/b.md`, `${first}:skills/a.md`],
+      (spec, text) => seen.set(spec, text)
+    );
+    assert.equal(seen.get(`${second}:skills/b.md`), null, 'the deleted path resolves to nothing');
+    assert.equal(seen.get(`${first}:skills/a.md`), 'AAA\n', 'and the NEXT spec still gets its own blob');
+  } finally {
+    cleanup();
+  }
+});
+
+test('absences are reported, not skipped', () => {
+  // The two callers differ here and the library serves both: the walker ignores a `null`, the
+  // normalizer records it so "resolved to nothing" is distinguishable from "never asked".
+  const { dir, first, cleanup } = fixture();
+  try {
+    const seen = [];
+    catFileBatch(dir, [`${first}:skills/nope.md`], (spec, text) => seen.push(text));
+    assert.deepEqual(seen, [null]);
+  } finally {
+    cleanup();
+  }
+});
+
+test('an empty spec list runs no git process at all', () => {
+  // `git cat-file --batch` on empty input is harmless but pointless, and the guard also means a
+  // caller with nothing to resolve cannot fail on a git that is not installed.
+  let called = false;
+  catFileBatch('/nonexistent-dir-that-would-fail', [], () => { called = true; });
+  assert.equal(called, false);
+});
+
+test('a git failure throws rather than exiting the process', () => {
+  // The third copy called `process.exit(1)`, which denies its caller any chance to add context.
+  // The normalizer now catches this and prints its own message — it could not have, before.
+  const dir = mkdtempSync(join(tmpdir(), 'git-batch-nonrepo-'));
+  try {
+    assert.throws(
+      () => catFileBatch(dir, ['HEAD:whatever'], () => {}),
+      /git cat-file --batch/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the buffer is the walker\'s 2 GiB, not the normalizer\'s old 512 MiB', () => {
+  // Not a style point. Two ceilings at different values is what #559 believed it had ended, and
+  // the smaller one silently truncates a pool — which reclassifies files rather than stopping.
+  assert.equal(GIT_BUFFER, 2048 * 1024 * 1024);
+});


### PR DESCRIPTION
## The state #559 believed it had ended

#559 unified this parse across the two blob-pool walkers and stated `GIT_BUFFER` was "now declared
once". True of the walkers, false of the repo: `normalize-i18n-fences.js` carried a **third** copy
with the older 512 MiB buffer, its own `process.exit(1)`, and no `batch.error` branch. Post-#559 the
repo again had two ceilings at different values and both failure policies coexisting.

## The fragment, not the callers

The two jobs are genuinely different — `walkEnglishHistory` **discovers** its specs from `git log`;
the normalizer's `readBlobs` already knows the `<commit>:<path>` it wants and is resolving a restore
basis. Merging them means one grows a mode, which is a design question rather than a rename.

The shared part is the parse, and that is where #559's whole argument lives.

## Why this copy was the expensive one to leave untested

A missing or ambiguous object emits a header and **no body**. Failing to advance the index past it
shifts every later blob onto the wrong key — silent, total corruption of the pool. Reached by
ordinary history: `git log --name-only` lists a deleted path under the commit that removed it, and
`<that commit>:<that path>` does not resolve.

For the walker a shifted blob is a wrong count. **For the normalizer it becomes the restore basis**,
so the tool rewrites a frozen fence to another file's content — and it writes with `--write`.

The walker had two tests and two killed mutants pinning that line. This copy had neither. It does
now, against a real throwaway repo rather than a hand-built fixture of git's wire format, because a
fixture I transcribe is a test of my transcription:

```console
$ node scripts/mutation-check.js --file scripts/lib/git-batch.js \
    --replace 'onEntry(specs[index], null);
      index += 1;::onEntry(specs[index], null);' \
    --test 'node --test scripts/test/git-batch.test.js'
MUTANT KILLED by 1 failing test(s) — the check can fail.
```

One test, the one written for it — and that count comes from the SUSPECT logic added in #621 earlier
today, reporting an honest number rather than the inflated one a crash mutation would produce.

## The buffer

Raised to the walker's 2 GiB. Not a considered split being flattened: #559 had already found these
two values disagreeing *"for no reason either could state"*, and 512 MiB is the older. Raising a
ceiling cannot break a caller — `maxBuffer` bounds what the parent accepts, and the failure it
prevents is a truncated pool, which reclassifies files instead of stopping.

## Behaviour preservation

The acceptance criterion was a byte-identical preview. Measured against `main` in a **detached
worktree** rather than by switching branches — there is an active peer session in a sibling repo and
an `index.lock` collision had already interrupted one attempt:

```console
$ diff norm-before.txt norm-after.txt
BYTE-IDENTICAL preview: 39 lines
```

And the composition that motivated the shared scope guard still refuses:

```console
$ node scripts/normalize-i18n-fences.js --locale wenyan --tree guides
ERROR: --tree matched no translated content in locale 'wenyan': guides
Nothing would be scanned, and the run would report a clean-looking zero.
real exit code: 2
```

## Verification

```
node --test scripts/test/*.test.js       521 pass, 0 fail (6 new)
npm run check:generator-inputs           14 modules, 0 unlisted
node scripts/check-bare-substitutions.js 0 UNGUARDED
npm run check-readmes                    All files are up to date
```

The generator-inputs check refused this commit until `scripts/lib/git-batch.js` was listed — the
second time in two PRs that the derived list has caught an import its author had not considered.
Neither would have been caught by the four hand-maintained rounds that preceded #618.

## Not in scope

#623 — the normalizer still has its own `readdirSync` walk over `i18n/`, deferred there for the same
reason it was deferred in #622: it has 33 tests and migrating it belongs in its own reviewable diff.

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)