### PR TITLE
fix(i18n): refuse a fence-parity scope that reached nothing (#634)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,7 +395,12 @@ did not reach, so an unknown id, an unknown locale, a real-but-untranslated id
 and a `--locale`/`--id` pair that is individually valid but jointly empty all
 exit 2 instead of printing `OK` over zero files. The guard asks REACHED, never
 EXISTS — `existsSync('skills/' + id)` would pass for a skill nobody has
-translated and still compare nothing.
+translated and still compare nothing. What licenses dropping the old "read
+`filesCompared`" advice is that a *reached* id cannot then compare zero files
+either: `walkEnglishHistory` feeds the working tree into the pool, so every
+English file that survived the target walk has a history entry and the orphan
+path is unreachable for it. A valid `--id` now either refuses or compares at
+least one file.
 `check-translation-freshness.js` adds nothing — those mirrors were already
 `STALE`, so the edit moved no signal at all. Both gates are green either way.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,8 +390,12 @@ The gate accepts a body from **any** English revision, so it cannot tell you
 whether your edit reached the mirrors. Measured on `write-helm-chart` (#551):
 editing the English fence and propagating to **zero** mirrors leaves
 `--id write-helm-chart` reporting `violations: 0`, before and after the commit.
-Read `filesCompared` alongside it — the gate's `--id` has no zero-target guard,
-so a mistyped id also reports `violations: 0` over nothing (#634).
+A mistyped id no longer hides inside that: since #634 the gate refuses a scope it
+did not reach, so an unknown id, an unknown locale, a real-but-untranslated id
+and a `--locale`/`--id` pair that is individually valid but jointly empty all
+exit 2 instead of printing `OK` over zero files. The guard asks REACHED, never
+EXISTS — `existsSync('skills/' + id)` would pass for a skill nobody has
+translated and still compare nothing.
 `check-translation-freshness.js` adds nothing — those mirrors were already
 `STALE`, so the edit moved no signal at all. Both gates are green either way.
 

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -185,8 +185,12 @@ export function collectTargets() {
   });
   if (scopeErrors.length) {
     for (const line of scopeErrors) console.error(line);
-    // 2, not 1. This module exits 1 for "the thing I check is wrong", and a caller scripting
-    // around it must not have to guess which happened. Same split as `usageExit`.
+    // 2, not 1, so a refusal is distinguishable from a finding. Same split as `usageExit`.
+    //
+    // The converse does NOT hold and must not be scripted on: `assertNotShallow` exits 1 for a
+    // refusal too, one call above this in `main()`. That is deliberate and CLAUDE.md argues for
+    // it — a warn-only caller that cannot measure at all should not warn less, it should stop.
+    // So 2 always means refusal; 1 means findings OR a shallow clone.
     process.exit(2);
   }
 

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -70,7 +70,7 @@ import {
   extractFences, buildEnglishFenceHistory, isGated, foldedTagSequence, compareTagSequence,
   isRetagEscape,
 } from './lib/fences.js';
-import { collectI18nTargets, I18N_TREES } from './lib/i18n-targets.js';
+import { collectI18nTargets, validateScope, I18N_TREES } from './lib/i18n-targets.js';
 import { FENCE_BASIS_FIELD, readFrontmatterField } from './lib/provenance.js';
 import { CONTENT_TYPES } from './lib/content-types.js';
 
@@ -159,7 +159,37 @@ export const TREES = I18N_TREES;
  * `--id` stays here: it is this gate's debugging convenience, not a property of the corpus.
  */
 export function collectTargets() {
-  const { targets } = collectI18nTargets({ root: ROOT, onlyLocale: ONLY_LOCALE });
+  const { targets, localesReached, treesReached } = collectI18nTargets({ root: ROOT, onlyLocale: ONLY_LOCALE });
+
+  // #634. Without this the gate answered a mistyped id with `OK: every gated code fence matches
+  // an English source revision.` and exit 0 — technically true of the empty set, and the command
+  // CLAUDE.md tells a contributor to run on the one file they just edited. Edit a fence, mistype
+  // the id, see OK, commit.
+  //
+  // `idsReached` is built from `targets` BEFORE the filter below, so it answers what this run
+  // actually reached rather than what exists on disk. That is also what makes a `--locale`/`--id`
+  // pair which is individually valid but jointly empty refuse, with no third check: the id is not
+  // among what that locale reached.
+  //
+  // The refusal covers `--locale` too, which this gate never validated at all. That reaches
+  // `measure-tag-sequence-parity.js` as well, since it imports this function — see the header
+  // above on module-scope flag parsing — and a mistyped locale there produced the same
+  // clean-looking zero.
+  const scopeErrors = validateScope({
+    onlyLocale: ONLY_LOCALE,
+    onlyTrees: null,
+    onlyId: ONLY_ID,
+    localesReached,
+    treesReached,
+    idsReached: new Set(targets.map((t) => t.id)),
+  });
+  if (scopeErrors.length) {
+    for (const line of scopeErrors) console.error(line);
+    // 2, not 1. This module exits 1 for "the thing I check is wrong", and a caller scripting
+    // around it must not have to guess which happened. Same split as `usageExit`.
+    process.exit(2);
+  }
+
   return targets.filter((t) => !ONLY_ID || t.id === ONLY_ID);
 }
 
@@ -210,6 +240,12 @@ export const SCANNED_FIELDS = ['filesCompared', 'fencesCompared'];
 function main() {
   assertNotShallow(ROOT);
 
+  // Scope BEFORE the history walk (#634). `collectTargets` refuses an empty scope, and making a
+  // contributor wait out a full-corpus `git log` to be told they mistyped an id is a worse
+  // version of the same message. The walk is still corpus-wide — `--id` scopes the comparison,
+  // not the history, which is #635.
+  const targets = collectTargets();
+
   const history = buildEnglishFenceHistory(ROOT);
   const findings = [];
   let filesCompared = 0;
@@ -219,7 +255,7 @@ function main() {
   let tagSequenceDrift = 0;
   let staleBasisClaims = 0;
 
-  for (const t of collectTargets()) {
+  for (const t of targets) {
     const englishFences = history.get(`${t.tree}/${t.id}`);
     if (!englishFences) continue; // orphan: check-i18n-frontmatter-parity.js owns that
 

--- a/scripts/lib/i18n-targets.js
+++ b/scripts/lib/i18n-targets.js
@@ -216,18 +216,43 @@ export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, 
 /**
  * Reject a scope flag that reached nothing, naming what WAS reachable.
  *
- * Shared so the three callers cannot disagree about when a scoped run is vacuous. Returns an
- * array of error lines; empty means the scope is good. The caller exits 2 — this module does not
- * call `process.exit`, because a library that kills the process cannot be tested.
+ * Returns an array of error lines; empty means the scope is good. The caller exits 2 — this
+ * module does not call `process.exit`, because a library that kills the process cannot be tested.
+ *
+ * ## Who actually calls this
+ *
+ * The docblock here said "shared so the three callers cannot disagree". It had one (#634). The
+ * count is now two — `backfill-fence-basis.js` and `check-i18n-fence-parity.js` — and the
+ * sentence is replaced by an inventory, because a number nobody can check is how the claim got
+ * wrong in the first place.
+ *
+ * `normalize-i18n-fences.js` has a HAND COPY of the `--tree` arm (its own `unreachable` block),
+ * and it is not a copy that merely duplicates: it omits the unknown-tree-name check above and
+ * validates no locale at all. Converting it therefore changes its behaviour rather than only its
+ * spelling, which is why it is filed rather than folded in here.
+ *
+ * ## `onlyId` asks REACHED, never EXISTS
+ *
+ * `idsReached` must be built from the targets the scan actually collected, AFTER any locale
+ * scoping and BEFORE the id filter. That is what makes a `--locale`/`--id` pair which is
+ * individually valid but jointly empty refuse without a third check: the id is simply not among
+ * what that locale reached.
+ *
+ * Guarding with `existsSync('skills/' + id)` instead would pass for a real skill nobody has
+ * translated and still compare nothing — the proxy-predicate mistake this function exists to
+ * avoid. There are deliberately no reachable ids in the message: the corpus carries hundreds, and
+ * a wall of them is not a diagnostic.
  *
  * @param {object} opts
  * @param {string|null} opts.onlyLocale
  * @param {Set<string>|null} opts.onlyTrees
+ * @param {string|null} [opts.onlyId]
  * @param {Set<string>} opts.localesReached
  * @param {Set<string>} opts.treesReached
+ * @param {Set<string>} [opts.idsReached] - required when `onlyId` is given
  * @returns {string[]}
  */
-export function validateScope({ onlyLocale, onlyTrees, localesReached, treesReached }) {
+export function validateScope({ onlyLocale, onlyTrees, onlyId = null, localesReached, treesReached, idsReached = null }) {
   const errors = [];
   if (onlyLocale && !localesReached.has(onlyLocale)) {
     errors.push(`ERROR: --locale '${onlyLocale}' matched no translated content.`);
@@ -248,6 +273,22 @@ export function validateScope({ onlyLocale, onlyTrees, localesReached, treesReac
       errors.push(`ERROR: --tree matched no translated content${onlyLocale ? ` in locale '${onlyLocale}'` : ''}: ${unreached.join(', ')}`);
       errors.push('Nothing would be scanned, and the run would report a clean-looking zero.');
       errors.push(`Reachable here: ${[...treesReached].sort().join(', ') || '(none)'}`);
+      return errors;
+    }
+  }
+  if (onlyId) {
+    // A caller that passes `onlyId` without `idsReached` would otherwise get a permanent refusal
+    // or a permanent pass depending on the default, and both are worse than saying so.
+    if (idsReached === null) {
+      errors.push('ERROR: validateScope was given --id with no idsReached set. This is a caller bug:');
+      errors.push('the accept-list must be what the scan reached, so it cannot be defaulted.');
+      return errors;
+    }
+    if (!idsReached.has(onlyId)) {
+      errors.push(`ERROR: --id '${onlyId}' matched no translated content${onlyLocale ? ` in locale '${onlyLocale}'` : ''}.`);
+      errors.push('Nothing would be compared, and the run would report a clean-looking zero.');
+      errors.push(`Translated content ids reachable here: ${idsReached.size}. A typo and a real but`);
+      errors.push('untranslated id land in the same place, and both mean this run examines nothing.');
     }
   }
   return errors;

--- a/scripts/lib/i18n-targets.js
+++ b/scripts/lib/i18n-targets.js
@@ -227,9 +227,18 @@ export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, 
  * wrong in the first place.
  *
  * `normalize-i18n-fences.js` has a HAND COPY of the `--tree` arm (its own `unreachable` block),
- * and it is not a copy that merely duplicates: it omits the unknown-tree-name check above and
- * validates no locale at all. Converting it therefore changes its behaviour rather than only its
- * spelling, which is why it is filed rather than folded in here.
+ * and converting it would change behaviour rather than spelling — but not for the reason this
+ * paragraph first gave. It said the normalizer "validates no locale at all", which is false: it
+ * refuses an unscannable `--locale` at exit 2, with its own tests. The real delta is which
+ * accept-list each asks:
+ *
+ *   normalize-i18n-fences.js   `scannableLocales` — pre-scan, DIRECTORY-based
+ *   validateScope              `localesReached`   — post-scan, CONTENT-based
+ *
+ * An `i18n/xx/skills/` directory carrying no translated file passes the normalizer's guard today
+ * and would refuse here. That is the behaviour change, and it is the one worth testing when #677
+ * is done. The `--tree` half of the delta is smaller than it looks too: an unknown tree name is a
+ * subset of unreached, so the normalizer already exits 2 on it and only the message differs.
  *
  * ## `onlyId` asks REACHED, never EXISTS
  *

--- a/scripts/test/fence-parity-scope-guard.test.js
+++ b/scripts/test/fence-parity-scope-guard.test.js
@@ -1,0 +1,138 @@
+/**
+ * `check-i18n-fence-parity.js` answered a mistyped `--id` with `OK` and exit 0 (#634).
+ *
+ * Measured before the fix:
+ *
+ *   $ node scripts/check-i18n-fence-parity.js --id write-helm-chrat
+ *   i18n fence parity: 0 fences in 0 translated skills
+ *   OK: every gated code fence matches an English source revision.
+ *   $ echo $?
+ *   0
+ *
+ * "Every gated code fence matches" is true of the empty set, which is what makes this worse than
+ * an ordinary typo: CLAUDE.md tells a contributor to run exactly this command on the one file
+ * they just edited. Edit a fence, mistype the id, see OK, commit.
+ *
+ * The guard asks REACHED, not EXISTS. A real content id nobody has translated must refuse too —
+ * `existsSync('skills/' + id)` would pass for it and still compare nothing, which is the
+ * proxy-predicate mistake CLAUDE.md names. That case has its own test below, and it is the one
+ * that separates this guard from the obvious wrong one.
+ *
+ * MUST-GO-RED, both measured against `npm run test:scripts` on a 529-test green baseline:
+ *
+ *   delete the `process.exit(2)` in `collectTargets`        exit 1, 4 failing — all four refusals
+ *   neuter the `onlyId` arm of `validateScope`              exit 1, 3 failing — locale stays green
+ *
+ * The second number is the one worth having. It shows the four tests are not one test written
+ * four ways: the locale arm and the id arm are covered separately, and a mutation to either is
+ * visible on its own. Both kills are narrow — 4 and 3 of 529 — and neither prints a runtime
+ * error, so neither is the crash-shaped false kill `mutation-verdict.js` exists to flag.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve, dirname } from 'path';
+import { execFileSync, spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const CHECKER = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'check-i18n-fence-parity.js');
+
+const doc = (title) => `# ${title}\n\n\`\`\`yaml\na: 1\n\`\`\`\n`;
+
+/**
+ * A fixture whose translation coverage is deliberately RAGGED, because every interesting case
+ * here is about a scope that is individually valid and jointly empty.
+ *
+ *   alpha  translated into de       gamma  English only — real id, zero mirrors
+ *   beta   translated into ja
+ */
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'aa-scope-'));
+  const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+  git('init', '-q', '-b', 'main');
+  git('config', 'user.email', 'test@example.com');
+  git('config', 'user.name', 'test');
+
+  for (const id of ['alpha', 'beta', 'gamma']) {
+    mkdirSync(join(dir, 'skills', id), { recursive: true });
+    writeFileSync(join(dir, 'skills', id, 'SKILL.md'), doc(id));
+  }
+  git('add', '-A');
+  git('commit', '-qm', 'english');
+
+  for (const [locale, id] of [['de', 'alpha'], ['ja', 'beta']]) {
+    mkdirSync(join(dir, 'i18n', locale, 'skills', id), { recursive: true });
+    writeFileSync(join(dir, 'i18n', locale, 'skills', id, 'SKILL.md'), doc(id));
+  }
+  return dir;
+}
+
+function run(dir, ...args) {
+  return spawnSync(process.execPath, [CHECKER, '--root', dir, ...args], { encoding: 'utf8' });
+}
+
+function withFixture(body) {
+  const dir = fixture();
+  try {
+    body(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('a mistyped --id refuses, and says so in the exit code', () => {
+  withFixture((dir) => {
+    const r = run(dir, '--id', 'alhpa');
+    // 2, not merely non-zero. 1 means "the thing I check is wrong"; asserting only `!== 0` would
+    // be satisfied by a findings-exit-1, so this test would stay green with the guard deleted on
+    // any fixture that happens to carry a violation.
+    assert.equal(r.status, 2, r.stdout + r.stderr);
+    assert.match(r.stderr, /--id 'alhpa' matched no translated content/);
+    assert.doesNotMatch(r.stdout, /OK: every gated code fence matches/);
+  });
+});
+
+test('a mistyped --locale refuses too — the gate validated neither before', () => {
+  withFixture((dir) => {
+    const r = run(dir, '--locale', 'ed');
+    assert.equal(r.status, 2, r.stdout + r.stderr);
+    assert.match(r.stderr, /--locale 'ed' matched no translated content/);
+  });
+});
+
+test('a --locale/--id pair that is individually valid but JOINTLY empty refuses', () => {
+  // `beta` is translated, and `de` has translations — but not of `beta`. Both flags name
+  // something real, so any guard checking them separately passes and compares nothing.
+  withFixture((dir) => {
+    assert.equal(run(dir, '--id', 'beta').status, 0, 'beta alone is reachable');
+    assert.equal(run(dir, '--locale', 'de').status, 0, 'de alone is reachable');
+
+    const r = run(dir, '--locale', 'de', '--id', 'beta');
+    assert.equal(r.status, 2, r.stdout + r.stderr);
+    assert.match(r.stderr, /--id 'beta' matched no translated content in locale 'de'/);
+  });
+});
+
+test('REACHED, not EXISTS: a real id with zero mirrors refuses', () => {
+  // THE CASE THAT SEPARATES THIS GUARD FROM THE WRONG ONE. `gamma` is a genuine English source in
+  // the fixture, so `existsSync('skills/gamma/SKILL.md')` is true — and there is nothing to
+  // compare it against. A guard built on existence passes here and reports a clean zero.
+  withFixture((dir) => {
+    const r = run(dir, '--id', 'gamma');
+    assert.equal(r.status, 2, r.stdout + r.stderr);
+    assert.match(r.stderr, /--id 'gamma' matched no translated content/);
+  });
+});
+
+test('a scope that DOES reach something still runs — the non-vacuity control', () => {
+  // Without this, every assertion above is satisfied by a gate that refuses everything.
+  withFixture((dir) => {
+    const r = run(dir, '--locale', 'de', '--id', 'alpha', '--json');
+    assert.equal(r.status, 0, r.stderr);
+    const report = JSON.parse(r.stdout);
+    assert.equal(report.filesCompared, 1, 'the scoped file must actually have been compared');
+    assert.equal(report.violations, 0);
+  });
+});

--- a/scripts/test/fence-parity-scope-guard.test.js
+++ b/scripts/test/fence-parity-scope-guard.test.js
@@ -37,6 +37,8 @@ import { join, resolve, dirname } from 'path';
 import { execFileSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
+import { validateScope } from '../lib/i18n-targets.js';
+
 const CHECKER = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'check-i18n-fence-parity.js');
 
 const doc = (title) => `# ${title}\n\n\`\`\`yaml\na: 1\n\`\`\`\n`;
@@ -135,4 +137,43 @@ test('a scope that DOES reach something still runs — the non-vacuity control',
     assert.equal(report.filesCompared, 1, 'the scoped file must actually have been compared');
     assert.equal(report.violations, 0);
   });
+});
+
+// ── the arm itself, not through a subprocess ────────────────────────────────
+
+test('validateScope refuses a caller that passes --id with no accept-list', () => {
+  // Dead from both CLIs today — the gate always passes `idsReached`, the backfill never passes
+  // `onlyId` — and an adversarial review pointed out that a mutation deleting this branch
+  // survives the whole suite. That is the shape the branch exists to prevent, so it gets the
+  // test rather than the benefit of the doubt.
+  //
+  // The default matters more than the branch. `idsReached = null` defaulting to an empty Set
+  // refuses every id forever; defaulting to "assume reached" passes every id forever. Both are
+  // silent. Saying "this is a caller bug" is the only answer that is neither.
+  const errors = validateScope({
+    onlyLocale: null, onlyTrees: null, onlyId: 'anything',
+    localesReached: new Set(['de']), treesReached: new Set(['skills']),
+  });
+  assert.equal(errors.length, 2);
+  assert.match(errors[0], /caller bug/);
+});
+
+test('validateScope reports the OUTERMOST failing scope, not every one', () => {
+  // A run with a mistyped locale AND a mistyped id should say the locale, because the id's
+  // accept-list is derived from the locale scoping and would be empty for a reason the reader
+  // has not been told yet. Cascading both reads as two independent faults.
+  const errors = validateScope({
+    onlyLocale: 'ed', onlyTrees: null, onlyId: 'alhpa',
+    localesReached: new Set(['de']), treesReached: new Set(['skills']), idsReached: new Set(),
+  });
+  assert.match(errors[0], /--locale 'ed'/);
+  assert.ok(!errors.some((line) => /--id/.test(line)), errors.join('\n'));
+});
+
+test('a reachable id produces no errors — the arm can stay silent', () => {
+  assert.deepEqual(validateScope({
+    onlyLocale: 'de', onlyTrees: null, onlyId: 'alpha',
+    localesReached: new Set(['de']), treesReached: new Set(['skills']),
+    idsReached: new Set(['alpha', 'beta']),
+  }), []);
 });


### PR DESCRIPTION
Closes #634.

## The vacuous pass

```
$ node scripts/check-i18n-fence-parity.js --id write-helm-chrat
i18n fence parity: 0 fences in 0 translated skills
OK: every gated code fence matches an English source revision.
$ echo $?
0
```

"Every gated code fence matches" is true of the empty set. What makes this worse than an ordinary typo is the role of the command: CLAUDE.md tells a contributor to run exactly this on the one file they just edited. So the failure is *edit a fence, mistype the id, see `OK`, commit.*

After:

```
$ node scripts/check-i18n-fence-parity.js --id write-helm-chrat
ERROR: --id 'write-helm-chrat' matched no translated content.
Nothing would be compared, and the run would report a clean-looking zero.
Translated content ids reachable here: 384. A typo and a real but
untranslated id land in the same place, and both mean this run examines nothing.
$ echo $?
2
```

Exit **2**, not 1 — this gate exits 1 for "the thing I check is wrong", and a caller scripting around it should not have to guess which happened. The test asserts `status === 2` rather than "non-zero", because a non-zero assertion is satisfied by a findings-exit-1 and would stay green with the guard deleted on any fixture that carries a violation.

## REACHED, never EXISTS

`idsReached` is built from the targets the scan collected — **after** locale scoping, **before** the id filter. That is the whole design:

- `existsSync('skills/' + id)` passes for a real skill nobody has translated and still compares nothing. The fixture has `gamma`, an English source with zero mirrors, and it has its own test — that case is what separates this guard from the obvious wrong one.
- a `--locale`/`--id` pair that is *individually valid but jointly empty* refuses with no third check, because the id is simply not among what that locale reached. The fixture's `beta` is translated into `ja` only, so `--id beta` passes, `--locale de` passes, and `--locale de --id beta` refuses.

## Two things beyond the issue's scope, both small

**`--locale` was never validated here either.** It now is, through the same `validateScope` the backfill already used. That reaches `measure-tag-sequence-parity.js` as well, since it imports `collectTargets` and this module parses its flags at module scope against the importer's argv — `--locale ed` there produced the same clean-looking zero and now exits 2. (That closes half of #676's finding 3 as a side effect.)

**Scoping moved ahead of `buildEnglishFenceHistory`.** Being told you mistyped an id *after* a full-corpus `git log` is a worse version of the same message. The walk is still corpus-wide — `--id` scopes the comparison, not the history. That is #635, deliberately untouched, and the code says so where a reader would otherwise assume this PR fixed it.

## Must-go-red

Both measured against `npm run test:scripts` — the command CI runs — on a 529-test green baseline:

| mutation | result |
|---|---|
| delete the `process.exit(2)` in `collectTargets` | exit 1, **4 failing** — all four refusals |
| neuter the `onlyId` arm of `validateScope` | exit 1, **3 failing** — the locale case stays green |

The second number is the one worth having. It shows the four tests are not one test written four ways: the locale arm and the id arm are covered separately, and a mutation to either is visible alone. Both kills are narrow (4 and 3 of 529) and neither prints a runtime error, so neither is the crash-shaped false kill `mutation-verdict.js` exists to flag. Restores verified byte-identical against the pre-mutation copies.

## Docblock correction, and what it turned up

`validateScope` claimed it was "shared so the three callers cannot disagree". It had **one**. Replacing the number with an inventory found what the number was hiding: `normalize-i18n-fences.js:408-417` carries a hand copy of the `--tree` arm which **omits the unknown-tree-name check and validates no locale** — so it is the weaker guard, in the one tool of the three that writes. Converting it changes behaviour rather than spelling, so it is **#677** rather than a drive-by here.

AC5 done: the `filesCompared` caveat is dropped from `CLAUDE.md` § Editing a frozen fence in English, and replaced by what is now true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw
