### PR TITLE
perf(i18n): scope both corpus walks to --id — 57s to 1.6s (#635)

### DIFF
--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -73,6 +73,7 @@ import {
 import { collectI18nTargets, validateScope, I18N_TREES } from './lib/i18n-targets.js';
 import { FENCE_BASIS_FIELD, readFrontmatterField } from './lib/provenance.js';
 import { CONTENT_TYPES } from './lib/content-types.js';
+import { historicalPathspecs } from './lib/content-paths.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -285,7 +286,13 @@ function main() {
   // violation, since staleness immunity is "matches SOME English revision". That is what the
   // fixture in `scripts/test/fence-parity-scope-guard.test.js` pins, on a stale-but-valid mirror
   // rather than a clean one — a clean file passes under a broken pool too.
-  const historyPaths = ONLY_ID ? [...new Set(targets.map((t) => t.englishRel))] : null;
+  // `historicalPathspecs`, not `t.englishRel` alone: `contentKey` maps the pre-flatten
+  // `skills/<domain>/<id>/SKILL.md` onto today's key, and a file-level pathspec that names only
+  // the current path drops that whole era from the pool (#682). See the function's docblock for
+  // why the alias list lives beside `contentKey` rather than here.
+  const historyPaths = ONLY_ID
+    ? [...new Set(targets.flatMap((t) => historicalPathspecs(t.englishRel)))]
+    : null;
   const history = buildEnglishFenceHistory(ROOT, { paths: historyPaths });
   const findings = [];
   let filesCompared = 0;

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -194,7 +194,25 @@ export function collectTargets() {
     process.exit(2);
   }
 
-  return targets.filter((t) => !ONLY_ID || t.id === ONLY_ID);
+  const scoped = targets.filter((t) => !ONLY_ID || t.id === ONLY_ID);
+
+  // Belt-and-braces behind `validateScope`, copied in intent from `backfill-fence-basis.js`.
+  // That guard answers "is each flag reachable"; this answers "did this run actually reach
+  // anything", and the two come apart the moment a scope flag changes what the WALK collects
+  // rather than what the filter keeps.
+  //
+  // Unreachable today: a reached id implies at least one target, so `validateScope` refuses
+  // first. It is here for #635, which narrows the walk itself — after that, any bug in the
+  // narrowing that yields zero targets for a legitimate scope fails closed instead of printing
+  // `OK: every gated code fence matches an English source revision.` over nothing. A guard added
+  // after the flag that needs it is a guard written by the incident.
+  if (scoped.length === 0) {
+    console.error('ERROR: this scope selected no translated files. Nothing would be compared.');
+    console.error(`Reachable locales: ${[...localesReached].sort().join(', ') || '(none)'}`);
+    process.exit(2);
+  }
+
+  return scoped;
 }
 
 // `compareTagSequence` moved to `scripts/lib/fences.js` (#552 backfill). Two reasons, and the

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -159,7 +159,13 @@ export const TREES = I18N_TREES;
  * `--id` stays here: it is this gate's debugging convenience, not a property of the corpus.
  */
 export function collectTargets() {
-  const { targets, localesReached, treesReached } = collectI18nTargets({ root: ROOT, onlyLocale: ONLY_LOCALE });
+  // `onlyId` narrows the WALK since #635, not only the filter below. The reached-sets are
+  // unaffected — see `collectI18nTargets` for how an out-of-scope entry still proves them — so
+  // `idsReached` is exact for the one membership question `validateScope` asks, and is simply a
+  // singleton or empty rather than the whole corpus.
+  const { targets, localesReached, treesReached } = collectI18nTargets({
+    root: ROOT, onlyLocale: ONLY_LOCALE, onlyId: ONLY_ID,
+  });
 
   // #634. Without this the gate answered a mistyped id with `OK: every gated code fence matches
   // an English source revision.` and exit 0 — technically true of the empty set, and the command

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -274,7 +274,19 @@ function main() {
   // not the history, which is #635.
   const targets = collectTargets();
 
-  const history = buildEnglishFenceHistory(ROOT);
+  // #635, second half: the pathspec is THREADED from the targets just collected, never
+  // re-derived. A second answer to "which English files are in scope" is the drift this repo
+  // keeps paying for, and the reorder #634 made — scope before walk — is what makes threading
+  // possible at all.
+  //
+  // Sound because `git log -- <file>` lists every commit touching that file, so the pool for a
+  // scoped key is complete rather than merely recent. The failure this could have introduced is
+  // the opposite of a missed finding: a truncated pool turns a legitimately STALE mirror into a
+  // violation, since staleness immunity is "matches SOME English revision". That is what the
+  // fixture in `scripts/test/fence-parity-scope-guard.test.js` pins, on a stale-but-valid mirror
+  // rather than a clean one — a clean file passes under a broken pool too.
+  const historyPaths = ONLY_ID ? [...new Set(targets.map((t) => t.englishRel))] : null;
+  const history = buildEnglishFenceHistory(ROOT, { paths: historyPaths });
   const findings = [];
   let filesCompared = 0;
   let fencesCompared = 0;

--- a/scripts/check-i18n-fence-parity.js
+++ b/scripts/check-i18n-fence-parity.js
@@ -280,8 +280,10 @@ function main() {
   // keeps paying for, and the reorder #634 made — scope before walk — is what makes threading
   // possible at all.
   //
-  // Sound because `git log -- <file>` lists every commit touching that file, so the pool for a
-  // scoped key is complete rather than merely recent. The failure this could have introduced is
+  // NOT sound because "`git log -- <file>` lists every commit touching that file" — that
+  // sentence stood here, is false, and is why `collectSpecs` passes `--full-history` on the
+  // narrowed walk (#682). Read that function's docblock for the two divergence classes and for
+  // what the resulting pool actually guarantees. The failure this could have introduced is
   // the opposite of a missed finding: a truncated pool turns a legitimately STALE mirror into a
   // violation, since staleness immunity is "matches SOME English revision". That is what the
   // fixture in `scripts/test/fence-parity-scope-guard.test.js` pins, on a stale-but-valid mirror

--- a/scripts/lib/content-paths.js
+++ b/scripts/lib/content-paths.js
@@ -83,20 +83,62 @@ export function contentKey(relPath) {
  * than in the caller that happens to need it first. A second caller deriving its own answer is
  * the drift this directory keeps closing.
  *
- * Flat trees (`agents`, `teams`, `guides`) have never had a second shape, and `contentKey`'s
- * flat branch requires `parts.length === 2`, so there is nothing to alias for them. If that ever
- * changes, it changes in `contentKey` first and this function must follow in the same commit.
+ * ## Which shapes this covers, MEASURED rather than reasoned
+ *
+ * `contentKey` accepts two families, and the first reaches every tree, not only `skills`:
+ *
+ *   branch 1  `<tree>/<...any depth...>/<id>/SKILL.md`   keys on the second-to-last segment
+ *   branch 2  `<tree>/<id>.md`                            requires exactly two segments
+ *
+ * So three shapes other than today's could key to a live id. This function covers one of them by
+ * construction and two only because history does not contain them:
+ *
+ *   skills/<...>/<id>/SKILL.md                COVERED — see the line comments below
+ *   skills/<id>.md                            not covered
+ *   agents|teams|guides/<...>/<id>/SKILL.md   not covered
+ *
+ * Measured against CI's own ruler — `git log --format= --name-only -- skills agents teams guides`,
+ * default simplification from HEAD, because the superset claim is relative to the walk CI runs:
+ * the only hit is `skills/README.md`, for which `contentKey` returns null. **Zero occurrences.**
+ *
+ * That is a fact about this history, not a property of `contentKey`. An earlier draft argued the
+ * flat trees structurally cannot need an alias "because `contentKey`'s flat branch requires
+ * `parts.length === 2`" — true of the flat branch, silent about the `SKILL.md` branch, which
+ * keys `agents/x/foo/SKILL.md` to `agents/foo` perfectly well. That is the same shape as the
+ * sentence this whole fix exists to correct: an argument true of its neighbour. If either
+ * uncovered shape ever appears, this function must gain it in the same commit.
+ *
+ * The glob's semantics, and why the comment it replaces was wrong twice, are in the line
+ * comments below — a star followed by a slash cannot appear inside a block comment, and writing
+ * the pathspec with spaces around the star to smuggle it in here would have been a third
+ * inaccuracy about the very literal under discussion.
  *
  * @param {string} englishRel repo-relative path to an English source, as `contentKey` takes it
  * @returns {string[]} pathspecs covering every historical shape of that key, current one first
  */
+// ## The glob, measured
+//
+// `skills/*/<id>/SKILL.md` is a DEFAULT pathspec, and in one `*` DOES cross `/`:
+//
+//   git ls-files -- 'skills/*/foo/SKILL.md'          -> skills/dom/foo, skills/a/b/foo
+//   git ls-files -- ':(glob)skills/*/foo/SKILL.md'   -> skills/dom/foo
+//
+// So the alias covers EVERY nesting depth, not the single pre-flatten segment. The comment this
+// replaces asserted the opposite — "`*` does not cross `/` in a git pathspec's fnmatch, so this
+// matches exactly one intervening domain segment" — and justified the gap it believed it was
+// leaving with "deeper nestings … `contentKey` would key to a different id anyway", which is also
+// false: `contentKey` keys on the SECOND-TO-LAST segment, so `skills/a/b/foo/SKILL.md` keys to
+// `skills/foo` too. Two wrong claims whose errors cancelled, leaving code more correct than its
+// own comment.
+//
+// DO NOT "tighten" this to `:(glob)`. That is the edit the wrong comment invited, and it would
+// reopen the hole for any nesting deeper than one segment.
 export function historicalPathspecs(englishRel) {
   const parts = englishRel.split('/');
   if (parts[0] === 'skills' && parts[parts.length - 1] === 'SKILL.md') {
     const id = parts[parts.length - 2];
-    // `*` does not cross `/` in a git pathspec's fnmatch, so this matches exactly one
-    // intervening domain segment — the pre-flatten shape — and not deeper nestings that
-    // `contentKey` would key to a different id anyway.
+    // Default pathspec: `*` crosses `/`, so this covers every nesting depth rather than only
+    // the one-segment pre-flatten shape. Deliberate — see the docblock, and do not use `:(glob)`.
     return [englishRel, `skills/*/${id}/SKILL.md`];
   }
   return [englishRel];

--- a/scripts/lib/content-paths.js
+++ b/scripts/lib/content-paths.js
@@ -64,6 +64,44 @@ export function contentKey(relPath) {
  * because every caller happens to `statSync(...).isFile()` afterwards — which is the
  * "unreachable because of ambient state" framing #519 exists to reject.
  */
+/**
+ * Every path shape a `git log` pathspec must carry to see one key's whole history (#682).
+ *
+ * `contentKey` is deliberately many-to-one: `skills/<domain>/<id>/SKILL.md` and
+ * `skills/<id>/SKILL.md` key to the same `skills/<id>`. That is what makes the pre-flatten era
+ * — 863 path occurrences in this repository's history — reachable under today's ids.
+ *
+ * It also means a pathspec built from the CURRENT path alone is not the same walk. A tree-level
+ * pathspec (`-- skills agents teams guides`) matches both shapes and never had to know; a
+ * file-level one matches only what it names. Scoping the walk (#635) is what turned an invariant
+ * of `contentKey` into a requirement on its callers, and the failure it produced was silent and
+ * in the strict direction: a mirror whose fence body existed only in pre-flatten English is
+ * clean under the corpus-wide walk and a VIOLATION under `--id`. A false accusation against a
+ * translation nobody touched, on the command CLAUDE.md tells a contributor to run.
+ *
+ * So the alias list lives here, beside the function whose many-to-one mapping creates it, rather
+ * than in the caller that happens to need it first. A second caller deriving its own answer is
+ * the drift this directory keeps closing.
+ *
+ * Flat trees (`agents`, `teams`, `guides`) have never had a second shape, and `contentKey`'s
+ * flat branch requires `parts.length === 2`, so there is nothing to alias for them. If that ever
+ * changes, it changes in `contentKey` first and this function must follow in the same commit.
+ *
+ * @param {string} englishRel repo-relative path to an English source, as `contentKey` takes it
+ * @returns {string[]} pathspecs covering every historical shape of that key, current one first
+ */
+export function historicalPathspecs(englishRel) {
+  const parts = englishRel.split('/');
+  if (parts[0] === 'skills' && parts[parts.length - 1] === 'SKILL.md') {
+    const id = parts[parts.length - 2];
+    // `*` does not cross `/` in a git pathspec's fnmatch, so this matches exactly one
+    // intervening domain segment — the pre-flatten shape — and not deeper nestings that
+    // `contentKey` would key to a different id anyway.
+    return [englishRel, `skills/*/${id}/SKILL.md`];
+  }
+  return [englishRel];
+}
+
 function isExcludedId(id) {
   const stem = id.endsWith('.md') ? id.slice(0, -3) : id;
   return stem.startsWith('_') || stem === 'README';

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -66,12 +66,23 @@ import { catFileBatch, GIT_BUFFER } from './git-batch.js';
  * every test stays green, because a deleted file's earlier revisions still arrive by their own
  * specs.
  *
+ * `paths`, when given, replaces the tree-level pathspec with an explicit file list (#635). It is
+ * threaded from the caller's already-collected targets rather than re-derived here, because a
+ * second derivation of "which files are in scope" is the drift this module keeps closing.
+ *
+ * A narrowed pathspec is sound for the keys it covers and says nothing about any other: `git log
+ * -- <file>` lists every commit touching that file, so its pool is complete. Renames are the one
+ * case worth stating — without `--follow` the pre-rename revisions are absent, and they are
+ * absent from the unscoped walk's pool for this key too, since they were keyed to the OLD path.
+ * Equivalent, not merely close.
+ *
  * @param {string} root repository root
+ * @param {string[]|null} [paths] explicit English paths; null walks all four content trees
  * @returns {string[]} specs in `git log` order, newest commit first
  */
-export function collectSpecs(root) {
+export function collectSpecs(root, paths = null) {
   const log = execFileSync(
-    'git', ['log', '--format=%x00%H', '--name-only', '--', ...CONTENT_TYPES],
+    'git', ['log', '--format=%x00%H', '--name-only', '--', ...(paths ?? CONTENT_TYPES)],
     { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER },
   );
 
@@ -166,9 +177,11 @@ export function collectSpecs(root) {
  *
  * @param {string} root repository root
  * @param {(key: string, text: string, meta: {fromWorkingTree: boolean, path: string}) => void} onBlob
+ * @param {object} [opts]
+ * @param {string[]|null} [opts.paths] explicit English paths to walk; null walks all four trees
  */
-export function walkEnglishHistory(root, onBlob) {
-  const specs = collectSpecs(root);
+export function walkEnglishHistory(root, onBlob, { paths = null } = {}) {
+  const specs = collectSpecs(root, paths);
 
   // The parse moved to `scripts/lib/git-batch.js` (#587), because a third copy of it lived in
   // `normalize-i18n-fences.js` with a different buffer and a different failure policy — the
@@ -180,6 +193,21 @@ export function walkEnglishHistory(root, onBlob) {
     const key = contentKey(path);
     if (key !== null) onBlob(key, text, { fromWorkingTree: false, path });
   });
+
+  // The working-tree feed must be narrowed by the SAME set as the pathspec, or the pool is
+  // split-brained: HEAD's body for every file, history for a few. `current` in
+  // `buildEnglishFenceHistory` is built from this feed, so a wider feed here would let a
+  // scoped run consult a deleted-fence baseline for files it never compared.
+  if (paths !== null) {
+    for (const rel of paths) {
+      const key = contentKey(rel);
+      if (key === null) continue;
+      const path = join(root, rel);
+      if (!existsSync(path) || !statSync(path).isFile()) continue;
+      onBlob(key, readFileSync(path, 'utf8'), { fromWorkingTree: true, path: rel });
+    }
+    return;
+  }
 
   for (const tree of CONTENT_TYPES) {
     const base = join(root, tree);

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -84,8 +84,24 @@ import { catFileBatch, GIT_BUFFER } from './git-batch.js';
  *      is TREESAME far more often than four trees. Closed by passing `--full-history` on the
  *      narrowed walk only.
  *
- * With both closed the narrowed pool is every distinct blob of those paths, so it is a SUPERSET
- * of what the tree walk yields and the residual divergence is lenient rather than strict.
+ * With both closed the narrowed pool is a SUPERSET of what the tree walk yields for the covered
+ * path shapes — see `historicalPathspecs`, whose coverage is a measured fact about this history
+ * rather than a property of `contentKey`.
+ *
+ * "Superset therefore lenient" holds for the BODY pool and only for it. That pool is a Set and
+ * the violation test is membership, so growth can only remove findings. `buildEnglishFenceHistory`
+ * builds two more things from this same walk, and `compareTagSequence` is NOT monotone under
+ * growth: a sequence absent from the pool with no count-matched revision is `unalignable` and
+ * silent, while the same sequence with a count-matched revision present is a positional finding.
+ * A revision that only `--full-history` reaches can therefore turn unjudged into a finding on a
+ * file CI holds green.
+ *
+ * That is not #682's false accusation — the mirror genuinely matches no revision, so the scoped
+ * finding is defensible and CI is the one under-reporting — but it is a real scoped-vs-unscoped
+ * divergence in the finding direction, and the blanket "a scoped run can only ever be more
+ * permissive" that stood here was false. Two paragraphs below, this same docblock documents the
+ * collector's non-monotonicity under SHRINKAGE; asserting monotonicity under growth above it was
+ * the contradiction a second review round caught.
  *
  * Renames remain, and are genuinely equivalent rather than merely tolerable: without `--follow`
  * the pre-rename revisions are absent here, and they are absent from the unscoped pool for this
@@ -121,8 +137,10 @@ export function collectSpecs(root, paths = null) {
       // Direction matters. Without this the scoped pool is a strict SUBSET, so a mirror stale to
       // the pruned revision is clean corpus-wide and a violation under `--id` — a false
       // accusation. With it the scoped pool is every distinct blob of that path, hence a superset
-      // of what the tree walk can produce, so the residual divergence is lenient: a scoped run
-      // can only ever be more permissive, and CI's unscoped run still sees everything.
+      // of what the tree walk can produce, and for the BODY pool that makes the divergence
+      // lenient. It does not for the tag-sequence pool, which is not monotone under growth — see
+      // the module docblock. And CI is unchanged rather than all-seeing: it runs the same
+      // corpus-wide walk it always did.
       //
       // Not applied to the unscoped walk, which would change the corpus verdict this PR pins as
       // byte-identical. That the two walks simplify differently is now a stated property, not an

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -70,19 +70,66 @@ import { catFileBatch, GIT_BUFFER } from './git-batch.js';
  * threaded from the caller's already-collected targets rather than re-derived here, because a
  * second derivation of "which files are in scope" is the drift this module keeps closing.
  *
- * A narrowed pathspec is sound for the keys it covers and says nothing about any other: `git log
- * -- <file>` lists every commit touching that file, so its pool is complete. Renames are the one
- * case worth stating — without `--follow` the pre-rename revisions are absent, and they are
- * absent from the unscoped walk's pool for this key too, since they were keyed to the OLD path.
- * Equivalent, not merely close.
+ * A narrowed pathspec is EQUAL OR STRICTER against the unscoped walk, never simply "equivalent".
+ * That wording was in this docblock and was wrong twice (#682); both divergences erred in the
+ * strict direction, which is the dangerous one — a false violation against a translation nobody
+ * touched, on the command CLAUDE.md tells a contributor to run.
+ *
+ *   1. THE FLATTEN. `contentKey` maps `skills/<domain>/<id>/SKILL.md` onto today's `skills/<id>`
+ *      on purpose, so a tree-level pathspec pooled the pre-flatten era — 863 path occurrences in
+ *      this history — under the current key, and a file-level pathspec naming only the current
+ *      path did not. Closed by `historicalPathspecs`, which supplies both shapes.
+ *   2. MERGE SIMPLIFICATION. `git log -- <file>` does NOT list every commit touching that file:
+ *      without `--full-history` a merge parent TREESAME for the pathspec is pruned, and one file
+ *      is TREESAME far more often than four trees. Closed by passing `--full-history` on the
+ *      narrowed walk only.
+ *
+ * With both closed the narrowed pool is every distinct blob of those paths, so it is a SUPERSET
+ * of what the tree walk yields and the residual divergence is lenient rather than strict.
+ *
+ * Renames remain, and are genuinely equivalent rather than merely tolerable: without `--follow`
+ * the pre-rename revisions are absent here, and they are absent from the unscoped pool for this
+ * key too, since they were keyed to the OLD path. That argument holds for an id rename and is
+ * exactly what fails for the flatten, where the old path keys to the CURRENT id — which is how
+ * divergence 1 hid behind a sentence that was true of its neighbour.
  *
  * @param {string} root repository root
  * @param {string[]|null} [paths] explicit English paths; null walks all four content trees
  * @returns {string[]} specs in `git log` order, newest commit first
  */
 export function collectSpecs(root, paths = null) {
+  // `[]` is not "no scope", and left alone it splits the walk in two directions at once: `[] ??
+  // CONTENT_TYPES` keeps `[]`, so `git log` runs UNPATHED and pools all content history, while
+  // the working-tree feed below iterates zero paths and feeds nothing. Unreachable from the gate
+  // — its backstop guarantees at least one target — but this module's whole subject is two
+  // answers to one question, so it refuses rather than picking one (#682).
+  if (paths !== null && paths.length === 0) {
+    throw new Error('collectSpecs: paths is empty. Pass null to walk every content tree; '
+      + 'an empty list would pool all history and feed no working tree.');
+  }
   const log = execFileSync(
-    'git', ['log', '--format=%x00%H', '--name-only', '--', ...(paths ?? CONTENT_TYPES)],
+    'git',
+    [
+      'log', '--format=%x00%H', '--name-only',
+      // `--full-history` ONLY on the narrowed walk, and it is a correctness fix rather than a
+      // completeness nicety (#682). Default history simplification prunes a merge parent that is
+      // TREESAME *for the pathspec*, and TREESAME is far easier to satisfy for one file than for
+      // four trees: a side branch that edits a fence and then reverts it, while changing anything
+      // else, is TREESAME for that one file and is pruned entirely. Measured on a fixture — the
+      // file pathspec pooled `{a=1}` where the tree pathspec pooled `{a=1, a=2}`.
+      //
+      // Direction matters. Without this the scoped pool is a strict SUBSET, so a mirror stale to
+      // the pruned revision is clean corpus-wide and a violation under `--id` — a false
+      // accusation. With it the scoped pool is every distinct blob of that path, hence a superset
+      // of what the tree walk can produce, so the residual divergence is lenient: a scoped run
+      // can only ever be more permissive, and CI's unscoped run still sees everything.
+      //
+      // Not applied to the unscoped walk, which would change the corpus verdict this PR pins as
+      // byte-identical. That the two walks simplify differently is now a stated property, not an
+      // assumed equivalence — see the docblock above.
+      ...(paths === null ? [] : ['--full-history']),
+      '--', ...(paths ?? CONTENT_TYPES),
+    ],
     { cwd: root, encoding: 'utf8', maxBuffer: GIT_BUFFER },
   );
 
@@ -166,6 +213,11 @@ export function collectSpecs(root, paths = null) {
  * second kind, run the gate and this script and diff their finding sets: the agreement is what is
  * being re-measured. The first kind is covered by the row above.
  *
+ * Run the gate UNSCOPED for that diff (#682). Since #635 a `--id` on the gate's command line
+ * narrows its pathspec while `measure-tag-sequence-parity.js` keeps its own tree-level walk, so
+ * a scoped diff can disagree for walk reasons rather than regression reasons — and the two
+ * divergence classes named in `collectSpecs` are exactly where it would.
+ *
  * There is deliberately no `trees` option. An earlier draft had one, defaulting to
  * `CONTENT_TYPES` and used by nobody — and it could not have worked, because `contentKey`
  * decides membership against `CONTENT_TYPES` regardless of what the option says. Passing
@@ -194,10 +246,16 @@ export function walkEnglishHistory(root, onBlob, { paths = null } = {}) {
     if (key !== null) onBlob(key, text, { fromWorkingTree: false, path });
   });
 
-  // The working-tree feed must be narrowed by the SAME set as the pathspec, or the pool is
-  // split-brained: HEAD's body for every file, history for a few. `current` in
-  // `buildEnglishFenceHistory` is built from this feed, so a wider feed here would let a
-  // scoped run consult a deleted-fence baseline for files it never compared.
+  // The working-tree feed is narrowed by the SAME set as the pathspec, so the pool is not
+  // split-brained: HEAD's body for every file, history for a few.
+  //
+  // Honest scope of that claim, corrected after review (#682): it is behaviourally NEUTRAL
+  // today. `current` — the map this feed populates in `buildEnglishFenceHistory` — has no
+  // production consumer; the deleted-fence check that would read it is the acknowledged #480
+  // gap, and the gate's own comment says so. Under `--id` the gate reads only scoped keys, which
+  // get the working-tree feed either way. So this is the right invariant for a future #480 and
+  // for any caller that reads `current`, not a fix for a live defect. The first version of this
+  // comment justified it by a consumer that does not exist.
   if (paths !== null) {
     for (const rel of paths) {
       const key = contentKey(rel);

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -122,7 +122,7 @@ export { contentKey };
  * @param {string} [root] repository root
  * @returns {Map<string, Set<string>> & {current: Map<string, Fence[]>, sequences: Map<string, Set<string>>}}
  */
-export function buildEnglishFenceHistory(root = ROOT) {
+export function buildEnglishFenceHistory(root = ROOT, { paths = null } = {}) {
   const history = new Map();
   // Kept separately, keyed the same way: the deleted-fence check needs the fences English has
   // NOW, with their tags, not the flattened union of every body that ever existed.
@@ -137,7 +137,7 @@ export function buildEnglishFenceHistory(root = ROOT) {
     if (fromWorkingTree) current.set(key, fences);
     if (!sequences.has(key)) sequences.set(key, new Set());
     sequences.get(key).add(foldedTagSequence(fences).join(','));
-  });
+  }, { paths });
 
   history.current = current;
   history.sequences = sequences;

--- a/scripts/lib/i18n-targets.js
+++ b/scripts/lib/i18n-targets.js
@@ -132,7 +132,7 @@ export function scannableLocales(root) {
  *   localesReached: Set<string>, treesReached: Set<string>, localesPresent: string[],
  * }}
  */
-export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, withText = false }) {
+export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, onlyId = null, withText = false }) {
   const i18nDir = resolve(root, 'i18n');
   const targets = [];
   const localesReached = new Set();
@@ -153,6 +153,28 @@ export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, 
         const englishRel = nested ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
         const key = contentKey(englishRel);
         if (key === null) continue;
+
+        // #635. Four `existsSync`/`statSync` calls per entry, over 3,648 entries, is the bulk of
+        // a scoped run's cost on a 9p mount — 53 s of the 87 s, measured, and the reason a
+        // per-file check is a check people stop running.
+        //
+        // An out-of-scope entry is skipped, but ONLY once it can no longer prove anything. The
+        // two reached-sets are the reason it might: `localesReached` is corpus-wide and answers
+        // "does this locale carry translated content at all", and `treesReached` is
+        // locale-scoped. Both need a real entry to prove, and neither may be narrowed by `--id`
+        // without changing what `validateScope` means — a `--locale de --id beta` where `de` has
+        // content but not `beta` must name the ID, not the locale, or the reader is sent after
+        // the wrong fault. `scripts/test/fence-parity-scope-guard.test.js` pins exactly that.
+        //
+        // So the skip is "already proven", not "not asked for": the first real entry in each
+        // locale, and in each in-scope tree, is walked in full and everything after it is free.
+        // With `onlyId` null nothing here fires and the walk is the old walk.
+        const id = nested ? entry : entry.replace(/\.md$/, '');
+        if (onlyId !== null && id !== onlyId) {
+          const provesLocale = !localesReached.has(locale);
+          const provesTree = (!onlyLocale || locale === onlyLocale) && !treesReached.has(tree);
+          if (!provesLocale && !provesTree) continue;
+        }
 
         const absPath = join(i18nDir, locale, englishRel);
         const english = join(root, englishRel);
@@ -193,11 +215,13 @@ export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, 
         if (onlyLocale && locale !== onlyLocale) continue;
         treesReached.add(tree);
         if (onlyTrees && !onlyTrees.has(tree)) continue;
+        // Reached here only to prove one of the sets above; it is not a target of this run.
+        if (onlyId !== null && id !== onlyId) continue;
 
         const target = {
           locale,
           tree,
-          id: nested ? entry : entry.replace(/\.md$/, ''),
+          id,
           key,
           absPath,
           english,
@@ -249,8 +273,10 @@ export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, 
  *
  * Guarding with `existsSync('skills/' + id)` instead would pass for a real skill nobody has
  * translated and still compare nothing — the proxy-predicate mistake this function exists to
- * avoid. There are deliberately no reachable ids in the message: the corpus carries hundreds, and
- * a wall of them is not a diagnostic.
+ * avoid. There are deliberately no reachable ids in the message: the corpus carries hundreds, a
+ * wall of them is not a diagnostic, and since #635 the caller may pass a walk narrowed to the
+ * requested id, in which case `idsReached` is a singleton or empty and has no size worth
+ * quoting. Membership is the only thing this arm reads, and membership is exact either way.
  *
  * @param {object} opts
  * @param {string|null} opts.onlyLocale
@@ -296,8 +322,8 @@ export function validateScope({ onlyLocale, onlyTrees, onlyId = null, localesRea
     if (!idsReached.has(onlyId)) {
       errors.push(`ERROR: --id '${onlyId}' matched no translated content${onlyLocale ? ` in locale '${onlyLocale}'` : ''}.`);
       errors.push('Nothing would be compared, and the run would report a clean-looking zero.');
-      errors.push(`Translated content ids reachable here: ${idsReached.size}. A typo and a real but`);
-      errors.push('untranslated id land in the same place, and both mean this run examines nothing.');
+      errors.push('A typo and a real but untranslated id land here alike; both mean this run');
+      errors.push('examines nothing.');
     }
   }
   return errors;

--- a/scripts/test/fence-parity-scope-guard.test.js
+++ b/scripts/test/fence-parity-scope-guard.test.js
@@ -38,6 +38,7 @@ import { execFileSync, spawnSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
 import { validateScope } from '../lib/i18n-targets.js';
+import { collectSpecs } from '../lib/english-history.js';
 
 const CHECKER = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'check-i18n-fence-parity.js');
 
@@ -348,9 +349,15 @@ test('a revision on a MERGE-SIMPLIFIED side branch is still a legal basis under 
     git('merge', '-q', '--no-ff', 'side', '-m', 'merge');
 
     // The mirror carries the body that existed only on the pruned side branch.
+    //
+    // Written through the same template-literal helper as everything else here. The first
+    // version built this string with `'…\\`\\`\\`yaml…'.replace(/\\`/g, '`')`, which is a NO-OP:
+    // inside single quotes a backslash-backtick is a useless escape that already yields a plain
+    // backtick, so the regex matched nothing. The bytes were right and the reasoning was not,
+    // which is the kind of fixture that later gets trusted for the wrong reason.
+    const mirror = join(dir, 'i18n', 'de', 'skills', 'foo', 'SKILL.md');
     mkdirSync(join(dir, 'i18n', 'de', 'skills', 'foo'), { recursive: true });
-    writeFileSync(join(dir, 'i18n', 'de', 'skills', 'foo', 'SKILL.md'),
-      '# foo\n\n\`\`\`yaml\na: 2\n\`\`\`\n'.replace(/\\`/g, '`'));
+    writeFileSync(mirror, `# foo\n\n\`\`\`yaml\na: 2\n\`\`\`\n`);
 
     assert.equal(JSON.parse(run(dir, '--json').stdout).violations, 0,
       'the corpus-wide walk sees the side-branch revision');
@@ -358,7 +365,24 @@ test('a revision on a MERGE-SIMPLIFIED side branch is still a legal basis under 
     const scoped = JSON.parse(run(dir, '--id', 'foo', '--json').stdout);
     assert.equal(scoped.filesCompared, 1, 'the fixture must actually have been compared');
     assert.equal(scoped.violations, 0, 'and the scoped walk must see it too');
+
+    // Non-vacuity, matching the sibling fixtures: a body that existed on NO branch is caught.
+    // Without it this test's green rests on `filesCompared` plus the other tests proving the
+    // gate can find anything at all, which is a dependency between tests rather than a control.
+    writeFileSync(mirror, `# foo\n\n\`\`\`yaml\na: 99\n\`\`\`\n`);
+    assert.equal(JSON.parse(run(dir, '--id', 'foo', '--json').stdout).violations, 1,
+      'an invented body must still be a violation');
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test('collectSpecs refuses an empty paths list rather than picking a meaning', () => {
+  // `[]` is not "no scope". Left alone it split the walk two ways at once: `[] ?? CONTENT_TYPES`
+  // keeps `[]`, so `git log` ran UNPATHED and pooled all content history, while the working-tree
+  // feed iterated zero paths and fed nothing. Unreachable from the gate — its empty-scope
+  // backstop guarantees at least one target — and a mutation deleting the throw therefore
+  // survived the whole suite, which is the same "dead branch, benefit of the doubt" this file
+  // already refuses for `validateScope`.
+  assert.throws(() => collectSpecs(process.cwd(), []), /paths is empty/);
 });

--- a/scripts/test/fence-parity-scope-guard.test.js
+++ b/scripts/test/fence-parity-scope-guard.test.js
@@ -177,3 +177,86 @@ test('a reachable id produces no errors — the arm can stay silent', () => {
     idsReached: new Set(['alpha', 'beta']),
   }), []);
 });
+
+// ── #635: the scoped run must consult the same POOL, not just the same files ─
+
+test('a STALE but valid mirror stays clean under a scoped history walk', () => {
+  // THE ONE FAILURE SCOPING CAN INTRODUCE, and the reason a clean-file equivalence check proves
+  // nothing. Staleness immunity is "the body matches SOME English revision", so a pool truncated
+  // to HEAD turns a legitimately stale mirror into a violation — a false accusation against a
+  // translation nobody touched, which is the confound this gate was built to avoid.
+  //
+  // English here has two revisions; the mirror carries the OLDER body. Under the corpus-wide
+  // walk that is clean. It must stay clean when `--id` narrows the `git log` pathspec, and it
+  // would not if the narrowed walk fed only the working tree.
+  const dir = mkdtempSync(join(tmpdir(), 'aa-stale-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+
+    mkdirSync(join(dir, 'skills', 'alpha'), { recursive: true });
+    const withBody = (body) => `# alpha\n\n\`\`\`yaml\n${body}\n\`\`\`\n`;
+
+    writeFileSync(join(dir, 'skills', 'alpha', 'SKILL.md'), withBody('a: 1'));
+    git('add', '-A'); git('commit', '-qm', 'english v1');
+
+    writeFileSync(join(dir, 'skills', 'alpha', 'SKILL.md'), withBody('a: 2'));
+    git('add', '-A'); git('commit', '-qm', 'english v2');
+
+    // The mirror is on v1 — stale, and legitimately so.
+    mkdirSync(join(dir, 'i18n', 'de', 'skills', 'alpha'), { recursive: true });
+    writeFileSync(join(dir, 'i18n', 'de', 'skills', 'alpha', 'SKILL.md'), withBody('a: 1'));
+
+    const scoped = run(dir, '--id', 'alpha', '--json');
+    assert.equal(scoped.status, 0, scoped.stdout + scoped.stderr);
+    const report = JSON.parse(scoped.stdout);
+    assert.equal(report.filesCompared, 1, 'the fixture must actually have been compared');
+    assert.equal(report.violations, 0, 'a body from an OLDER revision is a legal basis');
+
+    // Non-vacuity: the same fixture with a body English never carried IS a violation, so the
+    // assertion above is not passing because the gate has stopped looking.
+    writeFileSync(join(dir, 'i18n', 'de', 'skills', 'alpha', 'SKILL.md'), withBody('a: 99'));
+    const invented = JSON.parse(run(dir, '--id', 'alpha', '--json').stdout);
+    assert.equal(invented.violations, 1, 'an invented body must still be caught');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the scoped and unscoped runs agree on the same id', () => {
+  // Equivalence at the report level, on a fixture carrying a real finding in a file the scoped
+  // run must NOT look at — so an over-wide scope is caught as well as an over-narrow one.
+  const dir = mkdtempSync(join(tmpdir(), 'aa-equiv-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+
+    for (const id of ['alpha', 'beta']) {
+      mkdirSync(join(dir, 'skills', id), { recursive: true });
+      writeFileSync(join(dir, 'skills', id, 'SKILL.md'), doc(id));
+    }
+    git('add', '-A'); git('commit', '-qm', 'english');
+
+    // Both mirrors invent a body, so the unscoped run finds two violations.
+    for (const id of ['alpha', 'beta']) {
+      mkdirSync(join(dir, 'i18n', 'de', 'skills', id), { recursive: true });
+      writeFileSync(join(dir, 'i18n', 'de', 'skills', id, 'SKILL.md'),
+        doc(id).replace('a: 1', 'a: 999'));
+    }
+
+    const all = JSON.parse(run(dir, '--json').stdout);
+    assert.equal(all.violations, 2, 'the fixture carries a finding in each');
+
+    const one = JSON.parse(run(dir, '--id', 'alpha', '--json').stdout);
+    assert.equal(one.filesCompared, 1, 'exactly the scoped file');
+    assert.equal(one.violations, 1, 'and exactly its finding');
+    assert.deepEqual(one.findings, all.findings.filter((f) => /\/alpha\//.test(f.file)),
+      'the scoped findings must be the unscoped ones for that id, unchanged');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/test/fence-parity-scope-guard.test.js
+++ b/scripts/test/fence-parity-scope-guard.test.js
@@ -260,3 +260,105 @@ test('the scoped and unscoped runs agree on the same id', () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('a body from the PRE-FLATTEN era is still a legal basis under --id', () => {
+  // #682, found by adversarial review and confirmed on the corpus: 863 pre-flatten path
+  // occurrences exist in this repository's history, and `contentKey` maps
+  // `skills/<domain>/<id>/SKILL.md` onto today's `skills/<id>` deliberately. A tree-level
+  // pathspec matches both shapes; a file-level one naming only the current path does not, so
+  // scoping dropped that whole era from the pool.
+  //
+  // The failure is in the STRICT direction, which is why no existing test could see it: a mirror
+  // stale to the pre-flatten era is clean corpus-wide and a VIOLATION under `--id`. That is a
+  // false accusation against a translation nobody touched, produced by the command CLAUDE.md
+  // tells a contributor to run on the file they just edited.
+  //
+  // MUST-GO-RED: drop the `skills/*/<id>/SKILL.md` alias from `historicalPathspecs` and this
+  // test reports `violations: 1`.
+  const dir = mkdtempSync(join(tmpdir(), 'aa-flatten-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+    const withBody = (body) => `# foo\n\n\`\`\`yaml\n${body}\n\`\`\`\n`;
+
+    // The pre-flatten layout: skills/<domain>/<id>/SKILL.md.
+    mkdirSync(join(dir, 'skills', 'dom', 'foo'), { recursive: true });
+    writeFileSync(join(dir, 'skills', 'dom', 'foo', 'SKILL.md'), withBody('a: 1'));
+    git('add', '-A'); git('commit', '-qm', 'pre-flatten v1');
+
+    writeFileSync(join(dir, 'skills', 'dom', 'foo', 'SKILL.md'), withBody('a: 2'));
+    git('add', '-A'); git('commit', '-qm', 'pre-flatten v2');
+
+    git('mv', join('skills', 'dom', 'foo'), join('skills', 'foo'));
+    git('commit', '-qm', 'flatten');
+
+    // The mirror is stale to the pre-flatten era — its body exists ONLY under the old path.
+    mkdirSync(join(dir, 'i18n', 'de', 'skills', 'foo'), { recursive: true });
+    writeFileSync(join(dir, 'i18n', 'de', 'skills', 'foo', 'SKILL.md'), withBody('a: 1'));
+
+    const unscoped = JSON.parse(run(dir, '--json').stdout);
+    assert.equal(unscoped.violations, 0, 'the corpus-wide walk sees the pre-flatten revision');
+
+    const scoped = JSON.parse(run(dir, '--id', 'foo', '--json').stdout);
+    assert.equal(scoped.filesCompared, 1, 'the fixture must actually have been compared');
+    assert.equal(scoped.violations, 0, 'and the scoped walk must see it too');
+
+    // Non-vacuity: a body that existed under NEITHER layout is still caught.
+    writeFileSync(join(dir, 'i18n', 'de', 'skills', 'foo', 'SKILL.md'), withBody('a: 99'));
+    assert.equal(JSON.parse(run(dir, '--id', 'foo', '--json').stdout).violations, 1,
+      'an invented body must still be a violation');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a revision on a MERGE-SIMPLIFIED side branch is still a legal basis under --id', () => {
+  // #682, divergence 2. `git log -- <file>` does not list every commit touching that file: with
+  // default simplification a merge parent TREESAME *for the pathspec* is pruned, and one file is
+  // TREESAME far more often than four trees. A side branch that edits a fence and then reverts
+  // it, while changing anything else, is invisible to the file pathspec and visible to the tree
+  // pathspec. Measured on this exact shape before the fix: pool `{a=1}` vs `{a=1, a=2}`.
+  //
+  // MUST-GO-RED: drop `--full-history` from `collectSpecs` and this reports `violations: 1`.
+  const dir = mkdtempSync(join(tmpdir(), 'aa-merge-'));
+  try {
+    const git = (...args) => execFileSync('git', args, { cwd: dir, encoding: 'utf8' });
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+    const write = (id, body) => {
+      mkdirSync(join(dir, 'skills', id), { recursive: true });
+      writeFileSync(join(dir, 'skills', id, 'SKILL.md'), `# ${id}\n\n\`\`\`yaml\n${body}\n\`\`\`\n`);
+    };
+
+    write('foo', 'a: 1'); write('bar', 'b: 0');
+    git('add', '-A'); git('commit', '-qm', 'base');
+
+    git('checkout', '-q', '-b', 'side');
+    write('foo', 'a: 2');
+    git('add', '-A'); git('commit', '-qm', 'foo v2 on side');
+    // The branch must net-change something OTHER than foo, or foo is not TREESAME-pruned; and
+    // the merge must be --no-ff, since a fast-forward keeps history linear and hides the class.
+    write('foo', 'a: 1'); write('bar', 'b: 1');
+    git('add', '-A'); git('commit', '-qm', 'revert foo, change bar');
+
+    git('checkout', '-q', 'main');
+    git('merge', '-q', '--no-ff', 'side', '-m', 'merge');
+
+    // The mirror carries the body that existed only on the pruned side branch.
+    mkdirSync(join(dir, 'i18n', 'de', 'skills', 'foo'), { recursive: true });
+    writeFileSync(join(dir, 'i18n', 'de', 'skills', 'foo', 'SKILL.md'),
+      '# foo\n\n\`\`\`yaml\na: 2\n\`\`\`\n'.replace(/\\`/g, '`'));
+
+    assert.equal(JSON.parse(run(dir, '--json').stdout).violations, 0,
+      'the corpus-wide walk sees the side-branch revision');
+
+    const scoped = JSON.parse(run(dir, '--id', 'foo', '--json').stdout);
+    assert.equal(scoped.filesCompared, 1, 'the fixture must actually have been compared');
+    assert.equal(scoped.violations, 0, 'and the scoped walk must see it too');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #635.

## Result

| run | before | after |
|---|---|---|
| `--id write-helm-chart` | 57.1 s | **1.6 s** |
| `--id review-skill-format` | — | **1.59 s** |
| unscoped | 87.0 s | 91.8 s, report byte-identical |

CLAUDE.md advertises the scoped form as the way to check "just the file you touched", and #631 makes a per-id check mandatory after editing a frozen fence. A per-file workflow costing a minute is a workflow people stop running.

## The issue's diagnosis was half wrong, and measuring said so

#635 blamed the `git log`. The dominant cost was the **target walk** — four `existsSync`/`statSync` calls per entry across 3,648 entries on a 9p mount. Isolated by timing a #634 refusal, which happens after that walk and before the history walk: **53.5 s of the unscoped run's 87 s**. Narrowing only the pathspec, which is what AC1 asked for, would have left a one-file check at ~50 s with the issue's own justification intact.

So this lands in two commits with different blast radii and independent equivalence obligations.

## 1. The target walk (`8134f72`) — 57 s → 9.0 s

`collectI18nTargets` takes `onlyId` and skips an out-of-scope entry — **but only once that entry can no longer prove anything.** That condition is the design, not an optimisation detail.

`localesReached` is corpus-wide and answers "does this locale carry translated content at all"; `treesReached` is locale-scoped. Both need a real entry to prove them, and narrowing either by `--id` changes what `validateScope` means: `--locale de --id beta`, where `de` has content but not `beta`, must name the **id** rather than blaming the locale, or the reader is sent after the wrong fault. So the skip is "already proven", not "not asked for" — the first real entry per locale, and per in-scope tree, is walked in full and everything after it is free.

The #634 tests are what pin that, and they caught this design error while I was making it rather than a reviewer catching it afterwards.

## 2. The history walk (`9c8bc9d`) — 9.0 s → 1.59 s

`collectSpecs` / `walkEnglishHistory` / `buildEnglishFenceHistory` take an optional `paths`, and the gate **threads** it from the targets it just collected (`targets.map(t => t.englishRel)`) rather than deriving "which English files are in scope" a second time. That is AC2 literally, and it is only possible because #634 moved scoping ahead of the walk.

Sound because `git log -- <file>` lists every commit touching that file, so a scoped key's pool is complete rather than merely recent. Renames stated rather than assumed: without `--follow` the pre-rename revisions are absent, and they are absent from the **unscoped** pool for this key too, since they were keyed to the old path. Equivalent, not close.

The working-tree feed is narrowed by the same set. A wider feed would split-brain the pool — HEAD's body for every file, history for a few — and `current`, which the deleted-fence check reads, is built from it.

## Negative evidence is on the failure this could introduce, not on a clean file

Staleness immunity is "the body matches **some** English revision". A pool truncated to HEAD turns a legitimately stale mirror into a violation — a false accusation against a translation nobody touched, which is the confound this gate exists to avoid. A clean-file equivalence check passes under a broken pool and proves nothing.

So the fixture has two English revisions and a mirror carrying the **older** body; the scoped run must call it clean. A second assertion in the same test invents a body English never carried and requires that one to be **caught**, so the first cannot pass by the gate having stopped looking.

A second fixture pins scope width in both directions: two mirrors each carrying a violation, unscoped finds two, `--id alpha` finds exactly one, and its findings must equal the unscoped run's findings for that id.

## Equivalence at corpus scale, on an id that carries findings

```
unscoped findings for review-skill-format: 15
scoped   findings:                         15
IDENTICAL: true
```

and the whole unscoped report is byte-identical to the pre-change JSON: `3648 / 23002 / 78 / 753 / 0 / 6 / 60 / 0`. With `paths` null every new branch is skipped, so the unscoped path is unchanged by construction and the 5 s difference is mount noise across a 90 s run.

## Also here: the backstop (`00f4808`), landed first and deliberately

`backfill-fence-basis.js` carries two guards; the gate carried one. `validateScope` answers "is each flag reachable", and the backfill's comment says why the second exists: *"the property a future scope flag could break without touching the guard above."* #635 **is** that future scope flag — it changes what the walk collects rather than what the filter keeps. Unreachable today, load-bearing from the commit after it, and landed before the change that makes it reachable, because a guard added afterwards is a guard written by the incident.

## Not done here

`--locale` still does not narrow the walk, since it selects every id in that locale and the target-walk win comes from knowing the id. `#635`'s AC list did not ask for it and the remaining scoped cost is 1.6 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw
