### PR TITLE
fix(ci): make `npm test` run the tests (#680)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,12 @@ Guides, skills, agents, and teams are cross-referenced. The parent project `CLAU
 - The `references/` subdirectory pattern follows [agentskills.io progressive disclosure](https://agentskills.io/specification) — large code blocks (>15 lines), full configs, and multi-variant examples go in `references/EXAMPLES.md` with cross-references from the main SKILL.md
 - CI enforces validation on every PR (`.github/workflows/validate-skills.yml`): frontmatter fields, required sections, line counts, and registry sync. It ran only on PRs touching `skills/` until #641 removed the path filter so the job could become a required status check — a required check that does not report never goes green, it waits forever
 - CI also runs a repo-wide line-endings gate (`.github/workflows/validate-line-endings.yml`) that fails any PR whose committed blobs contain CRLF. Check locally with `npm run validate:line-endings` (reads the index, non-mutating). Repair: `git add --renormalize .` — and if a new file type is flagged, declare it in `.gitattributes` as `text eol=lf`
+- `npm test` is the release gate, and it runs **four** things: `validate:integrity`,
+  `check-readmes`, `test:scripts` and `test:cli`. It ran only the first two until #680, so
+  `release.yml`'s step named "Run tests" published to npm having executed neither suite. The CLI
+  surface was covered anyway — by `prepublishOnly`, npm's own lifecycle hook, which still runs
+  the CLI suite independently and must not be removed in favour of the step. `test:scripts` was
+  genuinely ungated
 - Changes under `scripts/` run `npm run test:scripts` (`.github/workflows/ci-scripts.yml`), the node:test suite in `scripts/test/`. Its `pretest:scripts` hook fails when the suite is empty — `node --test` exits 0 reporting `tests 0` when its glob matches nothing, so without that hook a rename or deletion leaves the job green having run nothing (#486)
 - To validate locally before committing:
   ```bash

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "gate-envelope": "node scripts/gate-envelope.js",
     "translation:status": "node scripts/generate-translation-status.js",
     "translate:scaffold": "bash scripts/translate-content.sh",
-    "test": "npm run validate:integrity && npm run check-readmes",
+    "test": "npm run validate:integrity && npm run check-readmes && npm run test:scripts && npm run test:cli",
     "test:cli": "node --test cli/test/cli.test.js",
     "pretest:scripts": "node scripts/test/_assert-suite-nonempty.js",
     "test:scripts": "node --test scripts/test/*.test.js",


### PR DESCRIPTION
Closes #680.

## The gap

`release.yml` has a step named **"Run tests"** immediately before `npm publish`. It ran `npm test`, and `npm test` was:

```
npm run validate:integrity && npm run check-readmes
```

Neither suite. Every publish this repository has made went out having executed zero of `scripts/test/` through that step.

## What was already covering the CLI, and stays

`prepublishOnly` is npm's own lifecycle hook and runs the CLI suite before the PUT. It predates `v1.3.0`, and the failed 1.9.0 publish shows it working — `tests 117, fail 0`, inside the publish step.

It stays exactly as it is. It is what has actually been protecting that surface, and the step must not replace it. What was genuinely ungated is `test:scripts` — 545 tests covering every gate and library under `scripts/`.

`npm test` now runs all four.

## The step name is why this was hard to see

A reader auditing the release path sees "Run tests" and stops looking. That is the same shape as `OK: every gated code fence matches` printed over zero files (#634), and `node --test <glob>` reporting `tests 0` at exit 0 (#486): **a truthful report of a question nobody asked.**

## What it costs, measured rather than assumed

#670 says `test:cli` cannot run on a `/mnt/` 9p mount, which would make `npm test` unrunnable on the machine most of this work happens on. That would be a real cost of this change, so I measured it instead of accepting it. Four runs from `/mnt/d/dev/p/agent-almanac`:

```
exit=0  x4        tests 117   pass 115   skipped 2   fail 0
60.5 s,  87.5 s,  70.9 s wall clock
```

It runs. #670 conflated the suite's **wall clock** with the **per-call** 10 s `execSync` cap (`cli/test/cli.test.js:41`). The slowest single call measured **7.9 s** — 79% of the budget, 2.1 s of headroom, with three calls above 6 s.

So the concern is **real as flakiness and false as unrunnability**. Re-scoped on #670 with the numbers, along with two corrections I owed that thread: my own earlier comment there blamed the corpus walk, and "npm test passes green from ext4" never bore on it — because `npm test` did not include `test:cli` at the time. Two sessions agreed on a conclusion neither had measured, both reading `npm test` as meaning "the tests".

## Note for whoever reads the bar this sets

Wiring a suite in buys exactly what its assertions assert. #680's own thread records the `shows version` case — a test that ran on every publish, passed every time, and could not have failed for the defect it was named after, because `assert.match(out, /\d+\.\d+\.\d+/)` accepts `0.1.0`. Adding suites to a gate is not the same as covering a surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw