### PR TITLE
fix(scripts): fold the tag-sequence reproducer through production (#612)

### DIFF
--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -146,9 +146,12 @@ export function collectSpecs(root) {
  * `scripts/measure-tag-sequence-parity.js`, and it is deliberately NOT scoped out of this table
  * for being a measurement script: `fences.js` cites it as the reproducer for the tag-sequence
  * finding set, so a change to this walk that moves its numbers moves the evidence the gate was
- * tuned against. It pools sequences inline rather than reusing `.sequences`, and folds tags with
- * a local copy rather than `foldedTagSequence` — a divergence tracked as #612. Until that closes,
- * a walk change must be re-measured through it separately; afterwards it inherits the row above.
+ * tuned against. Since #612 it folds through `foldedTagSequence`, so its sequences and the
+ * `.sequences` row above are now built from the same fold and a walk change moves both the same
+ * way. It still pools INLINE rather than calling `buildEnglishFenceHistory`, because it also
+ * needs a per-count index the pool does not carry — so a change to that builder's own logic,
+ * as opposed to this walk's, still does not reach it. Re-measure through it for the second kind
+ * of change; the first is now covered by the row above.
  *
  * There is deliberately no `trees` option. An earlier draft had one, defaulting to
  * `CONTENT_TYPES` and used by nobody — and it could not have worked, because `contentKey`

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -150,8 +150,10 @@ export function collectSpecs(root) {
  * `.sequences` row above are now built from the same fold and a walk change moves both the same
  * way. It still pools INLINE rather than calling `buildEnglishFenceHistory`, because it also
  * needs a per-count index the pool does not carry — so a change to that builder's own logic,
- * as opposed to this walk's, still does not reach it. Re-measure through it for the second kind
- * of change; the first is now covered by the row above.
+ * as opposed to this walk's, still does not reach it — and re-running this script ALONE cannot
+ * detect such a change, since by that same sentence it measures the unchanged pipeline. For the
+ * second kind, run the gate and this script and diff their finding sets: the agreement is what is
+ * being re-measured. The first kind is covered by the row above.
  *
  * There is deliberately no `trees` option. An earlier draft had one, defaulting to
  * `CONTENT_TYPES` and used by nobody — and it could not have worked, because `contentKey`

--- a/scripts/measure-tag-sequence-parity.js
+++ b/scripts/measure-tag-sequence-parity.js
@@ -26,7 +26,9 @@
  *
  *   - An untagged fence folds to `text`. `normalize-content-style.js --mode fences` retro-tagged
  *     untagged blocks as `text` on the newer side only, so that pairing is an artifact of a
- *     known repo tool rather than a translator action.
+ *     known repo tool rather than a translator action. A BRACE-INFO fence (```{r}) folds to `{`
+ *     instead, because `lang` is `''` for it too and collapsing both to `text` would let an
+ *     English ```{r} be swapped for a localisable ```text unseen — the escape this measures.
  *   - Alignment must NOT be expressed as `isGated(a) !== isGated(b)`. Under default-deny an
  *     untagged fence is gated while `text` is not, so that formulation makes every one of those
  *     benign pairings a misalignment — it stranded 169 repairable fences across 73 files when it
@@ -48,16 +50,32 @@
  *   node scripts/measure-tag-sequence-parity.js --locale de
  *   node scripts/measure-tag-sequence-parity.js --json
  *   node scripts/measure-tag-sequence-parity.js --list-retags   # every retag position, verbatim
+ *   node scripts/measure-tag-sequence-parity.js --root /tmp/fixture   # measure another tree
  */
 
 import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { extractFences } from './lib/fences.js';
+// `foldedTagSequence` and not a local fold (#612). The copy this replaces was
+// `fence.lang === '' ? 'text' : fence.lang`, which collapses a brace-info fence (```{r} — `lang`
+// empty, `info` non-empty) to `text` where production folds it to `{`. That placeholder exists
+// precisely so an English ```{r} cannot be swapped for a localisable ```text with neither the
+// sequence check nor the body check seeing it, so the reproducer had reintroduced the escape it
+// was written to reproduce. Latent — 0 of 3,644 translated files carry such a fence, which is why
+// the two folds agreed on the whole corpus and nothing caught it. What makes it worth fixing is
+// that this script is the instrument used to judge the gate's finding set, and it disagreed with
+// the thing it measures.
+import { foldedTagSequence } from './lib/fences.js';
 import { walkEnglishHistory } from './lib/english-history.js';
 import { collectTargets } from './check-i18n-fence-parity.js';
 
-const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+// `--root` exists so this script can be run against a fixture, and it is NOT a convenience.
+// `collectTargets` is imported from `check-i18n-fence-parity.js`, whose own `--root` is parsed at
+// module scope against the IMPORTER's argv — that module's header says so in capitals. So before
+// this line, `--root /tmp/x` on THIS command line already redirected the translation side to the
+// fixture while the English history side stayed on the repo, and the two halves of the comparison
+// silently addressed different trees. Parsing the same flag here is what makes them agree.
+const ROOT = resolve(flagValue('--root', resolve(dirname(fileURLToPath(import.meta.url)), '..')));
 
 function flagValue(name, fallback) {
   const i = process.argv.indexOf(name);
@@ -74,10 +92,6 @@ const AS_JSON = process.argv.includes('--json');
 const LIST_RETAGS = process.argv.includes('--list-retags');
 const ONLY_LOCALE = flagValue('--locale', null);
 
-/** Untagged folds to `text`; see the header for why this is not optional. */
-const alignmentTag = (fence) => (fence.lang === '' ? 'text' : fence.lang);
-const sequenceOf = (text) => extractFences(text).map(alignmentTag);
-
 // Pool every folded tag sequence each English source has ever carried, keyed by `<tree>/<id>`.
 // Sequences are stored joined; the per-count index lets a mismatch be classified as unalignable
 // (no revision of that length) rather than as a retag.
@@ -85,7 +99,7 @@ const english = new Map();
 walkEnglishHistory(ROOT, (key, text) => {
   if (!english.has(key)) english.set(key, { sequences: new Set(), byCount: new Map() });
   const entry = english.get(key);
-  const seq = sequenceOf(text);
+  const seq = foldedTagSequence(text);
   entry.sequences.add(seq.join(','));
   if (!entry.byCount.has(seq.length)) entry.byCount.set(seq.length, new Set());
   entry.byCount.get(seq.length).add(seq.join(','));
@@ -100,7 +114,7 @@ for (const target of collectTargets()) {
   const entry = english.get(`${target.tree}/${target.id}`);
   if (!entry) { totals.orphan += 1; continue; }
 
-  const seq = sequenceOf(readFileSync(target.absPath, 'utf8'));
+  const seq = foldedTagSequence(readFileSync(target.absPath, 'utf8'));
   const joined = seq.join(',');
   let bucket;
   if (entry.sequences.has(joined)) {

--- a/scripts/measure-tag-sequence-parity.js
+++ b/scripts/measure-tag-sequence-parity.js
@@ -21,8 +21,12 @@
  * applies here: a translation is clean when its folded tag sequence equals that of SOME revision
  * of its English source.
  *
- * Two foldings are load-bearing, both lifted from `normalize-i18n-fences.js`, which already
- * makes this exact judgement to decide whether ordinal mapping is sound:
+ * Two foldings are load-bearing, and both now come from `lib/fences.js` (`foldedTagSequence`),
+ * which is the definition production enforces against. They were originally lifted from
+ * `normalize-i18n-fences.js`, and that attribution is deliberately NOT kept: its `alignmentTag`
+ * still folds a brace fence to `text`, as its own comment beside `mirrorsBasis` admits — "cannot
+ * tell ```{r} from an untagged fence (#612)" — and #674 tracks it. Citing it as the authority for
+ * the brace arm would name the module that makes the opposite judgement.
  *
  *   - An untagged fence folds to `text`. `normalize-content-style.js --mode fences` retro-tagged
  *     untagged blocks as `text` on the newer side only, so that pairing is an artifact of a
@@ -61,10 +65,15 @@ import { fileURLToPath } from 'url';
 // empty, `info` non-empty) to `text` where production folds it to `{`. That placeholder exists
 // precisely so an English ```{r} cannot be swapped for a localisable ```text with neither the
 // sequence check nor the body check seeing it, so the reproducer had reintroduced the escape it
-// was written to reproduce. Latent — 0 of 3,644 translated files carry such a fence, which is why
-// the two folds agreed on the whole corpus and nothing caught it. What makes it worth fixing is
-// that this script is the instrument used to judge the gate's finding set, and it disagreed with
-// the thing it measures.
+// was written to reproduce. Latent: measured with this repair, 0 of the 3,648 translated files
+// walked, and no English source either, carries a TOP-LEVEL brace-info fence. Top-level is the
+// qualifier that matters — the corpus carries plenty NESTED inside ````markdown wrappers, where
+// they are body text rather than fences. Both sides are stated because the fold applies to the
+// English pool as well, so zero carriers on the translation side alone would not have implied the
+// two folds agree. The evidence that they did is the finding set being byte-identical across this
+// change; the counts are why that was expected. What makes it worth fixing anyway is that this
+// script is the instrument used to judge the gate's finding set, and it disagreed with the thing
+// it measures.
 import { foldedTagSequence } from './lib/fences.js';
 import { walkEnglishHistory } from './lib/english-history.js';
 import { collectTargets } from './check-i18n-fence-parity.js';

--- a/scripts/test/measure-tag-sequence-parity.test.js
+++ b/scripts/test/measure-tag-sequence-parity.test.js
@@ -9,10 +9,11 @@
  * cannot be swapped for a localisable ```text with neither the sequence check nor the body check
  * seeing it — so the reproducer reintroduced the escape it was written to reproduce.
  *
- * It was latent: 0 of 3,644 translated files carry a brace-info fence, the two folds agreed on
- * every one of them, and the finding set is byte-identical before and after the repair. A corpus
- * run therefore proves nothing here — which is the whole reason this fixture exists. Plant the
- * one shape the corpus does not contain and the two folds disagree immediately.
+ * It was latent: 0 of the 3,648 translated files walked, and no English source either, carries a
+ * TOP-LEVEL brace-info fence — nested ones inside ````markdown wrappers are body text, not fences
+ * — and the finding set is byte-identical before and after the repair. A corpus run therefore
+ * proves nothing here, which is the whole reason this fixture exists. Plant the one shape the
+ * corpus does not contain and the two folds disagree immediately.
  *
  * MUST-GO-RED, measured rather than asserted: restoring the local fold — importing
  * `extractFences` and re-deriving `foldedTagSequence` as `f.lang === '' ? 'text' : f.lang` —

--- a/scripts/test/measure-tag-sequence-parity.test.js
+++ b/scripts/test/measure-tag-sequence-parity.test.js
@@ -1,0 +1,103 @@
+/**
+ * `measure-tag-sequence-parity.js` is the REPRODUCER, and it had stopped reproducing (#612).
+ *
+ * `fences.js` cites this script as the instrument the tag-sequence finding set was tuned against,
+ * and `debt-ratchet.yml` ratchets that finding set. So the script is not a scratch measurement —
+ * it is the evidence a gate's member list was judged from. It carried its own tag fold,
+ * `lang === '' ? 'text' : lang`, which collapses a brace-info fence to `text` where production's
+ * `foldedTagSequence` folds it to `{`. The `{` placeholder exists precisely so an English ```{r}
+ * cannot be swapped for a localisable ```text with neither the sequence check nor the body check
+ * seeing it — so the reproducer reintroduced the escape it was written to reproduce.
+ *
+ * It was latent: 0 of 3,644 translated files carry a brace-info fence, the two folds agreed on
+ * every one of them, and the finding set is byte-identical before and after the repair. A corpus
+ * run therefore proves nothing here — which is the whole reason this fixture exists. Plant the
+ * one shape the corpus does not contain and the two folds disagree immediately.
+ *
+ * MUST-GO-RED, measured rather than asserted: restoring the local fold — importing
+ * `extractFences` and re-deriving `foldedTagSequence` as `f.lang === '' ? 'text' : f.lang` —
+ * fails 1 of 524 against `npm run test:scripts`, the command CI runs, and the 1 is the first test
+ * below. Exit 1, one `AssertionError` reading "the brace-to-text escape must be seen", no crash
+ * signature and no broad kill. Run against the npm script and not this file alone, because a
+ * suite that never discovers a new file reports success (#486).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve, dirname } from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const SCRIPT = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'measure-tag-sequence-parity.js');
+
+/** A fixture repo carrying one English source and one mirror of it. */
+function fixture(englishBody, translatedBody) {
+  const dir = mkdtempSync(join(tmpdir(), 'aa-measure-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+
+  mkdirSync(join(dir, 'skills', 'demo'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'demo', 'SKILL.md'), englishBody);
+  git('add', '-A');
+  git('commit', '-qm', 'english');
+
+  mkdirSync(join(dir, 'i18n', 'de', 'skills', 'demo'), { recursive: true });
+  writeFileSync(join(dir, 'i18n', 'de', 'skills', 'demo', 'SKILL.md'), translatedBody);
+  return dir;
+}
+
+function measure(dir) {
+  const run = spawnSync(process.execPath, [SCRIPT, '--root', dir, '--json'], { encoding: 'utf8' });
+  assert.equal(run.status, 0, run.stderr);
+  return JSON.parse(run.stdout);
+}
+
+test('a brace fence retagged to `text` is a retag, not a clean file', () => {
+  // THE #612 CASE. Under the local fold both sides read `['text']` and the file is clean; under
+  // `foldedTagSequence` English is `['{']` and the mirror `['text']`, which is the escape.
+  const english = '# Demo\n\n```{r}\nx <- 1\n```\n';
+  const dir = fixture(english, english.replace('```{r}', '```text'));
+  try {
+    const report = measure(dir);
+    assert.equal(report.totals.retag, 1, 'the brace-to-text escape must be seen');
+    assert.equal(report.totals.clean, 0);
+    assert.equal(report.totals.unalignable, 0, 'the counts match, so this is judged, not skipped');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('an untranslated brace fence stays clean — the non-vacuity control', () => {
+  // Without this, the test above would pass just as well against a script that called everything
+  // a retag. It also pins the half of the fold that was never in dispute: `{` equals `{`.
+  const english = '# Demo\n\n```{r}\nx <- 1\n```\n';
+  const dir = fixture(english, english.replace('# Demo', '# Demo auf Deutsch'));
+  try {
+    const report = measure(dir);
+    assert.equal(report.totals.clean, 1);
+    assert.equal(report.totals.retag, 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('--root moves BOTH halves of the comparison, not just the translation side', () => {
+  // `collectTargets` comes from `check-i18n-fence-parity.js`, which parses `--root` at module
+  // scope against the importer's argv. Before #612 this script did not read the flag itself, so
+  // `--root /tmp/x` pointed the translation side at the fixture while `walkEnglishHistory` still
+  // walked the real repo — every fixture file would then be an ORPHAN, since no English history
+  // exists for `skills/demo` there. A non-zero judged population is what proves they agree.
+  const english = '# Demo\n\n```yaml\na: 1\n```\n';
+  const dir = fixture(english, english.replace('```yaml', '```text'));
+  try {
+    const report = measure(dir);
+    assert.equal(report.totals.orphan, 0, 'the English side must have found the fixture too');
+    assert.equal(report.totals.retag, 1);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #612.

## What was wrong

`measure-tag-sequence-parity.js` carried its own tag fold:

```js
const alignmentTag = (fence) => (fence.lang === '' ? 'text' : fence.lang);
```

`lang` is `''` for a brace-info fence (` ```{r} `) as well as for a bare ` ``` `, so this collapses both to `text`. Production's `foldedTagSequence` folds the brace case to `{` instead, and that placeholder exists for exactly one reason: so an English ` ```{r} ` cannot be swapped for a localisable ` ```text ` with neither the sequence check nor the body check seeing it. The reproducer had reintroduced the escape it was written to reproduce.

Why it matters that this is a *measurement* script: `fences.js` cites it as the reproducer for the tag-sequence finding set, and `debt-ratchet.yml` ratchets that finding set. It is the instrument a gate's member list was judged from.

## AC2 — the finding counts, before and after

**Byte-identical.** `clean 3582, unalignable 60, retag 6, orphan 0`, the same six retags in the same order, `diff` clean over the full text report.

Nothing moved, and nothing should have. Re-measured for this PR rather than quoted: **0 of the 3,648 translated files walked**, and no English source either, carries a *top-level* brace-info fence — nested ones inside ` ````markdown ` wrappers are body text, not fences. Both sides are stated because the fold applies to the English pool too, so zero carriers on the translation side alone would not have implied agreement. The defect was latent.

(3,648, not the 3,644 this PR first claimed. That number came from `fences.js`'s docstring, which dates it honestly as "at introduction"; four `coordinate-peer-sessions` mirrors have landed since. The refutation was already here — the totals above sum to 3,648.)

## Which is why the corpus is not the evidence

A corpus run proves nothing when the corpus contains none of the shape in dispute. `scripts/test/measure-tag-sequence-parity.test.js` plants it: an English ` ```{r} ` and a mirror retagging it to ` ```text `.

**Must-go-red, measured against the command CI runs.** Restoring the local fold — importing `extractFences` and re-deriving the fold locally — fails **1 of 524** under `npm run test:scripts`. Exit 1, one `AssertionError` reading `the brace-to-text escape must be seen`, no crash signature, no broad kill. Run against the npm script rather than the file alone, because a suite that never discovers a new file reports success (#486); the three new test names appear in the full-suite transcript.

Two controls, so the first test cannot pass for the wrong reason:
- an untranslated brace fence stays `clean` (a script that called everything a retag would fail here);
- `--root` moves both halves of the comparison (see below).

## `--root`, and why it is not a convenience

`collectTargets` is imported from `check-i18n-fence-parity.js`, whose own `--root` is parsed at module scope against the **importer's** argv — that module's header says so in capitals. So before this PR, `--root /tmp/x` on this script's command line already redirected the translation side to the fixture while `walkEnglishHistory(ROOT)` stayed on the real repo, silently comparing two different trees. Parsing the same flag here is what makes the halves agree, and it is what makes the fixture possible at all. The third test pins it: with the flag reaching only one half, every fixture file is an orphan.

## Also in this PR

`scripts/lib/english-history.js` — the collector table said this script "folds tags with a local copy rather than `foldedTagSequence` — a divergence tracked as #612. Until that closes…". Corrected, and deliberately not over-corrected: it still pools inline rather than calling `buildEnglishFenceHistory`, because it needs a per-count index the pool does not carry. So a change to *this walk* now moves both the same way; a change to *that builder* still does not reach it.

## Found while here — filed, not fixed

Two copies of the same local fold survive, in the two writers that gate on ordinal alignment: `normalize-i18n-fences.js:491` and `check-placeholder-drift.js:371`. **#674**, with a component-level probe showing the normalizer's copy reads an English ` ```text ` facing a translated ` ```{r} ` as ALIGNED where production reads it as misaligned — and the normalizer writes. Out of scope here because fixing it properly needs `--root` on the normalizer first, which is the fourth appearance of that untestability defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw
