### PR TITLE
fix(i18n): route the normalizer's scope guards through validateScope (#677)

### DIFF
--- a/scripts/lib/i18n-targets.js
+++ b/scripts/lib/i18n-targets.js
@@ -245,24 +245,25 @@ export function collectI18nTargets({ root, onlyLocale = null, onlyTrees = null, 
  *
  * ## Who actually calls this
  *
- * The docblock here said "shared so the three callers cannot disagree". It had one (#634). The
- * count is now two — `backfill-fence-basis.js` and `check-i18n-fence-parity.js` — and the
- * sentence is replaced by an inventory, because a number nobody can check is how the claim got
- * wrong in the first place.
+ * The docblock here said "shared so the three callers cannot disagree". It had one (#634), then
+ * two, and since #677 it has three: `backfill-fence-basis.js`, `check-i18n-fence-parity.js` and
+ * `normalize-i18n-fences.js`. The sentence is an inventory rather than a number because a number
+ * nobody can check is how the claim got wrong in the first place — and this paragraph has now
+ * been falsified twice by the very PRs that changed the membership it describes. Update it in the
+ * commit that moves a caller, not after.
  *
- * `normalize-i18n-fences.js` has a HAND COPY of the `--tree` arm (its own `unreachable` block),
- * and converting it would change behaviour rather than spelling — but not for the reason this
- * paragraph first gave. It said the normalizer "validates no locale at all", which is false: it
- * refuses an unscannable `--locale` at exit 2, with its own tests. The real delta is which
- * accept-list each asks:
+ * `normalize-i18n-fences.js` carried a HAND COPY of the `--tree` arm until #677, and converting
+ * it changed behaviour rather than spelling. Two deltas, both now live and both tested there:
  *
- *   normalize-i18n-fences.js   `scannableLocales` — pre-scan, DIRECTORY-based
- *   validateScope              `localesReached`   — post-scan, CONTENT-based
- *
- * An `i18n/xx/skills/` directory carrying no translated file passes the normalizer's guard today
- * and would refuse here. That is the behaviour change, and it is the one worth testing when #677
- * is done. The `--tree` half of the delta is smaller than it looks too: an unknown tree name is a
- * subset of unreached, so the normalizer already exits 2 on it and only the message differs.
+ *   locale   `scannableLocales` is pre-scan and DIRECTORY-based; `localesReached` here is
+ *            post-scan and CONTENT-based. An `i18n/xx/skills/` directory carrying no translated
+ *            file passed the normalizer's own guard and refuses here. Its pre-scan guard is kept
+ *            rather than replaced: it is load-bearing for the `i18n/${ONLY_LOCALE}` write-scope
+ *            interpolation and runs before the dirty-tree check, so this function cannot stand in
+ *            for it even in principle.
+ *   tree     an unknown tree NAME. It is a subset of unreached, so the hand copy already exited
+ *            2 on it and only the message differs — but "matched no translated content" reads as
+ *            "right name, empty corpus" for what is actually a typo.
  *
  * ## `onlyId` asks REACHED, never EXISTS
  *
@@ -301,9 +302,12 @@ export function validateScope({ onlyLocale, onlyTrees, onlyId = null, localesRea
     if (unknown.length) {
       errors.push(`ERROR: --tree names no such content tree: ${unknown.join(', ')}`);
       errors.push(`Known trees: ${[...known].sort().join(', ')}`);
-      return errors;
+      // NOT a `return`. `--tree recipes,guides` — one typo and one real-but-unreached tree —
+      // used to report only the typo, so the caller fixed it, reran, and learned about the
+      // second on the next round trip. The hand copy this replaced named both in one message,
+      // and losing that was a regression the #690 review caught.
     }
-    const unreached = [...onlyTrees].filter((t) => !treesReached.has(t));
+    const unreached = [...onlyTrees].filter((t) => known.has(t) && !treesReached.has(t));
     if (unreached.length) {
       errors.push(`ERROR: --tree matched no translated content${onlyLocale ? ` in locale '${onlyLocale}'` : ''}: ${unreached.join(', ')}`);
       errors.push('Nothing would be scanned, and the run would report a clean-looking zero.');

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -104,7 +104,7 @@ import {
 } from './lib/provenance.js';
 import { parseArgs, usageExit } from './lib/parse-args.js';
 import { catFileBatch } from './lib/git-batch.js';
-import { collectI18nTargets, presentTrees, scannableLocales } from './lib/i18n-targets.js';
+import { collectI18nTargets, presentTrees, scannableLocales, validateScope } from './lib/i18n-targets.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -377,22 +377,6 @@ function readBlobs(specs) {
 }
 
 assertNotShallow(ROOT);
-// `ROOT`, explicitly. `buildEnglishFenceHistory` defaults to `fences.js`'s OWN module root, so
-// the argument-less call was correct only while this tool could not be pointed anywhere else.
-// Adding `--root` (#674) turned that default into a split-brain — targets from the fixture,
-// history from the real repository — and the first fixture written against the new flag reported
-// `no English history for this id` for a file whose English source it had just committed.
-//
-// Latent before the flag existed, and the precedent is #559 — `buildEnglishFenceHistory`
-// closing over its own module root — not #634, which is a vacuous-scope guard and shares only
-// "latent until first exercised". A module-scope root is invisible until something tries to move
-// it, and the thing that tries is always the first test.
-//
-// Corroborated by timing rather than proven by it: the fixture went from 15 s to 0.35 s once the
-// walk stopped scanning the real corpus. The load-bearing evidence is functional — the run
-// reported `no English history for this id` for a file it had just committed — and a fixture
-// pins that, so the delta is colour and not a measurement to quote elsewhere.
-const history = buildEnglishFenceHistory(ROOT);
 
 // ---- gather targets ----
 //
@@ -450,15 +434,47 @@ const treesInScope = collected.treesReached;
  * `files to change: 0`: each guard was satisfied on its own and neither saw the
  * composition, while six of the ten locales carry `skills/` alone.
  */
-if (ONLY_TREES !== null) {
-  const unreachable = [...ONLY_TREES].filter((t) => !treesInScope.has(t));
-  if (unreachable.length) {
-    console.error(`ERROR: --tree matched no translated content${ONLY_LOCALE ? ` in locale '${ONLY_LOCALE}'` : ''}: ${unreachable.join(', ')}`);
-    console.error('Nothing would be scanned, and the run would report a clean-looking zero.');
-    console.error(`Reachable here: ${[...treesInScope].sort().join(', ') || '(none)'}`);
-    process.exit(2);
-  }
+const scopeErrors = validateScope({
+  onlyLocale: ONLY_LOCALE,
+  onlyTrees: ONLY_TREES,
+  localesReached: collected.localesReached,
+  treesReached: treesInScope,
+});
+if (scopeErrors.length) {
+  for (const line of scopeErrors) console.error(line);
+  process.exit(2);
 }
+
+// Belt-and-braces behind both guards, copied in intent from `backfill-fence-basis.js`: they
+// answer "is each flag reachable", this answers "did this run reach anything at all", and the
+// two come apart the moment a scope flag changes what the WALK collects rather than what a
+// filter keeps.
+if (targets.length === 0) {
+  console.error('ERROR: this scope selected no translated files. Nothing would be repaired.');
+  console.error(`Reachable locales: ${[...collected.localesReached].sort().join(', ') || '(none)'}`);
+  console.error(`Reachable trees:   ${[...treesInScope].sort().join(', ') || '(none)'}`);
+  process.exit(2);
+}
+
+// The history walk runs AFTER the scope is validated (#677), not before. It is the ~90 s step,
+// and being told you mistyped `--tree` at the end of it is a worse version of the same message.
+// Same reorder #634 made in the parity gate, and for the same reason.
+// `ROOT`, explicitly. `buildEnglishFenceHistory` defaults to `fences.js`'s OWN module root, so
+// the argument-less call was correct only while this tool could not be pointed anywhere else.
+// Adding `--root` (#674) turned that default into a split-brain — targets from the fixture,
+// history from the real repository — and the first fixture written against the new flag reported
+// `no English history for this id` for a file whose English source it had just committed.
+//
+// Latent before the flag existed, and the precedent is #559 — `buildEnglishFenceHistory`
+// closing over its own module root — not #634, which is a vacuous-scope guard and shares only
+// "latent until first exercised". A module-scope root is invisible until something tries to move
+// it, and the thing that tries is always the first test.
+//
+// Corroborated by timing rather than proven by it: the fixture went from 15 s to 0.35 s once the
+// walk stopped scanning the real corpus. The load-bearing evidence is functional — the run
+// reported `no English history for this id` for a file it had just committed — and a fixture
+// pins that, so the delta is colour and not a measurement to quote elsewhere.
+const history = buildEnglishFenceHistory(ROOT);
 
 // ---- resolve each target's English basis ----
 const specs = BASIS === 'source-commit'

--- a/scripts/normalize-i18n-fences.js
+++ b/scripts/normalize-i18n-fences.js
@@ -424,15 +424,19 @@ const targets = collected.targets.map((t) => ({
 const treesInScope = collected.treesReached;
 
 /**
- * Validate `--tree` against what the SCOPED scan actually reached, not against
- * a corpus-wide union. Checked here rather than at parse time because the
- * accept-list is the scan's own output — the only formulation that cannot drift
- * from the scan — and before any write, so a mistyped or unreachable batch
- * cannot touch the corpus.
+ * Validate the scope against what the SCOPED scan actually reached, not against a corpus-wide
+ * union. Checked here rather than at parse time because the accept-list is the scan's own output
+ * — the only formulation that cannot drift from the scan — and before any write, so a mistyped
+ * or unreachable batch cannot touch the corpus.
  *
- * The pre-scan version passed `--locale wenyan --tree guides` and reported
- * `files to change: 0`: each guard was satisfied on its own and neither saw the
- * composition, while six of the ten locales carry `skills/` alone.
+ * The pre-scan version passed `--locale wenyan --tree guides` and reported `files to change: 0`:
+ * each guard was satisfied on its own and neither saw the composition, while six of the ten
+ * locales carry `skills/` alone.
+ *
+ * Since #677 this covers `--locale` too, content-based, on top of the directory-based pre-scan
+ * check above — which stays, because it is what licenses the `i18n/${ONLY_LOCALE}` interpolation
+ * in `WRITE_SCOPE` and runs before the dirty-tree check. Then the backstop, for the case no flag
+ * was given at all.
  */
 const scopeErrors = validateScope({
   onlyLocale: ONLY_LOCALE,
@@ -456,9 +460,16 @@ if (targets.length === 0) {
   process.exit(2);
 }
 
-// The history walk runs AFTER the scope is validated (#677), not before. It is the ~90 s step,
-// and being told you mistyped `--tree` at the end of it is a worse version of the same message.
-// Same reorder #634 made in the parity gate, and for the same reason.
+// The history walk runs AFTER the scope is validated (#677), not before, so a mistyped `--tree`
+// is refused before it rather than after. Same reorder #634 made in the parity gate.
+//
+// The magnitude is NOT measured for this tool, and an earlier draft of this comment called it
+// "the ~90 s step" on inherited lore. What is measured, on the parity gate and on this mount
+// (#635): of an 87 s unscoped run, 53 s was the TARGET walk's `existsSync`/`statSync` pass, not
+// the history build. This tool never passes `onlyId`, so its target walk still pays that in
+// full and necessarily runs before `validateScope` can say anything. The reorder is free and in
+// the right direction; how much it saves here is unknown, and saying so is cheaper than
+// repeating a number nobody took.
 // `ROOT`, explicitly. `buildEnglishFenceHistory` defaults to `fences.js`'s OWN module root, so
 // the argument-less call was correct only while this tool could not be pointed anywhere else.
 // Adding `--root` (#674) turned that default into a split-brain — targets from the fixture,

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -744,3 +744,110 @@ test('the same fixture with matching tags IS repaired — the non-vacuity contro
   assert.match(r.stdout, /would restore/, 'a matching-tag divergence is still repairable');
   assert.match(r.stdout, /files to change: 1/);
 });
+
+// ── #677: the scope guards, through the shared predicate ────────────────────
+
+/** A fixture whose `i18n/` carries a locale DIRECTORY with no translated file in it. */
+function emptyLocaleFixture(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'norm-scope-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+
+  mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'demo-skill', 'SKILL.md'), englishSkill(), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english source']);
+  const sourceCommit = git(dir, ['rev-parse', 'HEAD']);
+
+  // `de` is real and populated.
+  const translated = join(dir, 'i18n', 'de', 'skills', 'demo-skill', 'SKILL.md');
+  mkdirSync(dirname(translated), { recursive: true });
+  writeFileSync(translated, translatedSkill(sourceCommit), 'utf8');
+
+  // `fr` has the directory shape and nothing in it. `scannableLocales` — directory-based,
+  // pre-scan — says yes; `localesReached` — content-based, post-scan — says no. That gap is
+  // the behaviour change #677 is about, and it is why converting the guard was not a rename.
+  mkdirSync(join(dir, 'i18n', 'fr', 'skills'), { recursive: true });
+
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'de translation']);
+  return dir;
+}
+
+const runAt = (dir, ...args) =>
+  spawnSync(process.execPath, [join(REPO, SCRIPT), '--root', dir, ...args], { encoding: 'utf8' });
+
+test('a locale whose directory exists but holds no translation is REFUSED (#677)', (t) => {
+  const dir = emptyLocaleFixture(t);
+  const r = runAt(dir, '--locale', 'fr', '--basis', 'head');
+  // Exit 2 and not merely non-zero: 1 would be a finding, and this is a refusal.
+  assert.equal(r.status, 2, r.stdout + r.stderr);
+  assert.match(r.stderr, /--locale 'fr' matched no translated content/);
+  assert.doesNotMatch(r.stdout, /files to change/,
+    'the run must not reach a summary it would report as a clean zero');
+});
+
+test('an unknown --tree names the known trees, rather than only "unreachable" (#677)', (t) => {
+  const dir = emptyLocaleFixture(t);
+  const r = runAt(dir, '--tree', 'recipes', '--basis', 'head');
+  assert.equal(r.status, 2, r.stdout + r.stderr);
+  assert.match(r.stderr, /--tree names no such content tree: recipes/);
+  assert.match(r.stderr, /Known trees:/,
+    'the hand-rolled guard this replaces could only say "unreachable", which reads as '
+    + '"correct name, empty corpus" for what is actually a typo');
+});
+
+test('a --locale/--tree pair that is individually valid but jointly empty is refused', (t) => {
+  // The composition the hand-rolled guard was written for, kept as a regression: `de` is real
+  // and `skills` is real, but `de` carries no `guides`.
+  const dir = emptyLocaleFixture(t);
+  const r = runAt(dir, '--locale', 'de', '--tree', 'guides', '--basis', 'head');
+  assert.equal(r.status, 2, r.stdout + r.stderr);
+  assert.match(r.stderr, /--tree matched no translated content in locale 'de': guides/);
+});
+
+test('a scope that DOES reach something still runs — the non-vacuity control', (t) => {
+  const dir = emptyLocaleFixture(t);
+  const r = runAt(dir, '--locale', 'de', '--basis', 'head');
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /would restore/, 'the tool must still do its job for a live scope');
+});
+
+test('a corpus of orphan mirrors refuses rather than reporting a clean zero (#677)', (t) => {
+  // THE BACKSTOP'S REACHABLE CASE, and it took constructing to find. With no `--locale` and no
+  // `--tree`, `validateScope` has nothing to validate and returns clean — so the only thing
+  // between an all-orphan corpus and `files to change: 0` at exit 0 is the empty-targets check.
+  //
+  // `scannableLocales` says `de` is scannable (the directory shape is there), and
+  // `collectI18nTargets` drops the file because its English source does not exist. Two
+  // predicates, one directory-based and one content-based, disagreeing exactly as documented.
+  //
+  // Written because a mutation deleting the backstop survived all 39 tests: the guard was
+  // belt-and-braces with no belt.
+  const dir = mkdtempSync(join(tmpdir(), 'norm-orphan-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+
+  // A real English source, so the repo is not empty and the walk has something to do.
+  mkdirSync(join(dir, 'skills', 'demo-skill'), { recursive: true });
+  writeFileSync(join(dir, 'skills', 'demo-skill', 'SKILL.md'), englishSkill(), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'english source']);
+
+  // The only mirror is an ORPHAN — no `skills/ghost/SKILL.md` exists.
+  const orphan = join(dir, 'i18n', 'de', 'skills', 'ghost', 'SKILL.md');
+  mkdirSync(dirname(orphan), { recursive: true });
+  writeFileSync(orphan, translatedSkill('0'.repeat(40)), 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'an orphan mirror']);
+
+  const r = runAt(dir, '--basis', 'head');
+  assert.equal(r.status, 2, r.stdout + r.stderr);
+  assert.match(r.stderr, /this scope selected no translated files/);
+  assert.doesNotMatch(r.stdout, /files to change: 0/,
+    'a run that examined nothing must not print the same summary as a run that found nothing');
+});

--- a/scripts/test/normalize-i18n-fences.test.js
+++ b/scripts/test/normalize-i18n-fences.test.js
@@ -799,6 +799,19 @@ test('an unknown --tree names the known trees, rather than only "unreachable" (#
     + '"correct name, empty corpus" for what is actually a typo');
 });
 
+test('a --tree list with a typo AND an unreached tree names both, in one message', (t) => {
+  // Regression for the #690 review's finding 2. The unknown-name arm used to `return` early, so
+  // `--tree recipes,guides` reported only `recipes`; the caller fixed the typo, reran, and
+  // learned about `guides` on the next round trip. The hand-rolled guard this replaced named
+  // both, and a shared predicate that is worse than the copy it replaces is not a consolidation.
+  const dir = emptyLocaleFixture(t);
+  const r = runAt(dir, '--tree', 'recipes,guides', '--basis', 'head');
+  assert.equal(r.status, 2, r.stdout + r.stderr);
+  assert.match(r.stderr, /names no such content tree: recipes/);
+  assert.match(r.stderr, /matched no translated content.*guides/,
+    'the real-but-unreached tree must be reported in the SAME run as the typo');
+});
+
 test('a --locale/--tree pair that is individually valid but jointly empty is refused', (t) => {
   // The composition the hand-rolled guard was written for, kept as a regression: `de` is real
   // and `skills` is real, but `de` carries no `guides`.
@@ -816,7 +829,14 @@ test('a scope that DOES reach something still runs — the non-vacuity control',
 });
 
 test('a corpus of orphan mirrors refuses rather than reporting a clean zero (#677)', (t) => {
-  // THE BACKSTOP'S REACHABLE CASE, and it took constructing to find. With no `--locale` and no
+  // A REACHABLE CASE for the backstop — not "the" one, which is how this comment first read.
+  // The backstop fires whenever the walk collects zero targets under no `--locale`/`--tree`, and
+  // the #690 review enumerated at least four shapes that do it: a missing English source (this
+  // fixture), content-tree directories that are all empty, mirrors whose names `contentKey`
+  // rejects, and a mirror entry that is a directory named `*.md`. One class, so one
+  // representative is adequate coverage; the wording claimed more than the fixture shows.
+  //
+  // It took constructing to find. With no `--locale` and no
   // `--tree`, `validateScope` has nothing to validate and returns clean — so the only thing
   // between an all-orphan corpus and `files to change: 0` at exit 0 is the empty-targets check.
   //


### PR DESCRIPTION
Closes #677.

## Why this was an issue and not a drive-by

`validateScope`'s docblock claimed it was *"shared so the three callers cannot disagree"*. It had **one**. #634 made it two. This makes it three — and the hand copy it replaces is not a duplicate, so converting it changes behaviour. That is the whole reason #677 exists separately.

## Two real deltas, both now covered

**1. Locale: directory-based vs content-based.**

| guard | accept-list | asks |
|---|---|---|
| pre-scan (kept) | `scannableLocales` | does the locale DIRECTORY shape exist |
| `validateScope` (new) | `localesReached` | did the scan collect anything from it |

A locale whose `i18n/xx/skills/` holds no translated file passes the first and never the second. Before this, such a `--locale` produced `files to change: 0` at exit 0 — a clean-looking zero for a scope the tool never examined.

The pre-scan check **stays**. It is fast, its message is clearer for "not a translated locale at all", and two guards asking different questions is `backfill-fence-basis.js`'s shape rather than a redundancy.

**2. Tree: an unknown tree *name*.** The hand copy could only say "matched no translated content", which reads as "correct name, empty corpus" for what is actually a typo. `validateScope` rejects it first, naming the known trees.

## The history walk moved

It now runs **after** the scope is validated. It is the ~90 s step, and being told you mistyped `--tree` at the end of it is a worse version of the same message. Same reorder #634 made in the parity gate, and a one-line move rather than a restructuring.

## The backstop, and how it was actually tested

I added an empty-targets backstop alongside. The first mutation deleting it **survived all 39 tests** — unreachable through the flags, exactly like the parity gate's was.

Its reachable case took constructing: with no `--locale` and no `--tree`, `validateScope` has nothing to validate and returns clean, so the only thing between an **all-orphan corpus** and `files to change: 0` is the backstop. Fixture: a repo whose single mirror has no English source. `scannableLocales` says the locale is scannable; `collectI18nTargets` drops the file. Two predicates, one directory-based and one content-based, disagreeing exactly as documented.

That fixture exists now, and the mutation dies.

## Must-go-red

| mutation | result |
|---|---|
| neuter the `validateScope` call | 5 failing — 3 are the new scope tests |
| delete the empty-targets backstop | 1 failing — the orphan fixture |

## Evidence

- corpus preview **byte-identical** to the post-#674 baseline
- 544 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw