### PR TITLE
fix(i18n): fold the two writers' alignment guards through production (#674)

### DIFF
--- a/scripts/check-placeholder-drift.js
+++ b/scripts/check-placeholder-drift.js
@@ -380,8 +380,11 @@ for (const path of changed) {
   if (misaligned >= 0) {
     skippedFiles.push({
       path,
+      // Folded tokens, for the reason the sibling normalizer's label carries (#674): a brace
+      // fence would otherwise be reported as `untagged`, which is not a thing the reader can
+      // find in the file.
       reason: `tag sequence diverges at fence ${misaligned + 1} `
-        + `(${baseFences[misaligned].lang || 'untagged'} -> ${headFences[misaligned].lang || 'untagged'})`,
+        + `(${baseSeq[misaligned]} -> ${headSeq[misaligned]})`,
     });
     continue;
   }

--- a/scripts/check-placeholder-drift.js
+++ b/scripts/check-placeholder-drift.js
@@ -104,7 +104,7 @@
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { spawnSync } from 'child_process';
-import { extractFences, toLines, isGated } from './lib/fences.js';
+import { extractFences, toLines, isGated, foldedTagSequence } from './lib/fences.js';
 import { parseArgs, usageExit } from './lib/parse-args.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -368,8 +368,15 @@ for (const path of changed) {
   // a `text` -> `yaml` retag keeps the count and makes a translated table the
   // "before body" of a frozen fence. The sibling normalizer validates the tag
   // sequence before trusting the ordinal; so does this.
-  const alignmentTag = (f) => (f.lang === '' ? 'text' : f.lang);
-  const misaligned = headFences.findIndex((f, i) => alignmentTag(f) !== alignmentTag(baseFences[i]));
+  //
+  // Through `foldedTagSequence` since #674, and the comment above is the reason the local copy
+  // survived this long: "so does this" was true of the check and false of the FOLD. The copy
+  // here collapsed a brace-info fence to `text` exactly like an untagged one, so a base->head
+  // retag between those two shapes was not reported as a divergence and the comparison went on
+  // to trust an ordinal it had not established.
+  const headSeq = foldedTagSequence(headFences);
+  const baseSeq = foldedTagSequence(baseFences);
+  const misaligned = headSeq.findIndex((tag, i) => tag !== baseSeq[i]);
   if (misaligned >= 0) {
     skippedFiles.push({
       path,

--- a/scripts/measure-tag-sequence-parity.js
+++ b/scripts/measure-tag-sequence-parity.js
@@ -23,10 +23,11 @@
  *
  * Two foldings are load-bearing, and both now come from `lib/fences.js` (`foldedTagSequence`),
  * which is the definition production enforces against. They were originally lifted from
- * `normalize-i18n-fences.js`, and that attribution is deliberately NOT kept: its `alignmentTag`
- * still folds a brace fence to `text`, as its own comment beside `mirrorsBasis` admits — "cannot
- * tell ```{r} from an untagged fence (#612)" — and #674 tracks it. Citing it as the authority for
- * the brace arm would name the module that makes the opposite judgement.
+ * `normalize-i18n-fences.js`, and that attribution is deliberately NOT kept. When #612 moved this
+ * script to the shared fold, that module still carried its own `alignmentTag` — so citing it as
+ * the authority for the brace arm would have named the module making the opposite judgement.
+ * #674 has since given it `foldedTagSequence` too, and the three copies are now one; the
+ * attribution stays with `lib/fences.js`, which is where the definition lives.
  *
  *   - An untagged fence folds to `text`. `normalize-content-style.js --mode fences` retro-tagged
  *     untagged blocks as `text` on the newer side only, so that pairing is an artifact of a

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -86,6 +86,7 @@
  *   node scripts/normalize-i18n-fences.js --locale de    # restrict to one locale
  *   node scripts/normalize-i18n-fences.js --tag yaml,json  # restrict to tags (#477 batches)
  *   node scripts/normalize-i18n-fences.js --tree guides,agents  # restrict to trees
+ *   node scripts/normalize-i18n-fences.js --root /tmp/fixture   # run against another tree
  */
 
 import { readFileSync, writeFileSync } from 'fs';
@@ -152,14 +153,29 @@ const PREVIEW = !WRITE;
 /**
  * `--root` exists so the splice gate can be driven against a fixture (#674).
  *
- * This is the FOURTH appearance of the same untestability defect in this directory —
- * `buildEnglishFenceHistory` closing over its module root (#559), `gate-envelope` before its
- * `--root`, `check-i18n-fence-parity` before its own, and now the one tool of the four that
- * WRITES. #674 could only be demonstrated at component level for exactly this reason: there was
- * no way to run the real normalizer over a corpus you constructed.
+ * #674 could only be demonstrated at component level for exactly this reason: there was no way
+ * to run the real normalizer over a corpus you constructed. Every other fixture in this tool's
+ * test file COPIES `scripts/` into a temp repo to work around it.
  *
- * The rule it keeps teaching, in `english-history.js`'s words: a module that hardcodes its own
- * repo root cannot be tested, so it will not be.
+ * ## How common the retrofit is, counted rather than asserted
+ *
+ * An earlier draft called this "the FOURTH appearance … `buildEnglishFenceHistory` (#559),
+ * `gate-envelope`, `check-i18n-fence-parity`, and this". The number survives and the membership
+ * does not, which is the failure `english-history.js` warns about in as many words: "an
+ * unqualified 'three' is a count the obvious grep refutes". Measured over the 13 scripts here
+ * that take `--root`, comparing each file's creating commit against the commit that introduced
+ * the flag:
+ *
+ *   RETROFITTED (4)  check-i18n-fence-parity.js, generate-translation-status.js,
+ *                    measure-tag-sequence-parity.js, and this file
+ *   BORN WITH IT (9) including `gate-envelope.js`, which the draft named as a retrofit
+ *
+ * So four is right by coincidence. `gate-envelope` was born with the flag — its own comment
+ * explains why, which is presumably how it got into the list. `buildEnglishFenceHistory` (#559)
+ * belongs to the lineage as the FUNCTION-level precedent, not as one of these four.
+ *
+ * The rule it keeps teaching, in `check-i18n-fence-parity.js`'s words: a module that hardcodes
+ * its own repo root cannot be tested, so it will not be.
  */
 const ROOT = resolve(opts.root ?? resolve(__dirname, '..'));
 
@@ -367,9 +383,15 @@ assertNotShallow(ROOT);
 // history from the real repository — and the first fixture written against the new flag reported
 // `no English history for this id` for a file whose English source it had just committed.
 //
-// Latent before the flag existed, which is the same shape #634 found in the parity gate: a
-// module-scope root is invisible until something tries to move it, and the thing that tries is
-// always the first test.
+// Latent before the flag existed, and the precedent is #559 — `buildEnglishFenceHistory`
+// closing over its own module root — not #634, which is a vacuous-scope guard and shares only
+// "latent until first exercised". A module-scope root is invisible until something tries to move
+// it, and the thing that tries is always the first test.
+//
+// Corroborated by timing rather than proven by it: the fixture went from 15 s to 0.35 s once the
+// walk stopped scanning the real corpus. The load-bearing evidence is functional — the run
+// reported `no English history for this id` for a file it had just committed — and a fixture
+// pins that, so the delta is colour and not a measurement to quote elsewhere.
 const history = buildEnglishFenceHistory(ROOT);
 
 // ---- gather targets ----
@@ -521,12 +543,23 @@ for (const t of targets) {
   // removed the third from the measurement script. The stamp guard below already used the
   // shared fold, and the comment beside it said so — "STRICTER than the pre-splice guards" —
   // which is how a known asymmetry sat in the file for two issues without being read as a bug.
+  //
+  // Note what `{` does NOT distinguish: every brace fence folds to the same token, so ```{r}
+  // facing ```{python} still aligns, under this fold and under the old one alike. Inherited
+  // from `foldedTagSequence` by design and shared with the gate and `mirrorsBasis`, so it is
+  // not a regression — but it is the next thing to look at if brace fences ever land in the
+  // corpus, because a splice would then place an `{r}` body under a `{python}` tag.
   const translatedSeq = foldedTagSequence(translatedFences);
   const basisSeq = foldedTagSequence(basisFences);
   const misaligned = translatedSeq.findIndex((tag, i) => tag !== basisSeq[i]);
   if (misaligned >= 0) {
-    const a = translatedFences[misaligned].lang || 'untagged';
-    const b = basisFences[misaligned].lang || 'untagged';
+    // The FOLDED tokens, not `lang || 'untagged'`. That label predates #674 and was accurate
+    // while the only way to reach this branch was a genuine tag difference; the brace case this
+    // fix opens would print "(untagged vs text)" for a ```{r} fence, sending whoever does the
+    // manual repair hunting for an untagged fence that is not in the file. `{` is what the
+    // comparison actually used, so `{` is what the message owes the reader.
+    const a = translatedSeq[misaligned];
+    const b = basisSeq[misaligned];
     skipped.push({ file: t.relPath, reason: `tag sequence diverges at fence ${misaligned + 1} (${a} vs ${b})`, n: divergent.length });
     continue;
   }

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -106,7 +106,6 @@ import { catFileBatch } from './lib/git-batch.js';
 import { collectI18nTargets, presentTrees, scannableLocales } from './lib/i18n-targets.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const ROOT = resolve(__dirname, '..');
 
 const argv = process.argv.slice(2);
 
@@ -132,7 +131,7 @@ const argv = process.argv.slice(2);
  */
 const ARG_SPEC = {
   bool: ['--write', '--dry'],
-  value: ['--basis', '--locale', '--tag', '--tree'],
+  value: ['--basis', '--locale', '--tag', '--tree', '--root'],
 };
 // The parser this file grew is now `scripts/lib/parse-args.js` (#619), because
 // `generate-translation-status.js` had a hand-rolled one that disagreed with it — a third copy
@@ -149,6 +148,20 @@ if (opts.write && opts.dry) {
 }
 const WRITE = opts.write;
 const PREVIEW = !WRITE;
+
+/**
+ * `--root` exists so the splice gate can be driven against a fixture (#674).
+ *
+ * This is the FOURTH appearance of the same untestability defect in this directory —
+ * `buildEnglishFenceHistory` closing over its module root (#559), `gate-envelope` before its
+ * `--root`, `check-i18n-fence-parity` before its own, and now the one tool of the four that
+ * WRITES. #674 could only be demonstrated at component level for exactly this reason: there was
+ * no way to run the real normalizer over a corpus you constructed.
+ *
+ * The rule it keeps teaching, in `english-history.js`'s words: a module that hardcodes its own
+ * repo root cannot be tested, so it will not be.
+ */
+const ROOT = resolve(opts.root ?? resolve(__dirname, '..'));
 
 // Default applied HERE rather than seeded into the parse, because `parseArgs` initialises every
 // value flag to null and a default living inside the parser would be invisible from the call site.
@@ -348,7 +361,16 @@ function readBlobs(specs) {
 }
 
 assertNotShallow(ROOT);
-const history = buildEnglishFenceHistory();
+// `ROOT`, explicitly. `buildEnglishFenceHistory` defaults to `fences.js`'s OWN module root, so
+// the argument-less call was correct only while this tool could not be pointed anywhere else.
+// Adding `--root` (#674) turned that default into a split-brain — targets from the fixture,
+// history from the real repository — and the first fixture written against the new flag reported
+// `no English history for this id` for a file whose English source it had just committed.
+//
+// Latent before the flag existed, which is the same shape #634 found in the parity gate: a
+// module-scope root is invisible until something tries to move it, and the thing that tries is
+// always the first test.
+const history = buildEnglishFenceHistory(ROOT);
 
 // ---- gather targets ----
 //
@@ -479,7 +501,7 @@ for (const t of targets) {
   // A `text` fence facing an untagged one is NOT a divergence:
   // `normalize-content-style.js --mode fences` retro-tagged untagged blocks as
   // `text`, so that pairing is an artifact of a known repo tool acting on the
-  // newer side only. `alignmentTag` folds the two together.
+  // newer side only. `foldedTagSequence` folds the two together.
   //
   // This must NOT be expressed as `isGated(a) !== isGated(b)`. Under default-deny
   // an untagged fence is gated while `text` is not, so that formulation makes
@@ -488,10 +510,20 @@ for (const t of targets) {
   // this PR, while the comment above it still described the pre-inversion
   // behaviour. Alignment is a question about ordinal correspondence, not about
   // what the gate covers.
-  const alignmentTag = (f) => (f.lang === '' ? 'text' : f.lang);
-  const misaligned = translatedFences.findIndex(
-    (f, i) => alignmentTag(f) !== alignmentTag(basisFences[i]),
-  );
+  //
+  // `foldedTagSequence`, not a local copy (#674). The copy that stood here folded a brace-info
+  // fence to `text` exactly like an untagged one, so an English ```text facing a translated
+  // ```{r} at the same ordinal read as ALIGNED — and the brace fence is gated, so a divergent
+  // body at that position became eligible for a splice from a localisable block. The tool whose
+  // job is to restore frozen fences would have written translated prose into one.
+  //
+  // Its sibling copy in `check-placeholder-drift.js` went the same way in this commit; #612
+  // removed the third from the measurement script. The stamp guard below already used the
+  // shared fold, and the comment beside it said so — "STRICTER than the pre-splice guards" —
+  // which is how a known asymmetry sat in the file for two issues without being read as a bug.
+  const translatedSeq = foldedTagSequence(translatedFences);
+  const basisSeq = foldedTagSequence(basisFences);
+  const misaligned = translatedSeq.findIndex((tag, i) => tag !== basisSeq[i]);
   if (misaligned >= 0) {
     const a = translatedFences[misaligned].lang || 'untagged';
     const b = basisFences[misaligned].lang || 'untagged';
@@ -540,9 +572,14 @@ for (const t of targets) {
   const repairedFences = extractFences(repairedText);
   const stillDivergent = repairedFences.filter((f) => isGated(f) && !everEnglish.has(f.body)).length;
   // `mirrorsBasis` lives in `lib/fences.js` so this writer and `backfill-fence-basis.js` cannot
-  // drift about what "verified" means. Note it is STRICTER than the pre-splice guards: it also
-  // requires the folded tag sequence to equal the basis, where the splice gate used a local
-  // `alignmentTag` fold that cannot tell ```{r} from an untagged fence (#612).
+  // drift about what "verified" means. It used to be STRICTER than the pre-splice guards,
+  // because those folded through a local `alignmentTag` that could not tell ```{r} from an
+  // untagged fence; #674 gave the splice gate the same `foldedTagSequence`, so the asymmetry is
+  // gone.
+  //
+  // Worth keeping the history: that asymmetry was WRITTEN DOWN here, accurately, and read as a
+  // design note rather than as a bug for two issues. "Stricter than the pre-splice guards" is a
+  // true sentence about a guard that writes being looser than the one that only stamps.
   //
   // The stamp needs the basis to be one the GATE can see, on both axes the gate checks:
   //

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -702,8 +702,9 @@ test('a brace fence facing a text basis is SKIPPED, not spliced (#674)', (t) => 
     { encoding: 'utf8' });
 
   assert.equal(r.status, 0, r.stderr);
-  assert.match(r.stdout, /tag sequence diverges at fence 1/,
-    'the misalignment must be REPORTED, not silently tolerated');
+  assert.match(r.stdout, /tag sequence diverges at fence 1 \(\{ vs text\)/,
+    'reported, and reported with the FOLDED tokens — `untagged vs text` would send whoever '
+    + 'does the manual repair hunting for an untagged fence that is not in the file');
   assert.match(r.stdout, /files to change: 0/,
     'and nothing may be planned for that file');
   assert.doesNotMatch(r.stdout, /would restore/,

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -649,3 +649,97 @@ test('a template in the skills tree is not a target either', async (t) => {
   // Not a target, not merely unwritten — same distinction the flat arm asserts.
   assert.doesNotMatch(r.stdout, /_template/, 'the skills template reached the skipped list');
 });
+
+// ── #674: the splice gate's alignment fold ──────────────────────────────────
+
+/**
+ * A fixture built for `--root`, not for `cwd`.
+ *
+ * Every other fixture in this file COPIES `scripts/` into the temp repo, because the tool
+ * resolved its root from `__dirname/..` and there was no other way to point it at a corpus you
+ * constructed. #674 gave it `--root`, so this one runs the REAL script against a fixture — which
+ * is the whole reason the defect below could not be demonstrated end to end when it was filed.
+ */
+function braceFixture(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'norm-brace-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+
+  // English carries a LOCALISABLE `text` fence at ordinal 1.
+  mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'demo-skill', 'SKILL.md'), [
+    '---', 'name: demo-skill', 'description: A demo skill.', '---', '',
+    '# Demo Skill', '', '## Procedure', '',
+    '```text', 'fill this in', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english source']);
+
+  // The mirror carries a FROZEN brace-info fence at the same ordinal, with a body English has
+  // never held. Under the local `alignmentTag` both folded to `text`, the file passed the
+  // alignment guard, and the brace fence — gated, divergent — became eligible for a splice
+  // whose source is the localisable `text` block's prose.
+  const translated = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+  mkdirSync(dirname(translated), { recursive: true });
+  writeFileSync(translated, [
+    '---', 'name: demo-skill', 'description: Eine Demo-Fertigkeit.',
+    'locale: de', 'source_locale: en', '---', '',
+    '# Demo-Fertigkeit', '', '## Ablauf', '',
+    '```{r}', 'x <- 1', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de translation with a brace fence']);
+
+  return dir;
+}
+
+test('a brace fence facing a text basis is SKIPPED, not spliced (#674)', (t) => {
+  const dir = braceFixture(t);
+  const r = spawnSync(process.execPath, [join(REPO, SCRIPT), '--root', dir, '--basis', 'head'],
+    { encoding: 'utf8' });
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /tag sequence diverges at fence 1/,
+    'the misalignment must be REPORTED, not silently tolerated');
+  assert.match(r.stdout, /files to change: 0/,
+    'and nothing may be planned for that file');
+  assert.doesNotMatch(r.stdout, /would restore/,
+    'a splice into a frozen fence from a localisable block is the defect itself');
+});
+
+test('the same fixture with matching tags IS repaired — the non-vacuity control', (t) => {
+  // Without this, the assertions above are satisfied by a normalizer that refuses everything.
+  // Same shapes, same ordinal, tags agreeing: the tool must still do its job.
+  const dir = mkdtempSync(join(tmpdir(), 'norm-brace-ok-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+  mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'demo-skill', 'SKILL.md'), [
+    '---', 'name: demo-skill', 'description: A demo skill.', '---', '',
+    '# Demo Skill', '', '## Procedure', '',
+    '```{r}', 'x <- 1', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english source']);
+  const translated = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+  mkdirSync(dirname(translated), { recursive: true });
+  writeFileSync(translated, [
+    '---', 'name: demo-skill', 'description: Eine Demo-Fertigkeit.',
+    'locale: de', 'source_locale: en', '---', '',
+    '# Demo-Fertigkeit', '', '## Ablauf', '',
+    '```{r}', 'y <- 2', '```', '',
+  ].join('\n'), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de translation, brace fence, divergent body']);
+
+  const r = spawnSync(process.execPath, [join(REPO, SCRIPT), '--root', dir, '--basis', 'head'],
+    { encoding: 'utf8' });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /would restore/, 'a matching-tag divergence is still repairable');
+  assert.match(r.stdout, /files to change: 1/);
+});


### PR DESCRIPTION
Closes #674.

## The defect

Two files each carried the same two lines #612 removed from the measurement script:

```js
const alignmentTag = (f) => (f.lang === '' ? 'text' : f.lang);
```

`lang` is `''` for a brace-info fence (` ```{r} `) as well as for a bare one, so both collapse to `text` where `foldedTagSequence` folds a brace to `{`. That placeholder exists precisely so the two cannot be confused.

**The normalizer's copy is the one that writes.** Its alignment guard is the file-level control deciding whether ordinal mapping is sound enough to splice English bytes into a mirror. Under that fold an English ` ```text ` facing a translated ` ```{r} ` at the same ordinal read as **aligned** — and the brace fence is gated, so a divergent body there became eligible for a splice sourced from a localisable prose block. The tool whose job is to restore frozen fences, writing translated prose into one.

`check-placeholder-drift.js:371` had the identical fold with a smaller blast radius: a `{`-vs-`text` position was not reported as a divergence, so the comparison proceeded on an ordinal correspondence it had not established.

## End to end, which is new

When #674 was filed the evidence was component-level, and that was not a shortcut — `normalize-i18n-fences.js` had no `--root`, so there was no way to run it against a corpus you constructed. Every other fixture in `normalize-i18n-fences.test.js` **copies `scripts/` into a temp repo** to work around it.

`--root` is the fourth appearance of that defect in this directory: `buildEnglishFenceHistory` closing over its module root (#559), `gate-envelope` before its own, `check-i18n-fence-parity` before its own, and now the one tool of the four that writes.

**Must-go-red:** restore the local fold and the brace-versus-text fixture fails; the matching-tag control stays green, so the assertion is not satisfied by a normalizer that refuses everything.

## The flag immediately found a second defect

The first run of the new fixture reported `no English history for this id` — for a file whose English source it had just committed. Cause:

```js
const history = buildEnglishFenceHistory();
```

No argument, so it defaults to `fences.js`'s **own** module root. Correct only while this tool could not be pointed anywhere else; with `--root` it is a split-brain — targets from the fixture, history from the real repository.

Same shape #634 found in the parity gate, latent for the same reason: **a module-scope root cannot be seen as wrong until something tries to move it, and the thing that tries is always the first test.** Confirmation is in the timing — the fixture went from 15 s to 0.35 s once the history walk stopped scanning the real corpus.

## A comment that described the bug accurately, for two issues

```
Note it is STRICTER than the pre-splice guards … where the splice gate used a local
`alignmentTag` fold that cannot tell ```{r} from an untagged fence (#612).
```

A true sentence stating that the guard which **writes** was looser than the one which only stamps. It sat beside `mirrorsBasis` through #612 and #634, read as a design note. The asymmetry is now gone, and the comment says both that and what it used to be.

## Evidence

| | |
|---|---|
| corpus preview | **byte-identical** before and after |
| suite | 539 pass, 0 fail |
| must-go-red | local fold restored → brace fixture red, control green |

The preview being identical is the expected result, not a reassurance: 0 of 3,648 translated files carry a top-level brace-info fence. That makes the fixtures the evidence and the corpus run the control, which is the same shape as #612 — a latent defect in an instrument that a corpus run cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw
