### PR TITLE
docs(scripts): record the #589 triage where it can be acted on

### DIFF
--- a/scripts/gate-envelope.js
+++ b/scripts/gate-envelope.js
@@ -115,6 +115,38 @@ function syntaxCheck(absPath, text) {
   return { ok: true, checked: false, detail: `no dependency-free parser for ${ext || 'extensionless'}` };
 }
 
+/**
+ * TRIAGED SECURITY FINDING, and it is triaged CONDITIONALLY — read the condition before moving
+ * this tool.
+ *
+ * `semgrep`'s `javascript.lang.security.detect-child-process` fires here (PR #589, from an
+ * external report, closed as not-applicable). The pattern match is correct: `spawnSync` does
+ * receive its argv through a variable. Three facts make it not a vulnerability TODAY:
+ *
+ *   1. `command` is `spec.gate.command`, and `spec` is an ES module dynamically imported from
+ *      the `--spec` path. Anyone who can set that field already ran arbitrary top-level code at
+ *      import time. The spec is code by design — the trust model of an npm script or an ESLint
+ *      config — so supplying `gate.command` is a strictly weaker capability than the one needed
+ *      to supply it.
+ *   2. `scripts/` is not in `package.json`'s `files` array, so nothing here ships to a consumer.
+ *   3. Nothing in `.github/workflows/` runs this tool. It is maintainer-invoked, via
+ *      `npm run gate-envelope`.
+ *
+ * FACT 3 IS THE ONE THAT CAN CHANGE, and the whole triage rests on it. This is negative-evidence
+ * tooling of exactly the kind that gets wired into CI later, and `scripts/envelopes/*.mjs` are
+ * committed files a pull request may add or edit. The day a workflow runs this on a fork PR,
+ * a contributor-supplied spec executes arbitrary code in the runner with whatever token that job
+ * holds — and the finding stops being a false positive without anyone editing this line.
+ *
+ * So: wiring `gate-envelope` into CI is a security change, not a convenience. If you do it,
+ * pin the spec set rather than accepting `--spec` from the event, and say so here.
+ *
+ * The parameter is kept deliberately. #589 proposed reading `command` from the module scope
+ * instead, which stops the rule matching without changing the flow the rule was watching, and
+ * makes this function order-dependent: it would then be correct only because all three call
+ * sites happen to run after `command` is assigned, and a call added earlier would throw on the
+ * temporal dead zone.
+ */
 function runGate(command) {
   const [bin, ...args] = command;
   const r = spawnSync(bin, args, { cwd: ROOT, encoding: 'utf8' });


### PR DESCRIPTION
Follow-up to **#589**, this repository's first external contribution.

## Why the PR thread is the wrong place for that reasoning

#589 reported `javascript.lang.security.detect-child-process` at the `spawnSync` in `runGate`, and was closed as not-applicable. The pattern match was correct; the severity claims did not hold at this trust boundary. That triage went into the PR thread — and it is **conditional**, with the condition living in this file's future rather than in the closed discussion.

The triage rests on three facts. Two are structural and will not change on their own:

1. `command` is `spec.gate.command`, and `spec` is an ES module dynamically imported from the `--spec` path. Anyone who can set that field already executed arbitrary top-level code at import time, so supplying `gate.command` is a strictly weaker capability than the one required to supply it.
2. `scripts/` is not in `package.json`'s `files` array, so nothing here reaches a consumer of the published package.

The third is that **nothing in `.github/workflows/` runs this tool**.

## That one can change, quietly

`gate-envelope` is negative-evidence tooling of exactly the kind that gets wired into CI later — this repository already runs `ratchet`, `check-readmes`, and a dozen other `scripts/` entries there. And `scripts/envelopes/*.mjs` are committed files that a pull request may add or edit.

The day a workflow runs this on a fork PR, a contributor-supplied spec executes arbitrary code in the runner with whatever token that job holds — and the semgrep finding stops being a false positive **with nobody having touched this line**.

Whoever wired it up would have had no signal at the call site. The note now says that wiring `gate-envelope` into CI is a security change rather than a convenience, and what to do instead: pin the spec set, do not accept `--spec` from the event.

## Also recorded: why the parameter stays

#589 proposed reading `command` from module scope instead. That stops the rule matching without changing the flow the rule was watching, and it makes `runGate()` order-dependent — correct only because all three call sites happen to follow the assignment, with a temporal dead zone waiting for the fourth.

No behaviour change. The tool still runs (`node scripts/gate-envelope.js --spec scripts/envelopes/bare-substitution-lint.mjs` starts and reports its 4 cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw