### PR TITLE
refactor(i18n): classify the reproducer through compareTagSequence (#676)

### DIFF
--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -222,14 +222,20 @@ export function collectSpecs(root, paths = null) {
  * `scripts/measure-tag-sequence-parity.js`, and it is deliberately NOT scoped out of this table
  * for being a measurement script: `fences.js` cites it as the reproducer for the tag-sequence
  * finding set, so a change to this walk that moves its numbers moves the evidence the gate was
- * tuned against. Since #612 it folds through `foldedTagSequence`, so its sequences and the
- * `.sequences` row above are now built from the same fold and a walk change moves both the same
- * way. It still pools INLINE rather than calling `buildEnglishFenceHistory`, because it also
- * needs a per-count index the pool does not carry — so a change to that builder's own logic,
- * as opposed to this walk's, still does not reach it — and re-running this script ALONE cannot
- * detect such a change, since by that same sentence it measures the unchanged pipeline. For the
- * second kind, run the gate and this script and diff their finding sets: the agreement is what is
- * being re-measured. The first kind is covered by the row above.
+ * tuned against. Since #612 it folds through `foldedTagSequence` and since #676 it classifies
+ * through `compareTagSequence`, so both the fold and the triage are production's, and a walk
+ * change moves the gate and the reproducer the same way.
+ *
+ * It still pools INLINE rather than calling `buildEnglishFenceHistory` — it needs the sequence
+ * pool alone, and that builder also collects fence bodies and a HEAD snapshot it would discard.
+ * So a change to THAT builder's own logic, as opposed to this walk's, still does not reach it,
+ * and re-running this script alone cannot detect such a change: by that same sentence it
+ * measures the unchanged pipeline. For that kind, run the gate and this script and diff their
+ * finding sets — the agreement is what is being re-measured, and the gate must be run UNSCOPED
+ * for it (#682).
+ *
+ * The per-count index this paragraph used to cite as the reason for pooling inline is gone.
+ * `compareTagSequence` derives counts itself, which is what made the copy removable.
  *
  * Run the gate UNSCOPED for that diff (#682). Since #635 a `--id` on the gate's command line
  * narrows its pathspec while `measure-tag-sequence-parity.js` keeps its own tree-level walk, so

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -237,6 +237,17 @@ export function collectSpecs(root, paths = null) {
  * The per-count index this paragraph used to cite as the reason for pooling inline is gone.
  * `compareTagSequence` derives counts itself, which is what made the copy removable.
  *
+ * Which leaves the inline pool carrying a load the efficiency argument above understates, and it
+ * belongs on the record rather than in silence. Sharing the fold (#612) and then the triage
+ * (#676) each retired a leg of a differential oracle, and the triage leg had a confirmed kill:
+ * the hand copy is the "independent measurement of the same property [that] disagreed by exactly
+ * 3" which caught `compareTagSequence` treating `''.split(',')` as a one-fence revision — a bug
+ * no test saw. After #676 a fault in that classifier moves the gate and the reproducer
+ * identically, so their finding-set diff can never surface one again; the regression tests in
+ * `scripts/test/tag-sequence-parity.test.js` are now the only cover for that class, and they
+ * cover the known bug rather than the next one. Pooling inline is what preserves the one
+ * remaining channel — call `buildEnglishFenceHistory` here and the diff detects nothing at all.
+ *
  * Run the gate UNSCOPED for that diff (#682). Since #635 a `--id` on the gate's command line
  * narrows its pathspec while `measure-tag-sequence-parity.js` keeps its own tree-level walk, so
  * a scoped diff can disagree for walk reasons rather than regression reasons — and the two

--- a/scripts/measure-tag-sequence-parity.js
+++ b/scripts/measure-tag-sequence-parity.js
@@ -75,7 +75,7 @@ import { fileURLToPath } from 'url';
 // change; the counts are why that was expected. What makes it worth fixing anyway is that this
 // script is the instrument used to judge the gate's finding set, and it disagreed with the thing
 // it measures.
-import { foldedTagSequence } from './lib/fences.js';
+import { foldedTagSequence, compareTagSequence } from './lib/fences.js';
 import { walkEnglishHistory } from './lib/english-history.js';
 import { collectTargets } from './check-i18n-fence-parity.js';
 
@@ -103,16 +103,21 @@ const LIST_RETAGS = process.argv.includes('--list-retags');
 const ONLY_LOCALE = flagValue('--locale', null);
 
 // Pool every folded tag sequence each English source has ever carried, keyed by `<tree>/<id>`.
-// Sequences are stored joined; the per-count index lets a mismatch be classified as unalignable
-// (no revision of that length) rather than as a retag.
+//
+// The per-count index this used to build alongside is GONE (#676). It existed to classify a
+// mismatch as unalignable rather than a retag — which is exactly what `compareTagSequence`
+// already decides, and did decide, forty lines below in a hand copy of the same triage:
+// same clean/unalignable/retag split, same fewest-differing-positions choice of nearest basis,
+// same `{index, english, translated}` position shape.
+//
+// #612 gave this script production's FOLD and left its CLASSIFICATION a copy. That is half a
+// fix: `fences.js` cites this file as the reproducer for the tag-sequence finding set, and
+// `debt-ratchet.yml` ratchets that set, so an instrument agreeing with production on how tags
+// fold and disagreeing on what a fold means is the same defect one layer up.
 const english = new Map();
 walkEnglishHistory(ROOT, (key, text) => {
-  if (!english.has(key)) english.set(key, { sequences: new Set(), byCount: new Map() });
-  const entry = english.get(key);
-  const seq = foldedTagSequence(text);
-  entry.sequences.add(seq.join(','));
-  if (!entry.byCount.has(seq.length)) entry.byCount.set(seq.length, new Set());
-  entry.byCount.get(seq.length).add(seq.join(','));
+  if (!english.has(key)) english.set(key, new Set());
+  english.get(key).add(foldedTagSequence(text).join(','));
 });
 
 const totals = { clean: 0, unalignable: 0, retag: 0, orphan: 0 };
@@ -124,30 +129,24 @@ for (const target of collectTargets()) {
   const entry = english.get(`${target.tree}/${target.id}`);
   if (!entry) { totals.orphan += 1; continue; }
 
+  // The gate's own predicate, not a copy of it. `null` is clean, `{unalignable: true}` is
+  // unjudged, `{positions}` is the finding — and `positions` already carries the nearest-basis
+  // choice and the 1-based index this report prints.
   const seq = foldedTagSequence(readFileSync(target.absPath, 'utf8'));
-  const joined = seq.join(',');
+  const verdict = compareTagSequence(seq, entry);
   let bucket;
-  if (entry.sequences.has(joined)) {
+  if (verdict === null) {
     bucket = 'clean';
-  } else if (!entry.byCount.has(seq.length)) {
+  } else if (verdict.unalignable) {
     bucket = 'unalignable';
   } else {
     bucket = 'retag';
-    // Report against the count-matched revision that differs in the FEWEST positions — the
-    // nearest legal basis. Reporting against an arbitrary one would inflate the diff and make a
-    // single retag look like wholesale divergence.
-    let best = null;
-    for (const candidate of entry.byCount.get(seq.length)) {
-      const other = candidate.split(',');
-      const positions = seq.map((t, i) => [i, t, other[i]]).filter(([, a, b]) => a !== b);
-      if (!best || positions.length < best.positions.length) best = { positions, other };
-    }
     retags.push({
       file: target.relPath,
       locale: target.locale,
       tree: target.tree,
       id: target.id,
-      positions: best.positions.map(([i, a, b]) => ({ index: i + 1, translated: a, english: b })),
+      positions: verdict.positions,
     });
   }
   totals[bucket] += 1;

--- a/scripts/measure-tag-sequence-parity.js
+++ b/scripts/measure-tag-sequence-parity.js
@@ -75,7 +75,7 @@ import { fileURLToPath } from 'url';
 // change; the counts are why that was expected. What makes it worth fixing anyway is that this
 // script is the instrument used to judge the gate's finding set, and it disagreed with the thing
 // it measures.
-import { foldedTagSequence, compareTagSequence } from './lib/fences.js';
+import { foldedTagSequence, compareTagSequence, isRetagEscape } from './lib/fences.js';
 import { walkEnglishHistory } from './lib/english-history.js';
 import { collectTargets } from './check-i18n-fence-parity.js';
 
@@ -188,9 +188,15 @@ if (retags.length) {
 
   // The distribution that decides whether this is a gate or a backlog: a retag TO a localisable
   // tag is the #481 escape; anything else is ordinary tag drift and a likely false positive.
-  const escapes = retags.filter((r) => r.positions.some(
-    (p) => ['text', 'markdown', 'md'].includes(p.translated) && !['text', 'markdown', 'md'].includes(p.english),
-  ));
+  //
+  // `isRetagEscape`, and NOT a hand copy of it — which is the same sentence the rest of this
+  // change is about, one predicate over. This filter was a literal `['text','markdown','md']`
+  // pair until the review of #694 read the file the fix had just landed in and found it: the
+  // fourth literal copy that `isRetagEscape`'s own docstring names and forbids. `LOCALISABLE_TAGS`
+  // is a designed extension point (`fences.js` states the procedure for adding a tag), so the
+  // copy was not merely redundant — adding a tag would have moved the gate's blocking boundary
+  // and left this instrument's escape/drift split silently behind, which is #676 exactly.
+  const escapes = retags.filter((r) => isRetagEscape(r.positions));
   console.log(`\nof those, ${escapes.length} involve a frozen tag becoming localisable — the #481 escape proper.`);
   console.log(`the remaining ${retags.length - escapes.length} are other tag drift, and are the false-positive risk.`);
 }

--- a/scripts/test/tag-sequence-parity.test.js
+++ b/scripts/test/tag-sequence-parity.test.js
@@ -233,6 +233,28 @@ test('isRetagEscape separates the two populations #598 catalogued', () => {
   ]), true);
 });
 
+test('foldedTagSequence emits no comma and no empty tag — the join alphabet the pool depends on', () => {
+  // Sequences are pooled as `seq.join(',')` and their length is recovered by splitting that
+  // string back apart, so a tag containing a comma would inflate the recovered length and a tag
+  // that is the empty string would collide with the no-fence revision. Both are unreachable
+  // today: `lang` is the [0] segment of a split whose delimiter class already contains the
+  // comma, and the two fallbacks are comma-free literals. That is a property of the extractor,
+  // not of the corpus — and #676 removed the last caller that carried a true array length
+  // alongside the joined form, so nothing else would disagree if it ever stopped holding.
+  const alphabet = (src) => foldedTagSequence(src);
+  for (const tag of alphabet([
+    '```js,foo', 'x', '```', '', '```{r setup}', 'y', '```', '', '```', 'z', '```', '', '```JSON',
+    'w', '```',
+  ].join('\n'))) {
+    assert.ok(!tag.includes(','), `folded tag ${JSON.stringify(tag)} contains a comma`);
+    assert.notEqual(tag, '', 'folded tag is the empty string');
+  }
+  // Named explicitly rather than left to the loop: the info string most likely to smuggle one in.
+  assert.deepEqual(alphabet('```js,foo\nx\n```\n'), ['js']);
+  assert.deepEqual(alphabet('```{r}\nx\n```\n'), ['{']);
+  assert.deepEqual(alphabet('```\nx\n```\n'), ['text']);
+});
+
 test('isRetagEscape treats a brace fence as frozen — the escape must not survive its own fix', () => {
   // `foldedTagSequence` emits `{` for ```{r} precisely so this classifies as an escape. If the
   // fold ever collapsed braces to `text` this would silently become drift and stop blocking.


### PR DESCRIPTION
Closes #676.

## Half a fix, completed

#612 gave this script production's **fold** and left its **classification** a hand copy — the same clean/unalignable/retag triage, the same fewest-differing-positions choice of nearest basis, the same `{index, english, translated}` position shape, forty lines below the import it had just fixed.

It matters because of what this script *is*. `fences.js` cites it as the reproducer for the tag-sequence finding set, and `debt-ratchet.yml` ratchets that set. An instrument that agrees with production on how tags **fold** and disagrees on what a fold **means** is the same defect one layer up.

`byCount` is deleted. It existed to answer "is there a count-matched revision", which `compareTagSequence` derives itself — that is what made the copy removable rather than merely duplicated.

## Equivalence, and the line worth reading

```
before {"clean":3582,"unalignable":60,"retag":6,"orphan":0}
after  {"clean":3582,"unalignable":60,"retag":6,"orphan":0}
totals identical  : true
retags identical  : FALSE
```

The raw JSON differs. The hand copy emitted `{index, translated, english}`; the shared predicate emits `{index, english, translated}`. A string comparison says no, a normalised comparison says **yes** — same six findings, same positions, same nearest-basis choices.

Recorded rather than waved through, because *"retags identical: false"* is exactly the line that gets explained away by whoever is confident about the change they just made.

Nothing consumes this script's `--json`: no npm entry, no workflow, one test that runs it as a subprocess and reads `totals`.

## The predicate is now load-bearing, not merely imported

```
$ # disable compareTagSequence's unalignable branch
✖ a count mismatch is UNALIGNABLE, never a violation
   pass 18   fail 1
```

A mutation of *production* now reaches the measure script's behaviour. Before, it had a private copy no mutation of `fences.js` could touch — which is the property that makes "the reproducer reproduces" checkable at all.

## Doc correction it forces

`english-history.js`'s collector table said the inline pool was kept "because it also needs a per-count index the pool does not carry". That reason is gone. The pool is still inline for a smaller one — this script needs the sequence pool alone, while `buildEnglishFenceHistory` also collects fence bodies and a HEAD snapshot it would discard — and the paragraph now says which.

551 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013RVUw6KzMgkY7gyWDHQ9mw