### PR TITLE
fix(tooling): migrate the normalizer's target walk onto the shared one (#623)

### DIFF
--- a/scripts/lib/i18n-targets.js
+++ b/scripts/lib/i18n-targets.js
@@ -72,6 +72,47 @@ export const I18N_TREES = CONTENT_TYPES.map((dir) => {
  *   localesReached: Set<string>, treesReached: Set<string>, localesPresent: string[],
  * }}
  */
+/**
+ * Does `<i18n>/<locale>/<tree>` exist as a directory?
+ *
+ * Directory-ness, not mere existence — the same test the walk applies one level down, so a file
+ * named like a tree cannot make a locale look scannable.
+ */
+export function hasTree(root, locale, tree) {
+  const path = join(resolve(root, 'i18n'), locale, tree);
+  return existsSync(path) && statSync(path).isDirectory();
+}
+
+/**
+ * Trees this repository actually carries translations for.
+ *
+ * A corpus-wide union, and that is its limit: it answers "does any locale have this tree", which
+ * stops being the scan's own list the moment `--locale` narrows the scan. `--tree` must NOT be
+ * validated against it — that is `validateScope`'s job, against `treesReached`. Kept because the
+ * dirty-check pathspec and the write scope need a tree list BEFORE the scan runs.
+ */
+export function presentTrees(root) {
+  const i18nDir = resolve(root, 'i18n');
+  if (!existsSync(i18nDir)) return [];
+  const locales = readdirSync(i18nDir);
+  return I18N_TREES.map(({ dir }) => dir).filter((tree) => locales.some((l) => hasTree(root, l, tree)));
+}
+
+/**
+ * Locales carrying at least one present tree.
+ *
+ * The `--locale` accept-list, and it has to be computable BEFORE the scan: rejecting an
+ * unreachable locale after a ~90s history build is a worse tool. `localesReached` from the walk
+ * is the stricter, content-based answer and is what `validateScope` uses; this is the cheap
+ * pre-scan one.
+ */
+export function scannableLocales(root) {
+  const i18nDir = resolve(root, 'i18n');
+  if (!existsSync(i18nDir)) return [];
+  const trees = presentTrees(root);
+  return readdirSync(i18nDir).filter((entry) => trees.some((tree) => hasTree(root, entry, tree)));
+}
+
 export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, withText = false }) {
   const i18nDir = resolve(root, 'i18n');
   const targets = [];

--- a/scripts/lib/i18n-targets.js
+++ b/scripts/lib/i18n-targets.js
@@ -59,19 +59,28 @@ export const I18N_TREES = CONTENT_TYPES.map((dir) => {
 });
 
 /**
- * Every translated file, richly described.
+ * The locale directories under `i18n/`, and the ONLY definition of that set.
  *
- * @param {object} opts
- * @param {string} opts.root repository root
- * @param {string|null} [opts.onlyLocale] restrict to one locale
- * @param {Set<string>|null} [opts.onlyTrees] restrict to these content trees
- * @param {boolean} [opts.withText] read each file (the callers that classify always do)
- * @returns {{
- *   targets: Array<{locale: string, tree: string, id: string, key: string, absPath: string,
- *                   english: string, englishRel: string, relPath: string, text?: string}>,
- *   localesReached: Set<string>, treesReached: Set<string>, localesPresent: string[],
- * }}
+ * `_config.yml`, `README.md` and `glossaries/` are not locales. Directory-ness is the test, plus
+ * the underscore convention the rest of the repo already uses.
+ *
+ * Extracted because the pre-scan guards below and the walk had DIFFERENT answers (#623 review):
+ * `scannableLocales` listed `i18n/` raw while the walk filtered `_`-prefixed entries and
+ * `glossaries`. That is the guard-proxy shape — validating a flag against something adjacent to
+ * the consumer's accept-list rather than against the list itself — and it is the specific defect
+ * `--locale wenyan --tree guides` was fixed for. With an `i18n/_wip/skills/` present,
+ * `--locale _wip` would have passed the guard, scanned nothing, and reported
+ * `files to change: 0` at exit 0, on a tool that writes.
  */
+export function localeDirs(root) {
+  const i18nDir = resolve(root, 'i18n');
+  if (!existsSync(i18nDir)) return [];
+  return readdirSync(i18nDir).filter((entry) => {
+    if (entry.startsWith('_') || entry === 'glossaries') return false;
+    return statSync(join(i18nDir, entry)).isDirectory();
+  });
+}
+
 /**
  * Does `<i18n>/<locale>/<tree>` exist as a directory?
  *
@@ -92,9 +101,7 @@ export function hasTree(root, locale, tree) {
  * dirty-check pathspec and the write scope need a tree list BEFORE the scan runs.
  */
 export function presentTrees(root) {
-  const i18nDir = resolve(root, 'i18n');
-  if (!existsSync(i18nDir)) return [];
-  const locales = readdirSync(i18nDir);
+  const locales = localeDirs(root);
   return I18N_TREES.map(({ dir }) => dir).filter((tree) => locales.some((l) => hasTree(root, l, tree)));
 }
 
@@ -107,26 +114,32 @@ export function presentTrees(root) {
  * pre-scan one.
  */
 export function scannableLocales(root) {
-  const i18nDir = resolve(root, 'i18n');
-  if (!existsSync(i18nDir)) return [];
   const trees = presentTrees(root);
-  return readdirSync(i18nDir).filter((entry) => trees.some((tree) => hasTree(root, entry, tree)));
+  return localeDirs(root).filter((entry) => trees.some((tree) => hasTree(root, entry, tree)));
 }
 
+/**
+ * Every translated file, richly described.
+ *
+ * @param {object} opts
+ * @param {string} opts.root repository root
+ * @param {string|null} [opts.onlyLocale] restrict to one locale
+ * @param {Set<string>|null} [opts.onlyTrees] restrict to these content trees
+ * @param {boolean} [opts.withText] read each file (the callers that classify always do)
+ * @returns {{
+ *   targets: Array<{locale: string, tree: string, id: string, key: string, absPath: string,
+ *                   english: string, englishRel: string, relPath: string, text?: string}>,
+ *   localesReached: Set<string>, treesReached: Set<string>, localesPresent: string[],
+ * }}
+ */
 export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, withText = false }) {
   const i18nDir = resolve(root, 'i18n');
   const targets = [];
   const localesReached = new Set();
   const treesReached = new Set();
 
-  const localesPresent = existsSync(i18nDir)
-    ? readdirSync(i18nDir).filter((entry) => {
-      // `_config.yml`, `README.md`, `glossaries/` are not locales. Directory-ness is the test,
-      // plus the underscore convention the rest of the repo already uses.
-      if (entry.startsWith('_') || entry === 'glossaries') return false;
-      return statSync(join(i18nDir, entry)).isDirectory();
-    })
-    : [];
+  // One definition, shared with the pre-scan guards above — see `localeDirs`.
+  const localesPresent = localeDirs(root);
 
   for (const locale of localesPresent) {
     for (const { dir: tree, nested } of I18N_TREES) {

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -88,7 +88,7 @@
  *   node scripts/normalize-i18n-fences.js --tree guides,agents  # restrict to trees
  */
 
-import { readFileSync, writeFileSync, readdirSync, existsSync, statSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
@@ -103,6 +103,7 @@ import {
 } from './lib/provenance.js';
 import { parseArgs, usageExit } from './lib/parse-args.js';
 import { catFileBatch } from './lib/git-batch.js';
+import { collectI18nTargets, presentTrees, scannableLocales } from './lib/i18n-targets.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -196,10 +197,9 @@ const tagOf = (fence) => (fence.lang === '' ? 'untagged' : fence.lang);
  * Membership in the scan's own list is the only formulation that cannot drift
  * from the scan.
  */
-const hasTree = (locale, tree) => {
-  const p = join(I18N_DIR, locale, tree);
-  return existsSync(p) && statSync(p).isDirectory();
-};
+// `hasTree`, `PRESENT_TREES` and `SCANNABLE_LOCALES` come from `./lib/i18n-targets.js` (#623),
+// so this file performs no `readdirSync` over `i18n/` at all and the pre-scan guards cannot drift
+// from the walk they gate.
 
 /**
  * Scoped to content trees, so the mirrors can be repaired as their own batch —
@@ -212,8 +212,7 @@ const hasTree = (locale, tree) => {
  * translations for would otherwise report the clean-looking zero both guards
  * exist to reject.
  */
-const PRESENT_TREES = TREES.filter((tree) =>
-  readdirSync(I18N_DIR).some((locale) => hasTree(locale, tree)));
+const PRESENT_TREES = presentTrees(ROOT);
 
 const ONLY_TREES = opts.tree === null ? null : new Set(
   opts.tree.split(',').map((t) => t.trim().toLowerCase()).filter((t) => t !== ''),
@@ -231,8 +230,7 @@ if (ONLY_TREES !== null && ONLY_TREES.size === 0) {
 // It is checked after the scan instead, against the trees the SCOPED run
 // actually visited — the same shape as `--tag`, and for the same reason.
 
-const SCANNABLE_LOCALES = readdirSync(I18N_DIR).filter((entry) =>
-  PRESENT_TREES.some((tree) => hasTree(entry, tree)));
+const SCANNABLE_LOCALES = scannableLocales(ROOT);
 
 if (ONLY_LOCALE && !SCANNABLE_LOCALES.includes(ONLY_LOCALE)) {
   console.error(`ERROR: --locale '${ONLY_LOCALE}' is not a translated locale under i18n/.`);
@@ -344,47 +342,45 @@ assertNotShallow(ROOT);
 const history = buildEnglishFenceHistory();
 
 // ---- gather targets ----
-const targets = [];
+//
+// The walk moved to `scripts/lib/i18n-targets.js` (#623). #622 extracted it because the gate and
+// this tool had each grown a copy and the copies had ALREADY DRIFTED on the two points that
+// decide whether a scoped run reaching nothing reports a clean zero or exits 2 — one recorded
+// its reached-trees before the `--tree` filter and one after (validating a filter against the
+// post-filter set is circular and always passes), and one checked `isFile` where the other
+// checked only `existsSync`. This file was left on its own copy there to keep a 3,415-file diff
+// auditable, which made the count 2 → 2 rather than 2 → 3.
+//
+// `SCANNABLE_LOCALES` and `PRESENT_TREES` stay: the `--locale` guard above fires BEFORE the scan
+// and needs them, and `gitStatus(...PRESENT_TREES)` and `WRITE_SCOPE` read them too. They select
+// the same targets the lib's own enumeration does — both only record a locale or tree once an
+// entry has passed every existence check — so this is a narrowing of what the walk decides, not
+// of what it returns.
+const collected = collectI18nTargets({
+  root: ROOT,
+  onlyLocale: ONLY_LOCALE,
+  onlyTrees: ONLY_TREES,
+  withText: true,
+});
+
+const targets = collected.targets.map((t) => ({
+  locale: t.locale,
+  tree: t.tree,
+  key: t.key,
+  // The lib calls it `absPath`; everything downstream here reads `path`. Renamed at the seam
+  // rather than in the lib, whose other two callers already use `absPath`.
+  path: t.absPath,
+  english: t.english,
+  englishRel: t.englishRel,
+  relPath: t.relPath,
+  text: t.text,
+  // Not the lib's job: it returns content, and provenance has its own reader. `readFrontmatterField`
+  // is the anchored one from #552 — the same call the old inline walk made.
+  sourceCommit: readFrontmatterField(t.text, SOURCE_COMMIT_FIELD),
+}));
+
 /** Trees the locale-scoped scan found translated content in, before `--tree`. */
-const treesInScope = new Set();
-for (const locale of SCANNABLE_LOCALES) {
-  if (ONLY_LOCALE && locale !== ONLY_LOCALE) continue;
-  for (const tree of PRESENT_TREES) {
-    if (!hasTree(locale, tree)) continue;
-    for (const entry of readdirSync(join(I18N_DIR, locale, tree))) {
-      // `skills/<id>/SKILL.md` for skills, `<tree>/<id>.md` for the mirrors.
-      // `contentKey` decides which names are content at all, so `_template.md`,
-      // `README.md` and `_registry.yml` fall out here rather than needing a
-      // second list that could drift from the checker's.
-      const englishRel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
-      const key = contentKey(englishRel);
-      if (key === null) continue;
-      const translated = join(I18N_DIR, locale, englishRel);
-      const english = join(ROOT, englishRel);
-      // `isFile`, not merely `existsSync`, matching the checker. For skills the
-      // entry is a directory and the file is `SKILL.md`, so existence alone was
-      // safe by construction; on the mirror branch the ENTRY is the file, and a
-      // directory named `foo.md` would reach readFileSync and kill the run with
-      // EISDIR where the checker skips it.
-      if (!existsSync(translated) || !statSync(translated).isFile()) continue;
-      if (!existsSync(english) || !statSync(english).isFile()) continue;
-      // Recorded BEFORE the `--tree` filter, so the accept-list describes what
-      // this locale-scoped run could have reached rather than what it selected.
-      // Collected after the existence checks, so it means "carries translated
-      // content" and not merely "has a directory of that name" — the same
-      // distinction the `--locale` guard turns on.
-      treesInScope.add(tree);
-      if (ONLY_TREES && !ONLY_TREES.has(tree)) continue;
-      const text = readFileSync(translated, 'utf8');
-      targets.push({
-        locale, tree, key, path: translated, english, englishRel,
-        relPath: `i18n/${locale}/${englishRel}`,
-        text,
-        sourceCommit: readFrontmatterField(text, SOURCE_COMMIT_FIELD),
-      });
-    }
-  }
-}
+const treesInScope = collected.treesReached;
 
 /**
  * Validate `--tree` against what the SCOPED scan actually reached, not against

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -88,12 +88,12 @@
  *   node scripts/normalize-i18n-fences.js --tree guides,agents  # restrict to trees
  */
 
-import { readFileSync, writeFileSync, existsSync, statSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
 import {
-  extractFences, toLines, isGated, buildEnglishFenceHistory, TREES, contentKey,
+  extractFences, toLines, isGated, buildEnglishFenceHistory,
   foldedTagSequence, compareTagSequence, mirrorsBasis,
 } from './lib/fences.js';
 import { assertNotShallow } from './lib/git-freshness.js';

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -89,7 +89,7 @@
  */
 
 import { readFileSync, writeFileSync } from 'fs';
-import { resolve, dirname, join } from 'path';
+import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
 import {
@@ -107,7 +107,6 @@ import { collectI18nTargets, presentTrees, scannableLocales } from './lib/i18n-t
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
-const I18N_DIR = resolve(ROOT, 'i18n');
 
 const argv = process.argv.slice(2);
 
@@ -232,6 +231,16 @@ if (ONLY_TREES !== null && ONLY_TREES.size === 0) {
 
 const SCANNABLE_LOCALES = scannableLocales(ROOT);
 
+// A missing `i18n/` used to crash here on `readdirSync`. The lib returns `[]` instead — correct
+// for a library, and a silent `files to change: 0` at exit 0 for a tool that writes. Refused
+// explicitly, because "there is nothing to repair" and "I am not looking at the corpus" must not
+// print the same thing.
+if (SCANNABLE_LOCALES.length === 0) {
+  console.error('ERROR: no translated locales found under i18n/.');
+  console.error('Nothing would be scanned, and the run would report a clean-looking zero.');
+  process.exit(2);
+}
+
 if (ONLY_LOCALE && !SCANNABLE_LOCALES.includes(ONLY_LOCALE)) {
   console.error(`ERROR: --locale '${ONLY_LOCALE}' is not a translated locale under i18n/.`);
   console.error('Nothing would be scanned, and the run would report a clean-looking zero.');
@@ -352,10 +361,14 @@ const history = buildEnglishFenceHistory();
 // auditable, which made the count 2 → 2 rather than 2 → 3.
 //
 // `SCANNABLE_LOCALES` and `PRESENT_TREES` stay: the `--locale` guard above fires BEFORE the scan
-// and needs them, and `gitStatus(...PRESENT_TREES)` and `WRITE_SCOPE` read them too. They select
-// the same targets the lib's own enumeration does — both only record a locale or tree once an
-// entry has passed every existence check — so this is a narrowing of what the walk decides, not
-// of what it returns.
+// and needs them, and `gitStatus(...PRESENT_TREES)` and `WRITE_SCOPE` read them too.
+//
+// They are NOT the same predicate as the walk's, and the first version of this comment claimed
+// they were. They are directory-based and answer "could this locale be scanned at all"; the walk's
+// `localesReached` is content-based and answers "did anything survive every check". A locale whose
+// `skills/` is empty is in the first and never in the second. Both now enumerate `i18n/` through
+// the lib's single `localeDirs`, so they cannot disagree about what a locale IS — which is the part
+// that was a live divergence, not a documentation nicety.
 const collected = collectI18nTargets({
   root: ROOT,
   onlyLocale: ONLY_LOCALE,


### PR DESCRIPTION
## Finishing what #622 deferred

#622 extracted `lib/i18n-targets.js` because the gate and this tool had each grown a copy of the
walk and the copies had **already drifted** on the two points that decide whether a scoped run
reaching nothing reports a clean zero or exits 2:

- one recorded its reached-trees *before* the `--tree` filter and one *after* — and validating a
  filter against the post-filter set is circular, so it always passes;
- one checked `isFile`, the other only `existsSync`.

This file was left on its own copy there to keep a 3,415-file diff auditable, which made the count
2 → 2 rather than 2 → 3. This finishes it.

## Two acceptance criteria that pull against each other

The issue asks for **no `readdirSync` walk over `i18n/`** *and* for the
`SCANNABLE_LOCALES` / `PRESENT_TREES` precomputation to be **preserved** — and both cannot hold
while that precomputation lives here, because it *is* a `readdirSync` over `i18n/`.

It genuinely has to run before the scan: the `--locale` guard fires early on purpose (rejecting an
unreachable locale *after* a ~90 s history build is a worse tool), and `gitStatus(...PRESENT_TREES)`
and `WRITE_SCOPE` read it too.

Resolved by moving it rather than choosing. `hasTree`, `presentTrees` and `scannableLocales` are
exported from the lib now. Both criteria hold, and the pre-scan guards can no longer drift from the
walk they gate — the property the extraction exists for, applied one level up.

## Preserved deliberately

`treesInScope` is `collected.treesReached`, which the lib records **after** the locale filter and
**before** the `--tree` filter — the ordering that makes the accept-list mean "could have reached"
rather than "selected". The lib's own header records that its first version got this wrong and
reintroduced the bug it was written to prevent.

`SCANNABLE_LOCALES` (directory-based, cheap, pre-scan) and `localesReached` (content-based, from the
walk) are different answers to different questions; both are kept. The first gates the flag, the
second is what `validateScope` uses.

Field rename at the seam only: the lib returns `absPath`, everything downstream here reads `path`.
Renamed here rather than in the lib, whose other two callers already use `absPath`. `sourceCommit`
stays a call-site concern — the lib returns content, and provenance has its own anchored reader
(#552).

## Acceptance criteria

- [x] **No `readdirSync` walk over `i18n/`** — the import is gone from the file too
- [x] **Its tests pass unchanged** — 44 across the three normalizer suites
      (`normalize-i18n-fences`, `fence-basis-stamp`, `fence-basis-claim`)
- [x] **Preview byte-identical** — 39 lines, equal to the #587 branch's output, which was measured
      byte-identical to `main` at `e456cc280`, which is what `main` now is. Three runs agreeing
      across two hours also shows the corpus did not move under the peer session sharing this
      worktree.
- [x] **`--locale wenyan --tree guides` still exits 2**, not `files to change: 0`:

```console
$ node scripts/normalize-i18n-fences.js --locale wenyan --tree guides
ERROR: --tree matched no translated content in locale 'wenyan': guides
Nothing would be scanned, and the run would report a clean-looking zero.
Reachable here: skills
real exit code: 2
```

## Verification

```
node --test scripts/test/*.test.js   521 pass, 0 fail
npm run check:generator-inputs       14 modules, 0 unlisted
node scripts/check-bare-substitutions.js  0 UNGUARDED
npm run check-readmes                All files are up to date
```

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)