### PR TITLE
feat(guard): a run that moves its own HEAD now has an exit that is not --force (#688)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,9 @@ npm run guard:rebaseline                       # prints the commits; refuses, ex
 npm run guard:rebaseline -- --accept=<sha>     # re-arms, recording what it accepted
 ```
 
-Read every author it prints before accepting — that is the only thing separating your merge from a commit you did not make, and the tool cannot read it for you. The `<sha>` must equal the current HEAD, so the acknowledgement cannot be typed unread, and the new snapshot records the accepted commits and reason where `--force` leaves no trace. It **refuses** any worktree, content, or index-flag change: "I moved HEAD deliberately" is a claim about history and says nothing about file contents.
+Read every commit it prints and decide whether you made it. The **author line is a hint, not the test** — a subagent commits through this repository's own git config, so in #493 the author was identical to the operator's; what the commit *contains* is the test. The `<sha>` must equal the current HEAD, and the new snapshot records the accepted commits and reason where `--force` leaves no trace. It **refuses** any worktree, content, or index-flag change: "I moved HEAD deliberately" is a claim about history and says nothing about file contents.
+
+The sha requirement is a control against **accident, not intent** — anyone can type `$(git rev-parse HEAD)`. What it buys is that a red `guard:verify` never carries a paste-ready override in its own output, so the green path is not one paste away from the failure it is reporting. `verify` therefore names the command without the sha, and refuses to name it at all when the working tree also moved, since `rebaseline` would then decline.
 
 It compares HEAD, branch, worktree status, **the content of every changed or untracked file**, and index flags. Content is load-bearing: overwriting a file that was already modified leaves its ` M path` status line byte-identical, and this repo is usually mid-edit. Index flags are included because `git update-index --skip-worktree` makes git report a modified file as clean from that point on, disarming every later check.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,15 @@ npm run guard:verify     # after — exit 1 if anything moved
 npm run guard:release    # when the run is genuinely over
 ```
 
+**When your own run moves HEAD** — you merge your branch, switch branches, rebase — `verify` reports it as a change, because from the outside a merge and an agent's stray commit look identical. That is correct and it used to have no exit but `guard:snapshot -- --force`, a flag whose own text warns against itself. Reaching for `--force` twice is how a control becomes a ritual, so the legitimate move has its own command (#688):
+
+```bash
+npm run guard:rebaseline                       # prints the commits; refuses, exit 2
+npm run guard:rebaseline -- --accept=<sha>     # re-arms, recording what it accepted
+```
+
+Read every author it prints before accepting — that is the only thing separating your merge from a commit you did not make, and the tool cannot read it for you. The `<sha>` must equal the current HEAD, so the acknowledgement cannot be typed unread, and the new snapshot records the accepted commits and reason where `--force` leaves no trace. It **refuses** any worktree, content, or index-flag change: "I moved HEAD deliberately" is a claim about history and says nothing about file contents.
+
 It compares HEAD, branch, worktree status, **the content of every changed or untracked file**, and index flags. Content is load-bearing: overwriting a file that was already modified leaves its ` M path` status line byte-identical, and this repo is usually mid-edit. Index flags are included because `git update-index --skip-worktree` makes git report a modified file as clean from that point on, disarming every later check.
 
 It fails closed — a missing, unreadable, or foreign snapshot exits 2 rather than reporting success, and exit 2 must never be read as a pass. `snapshot` refuses to overwrite and `verify` keeps the snapshot until `guard:release`, so a nested run cannot rebaseline the outer run's damage into a green. **Ignored paths are out of scope** (walking them means hashing `node_modules`), so a stray write to `CONTINUE_HERE.md` would not be seen (#493).

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "guard:snapshot": "node scripts/repo-guard.js snapshot",
     "guard:verify": "node scripts/repo-guard.js verify",
     "guard:release": "node scripts/repo-guard.js verify --release",
+    "guard:rebaseline": "node scripts/repo-guard.js rebaseline",
     "coverage:evals": "node scripts/eval-coverage.js",
     "mutation-check": "node scripts/mutation-check.js",
     "gate-envelope": "node scripts/gate-envelope.js",

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -6,6 +6,10 @@
  *   npm run guard:verify    # after it returns
  *   npm run guard:release   # ... and drop the snapshot
  *
+ * and, when the arming session itself moved HEAD for a reason it can name:
+ *
+ *   npm run guard:rebaseline -- --accept=<sha>
+ *
  * The npm scripts are the supported entrypoint, and every message this tool
  * prints names them rather than the raw `node scripts/repo-guard.js …` form:
  * advice that is not copy-pasteable at the moment something broke is advice that
@@ -72,6 +76,23 @@
  *   - `verify` KEEPS the snapshot unless `--release`. Consuming it by default
  *     silently disarms every later check — and a stale snapshot can only ever
  *     over-report, never under-report, so keeping is the safe direction.
+ *
+ * ## The legitimate mover (#688)
+ *
+ * Both rules above assume a moved HEAD is UNEXPLAINED. That is right for the
+ * case the tool exists for and wrong for the commonest event in any long run:
+ * the arming session merges its own branch, or switches branches, and then has
+ * nowhere to go but `snapshot --force` — which the text above warns against in
+ * the same breath, and which leaves a transcript indistinguishable from a
+ * careless rebaseline over an agent's commit.
+ *
+ * `rebaseline` is that exit. It costs exactly the three steps of judgement the
+ * honest sequence already required — enumerate the delta, confirm the commits
+ * are yours, record that you did — with the difference that the tool performs
+ * them instead of assuming them. It refuses without an `--accept=<sha>` equal to
+ * the current HEAD, and it refuses ANY worktree, content, or index-flag change,
+ * because "I moved HEAD deliberately" is a claim about history and says nothing
+ * about file contents.
  */
 
 import { readFileSync, writeFileSync, existsSync, unlinkSync, statSync } from 'node:fs';
@@ -97,11 +118,17 @@ const USAGE = `Usage:
   npm run guard:snapshot              record HEAD, branch, status, contents, index flags
   npm run guard:verify                compare the repository against that record
   npm run guard:release               verify, then drop the snapshot if unchanged
+  npm run guard:rebaseline            re-arm after YOUR OWN run moved HEAD (a merge,
+                                      a branch switch), naming the commits it accepts
 
   npm run guard:snapshot -- --force   replace an existing snapshot (refused by default)
   npm run guard:snapshot -- --quiet   suppress the success line (also valid on verify)
+  npm run guard:rebaseline -- --accept=<sha> [--reason="..."]
+                                      accept the printed move; <sha> must equal the
+                                      current HEAD, so it cannot be typed unread
 
-  (flags must follow \`--\`; npm swallows them otherwise)`;
+  (flags must follow \`--\`; npm swallows them otherwise. Valued flags use \`=\`, not a
+   space, so the value cannot be mistaken for the command.)`;
 
 function die(message, code = 2) {
   console.error(`repo-guard: ${message}`);
@@ -111,16 +138,41 @@ function die(message, code = 2) {
 // ── arguments: default-deny, and per-command, so a flag that means nothing to
 // this subcommand is an error rather than a silently narrower check.
 const argv = process.argv.slice(2);
-const FLAGS_FOR = { snapshot: ['--force', '--quiet'], verify: ['--release', '--quiet'] };
+const FLAGS_FOR = {
+  snapshot: ['--force', '--quiet'],
+  verify: ['--release', '--quiet'],
+  rebaseline: ['--quiet'],
+};
+/**
+ * Flags that take a value, spelled `--flag=value`.
+ *
+ * The `=` form is required rather than a space-separated one because the
+ * command is found with `argv.find(a => !a.startsWith('-'))`: a bare value would
+ * be a candidate for the command name, and `rebaseline --accept 255114999` would
+ * parse fine only by the accident of argument order.
+ */
+const VALUED_FLAGS_FOR = { rebaseline: ['--accept', '--reason'] };
 
 const command = argv.find((a) => !a.startsWith('-'));
 if (!command) die(`no command given.\n${USAGE}`);
 if (!FLAGS_FOR[command]) die(`unknown command '${command}'.\n${USAGE}`);
+const valued = VALUED_FLAGS_FOR[command] ?? [];
+const values = {};
 for (const arg of argv) {
   if (arg === command) continue;
-  if (!FLAGS_FOR[command].includes(arg)) {
-    die(`unknown argument '${arg}' for '${command}'.\n${USAGE}`);
+  if (FLAGS_FOR[command].includes(arg)) continue;
+  const named = valued.find((flag) => arg.startsWith(`${flag}=`));
+  if (named) {
+    values[named] = arg.slice(named.length + 1);
+    continue;
   }
+  // A valued flag given without its `=value` is its own message: the caller
+  // reached for the right flag and would otherwise be told only "unknown
+  // argument", which reads as "this flag does not exist".
+  if (valued.includes(arg)) {
+    die(`'${arg}' needs a value, spelled '${arg}=<value>'.\n${USAGE}`);
+  }
+  die(`unknown argument '${arg}' for '${command}'.\n${USAGE}`);
 }
 const QUIET = argv.includes('--quiet');
 
@@ -284,7 +336,13 @@ if (command === 'snapshot') {
 
 if (!existsSync(SNAPSHOT_PATH)) {
   die(`no snapshot at ${SNAPSHOT_NAME}. Run \`npm run guard:snapshot\` before the run.\n` +
-    'Refusing to report "unchanged" for a comparison that never happened.');
+    (command === 'rebaseline'
+      // Rebaselining without a baseline is just arming, and letting it silently
+      // become that would make `guard:rebaseline` a synonym for `guard:snapshot`
+      // — a second spelling of arming that no longer means "I accepted a move".
+      ? 'There is nothing to re-baseline FROM: `rebaseline` re-arms an existing baseline after\n' +
+        'you moved HEAD, and records what it accepted. To arm a fresh one, use `guard:snapshot`.'
+      : 'Refusing to report "unchanged" for a comparison that never happened.'));
 }
 
 let before;
@@ -308,6 +366,8 @@ if (before.toplevel !== TOPLEVEL) {
 const after = captureState();
 let changed = false;
 let headMoved = false;
+let fastForward = false;
+let addedCommits = [];
 
 if (before.head !== after.head) {
   changed = true;
@@ -315,12 +375,25 @@ if (before.head !== after.head) {
   console.error(`\n  HEAD moved: ${before.head.slice(0, 8)} -> ${after.head.slice(0, 8)}`);
   // The commits themselves are the actionable part: this is the case `git
   // status` cannot see, because a committed stray write leaves a clean tree.
-  const range = git(['log', '--format=  %h %an  %s', `${before.head}..${after.head}`],
+  const range = git(['log', '--format=  %h %an <%ae>  %s', `${before.head}..${after.head}`],
     { cwd: TOPLEVEL, allowFailure: true });
   if (range && range.trim()) {
     console.error('  commits added:');
     console.error(range.trimEnd());
   }
+  addedCommits = (range ?? '').trim().split('\n').filter(Boolean).map((l) => l.trim());
+
+  // Ancestry, printed because it is the one discriminator the tool can compute
+  // between the two readings of a moved HEAD. It is EVIDENCE, not a verdict —
+  // an agent's stray commit on the current branch is a descendant too. What it
+  // rules out is the other shape: a checkout that moved to unrelated history,
+  // where `git reset --mixed <snapshot>` would be destructive rather than
+  // merely wrong.
+  fastForward = before.head !== UNBORN
+    && git(['merge-base', '--is-ancestor', before.head, after.head],
+      { cwd: TOPLEVEL, allowFailure: true }) !== null;
+  console.error(`  the snapshot commit IS${fastForward ? '' : ' NOT'} an ancestor of the new HEAD` +
+    `${fastForward ? ' — history was added on top, not replaced' : ' — history diverged or was replaced'}.`);
 }
 
 if (before.branch !== after.branch) {
@@ -328,7 +401,12 @@ if (before.branch !== after.branch) {
   console.error(`\n  branch changed: ${before.branch} -> ${after.branch}`);
 }
 
-changed = reportList('working tree', before.status, after.status) || changed;
+// Tracked separately from `changed` because `rebaseline` may accept a HEAD move
+// and must NEVER accept a worktree move: a stray write is exactly what the guard
+// exists for, and "I merged my own branch" is not a claim about file contents.
+let worktreeMoved = false;
+
+worktreeMoved = reportList('working tree', before.status, after.status) || worktreeMoved;
 
 // Iterating `after` is sufficient ONLY because every status-listed path now gets
 // an entry — including the `(absent)` and `(not-a-regular-file)` sentinels. The
@@ -343,13 +421,102 @@ const contentChanged = Object.keys(after.contents)
   .filter((path) => before.contents[path] !== after.contents[path])
   .sort();
 if (contentChanged.length) {
-  changed = true;
+  worktreeMoved = true;
   console.error('\n  contents changed (file was already modified, so its status line did not move):');
   for (const path of contentChanged) console.error(`    ~ ${path}`);
 }
 
-changed = reportList('index flags (skip-worktree / assume-unchanged)',
-  before.indexFlags, after.indexFlags) || changed;
+worktreeMoved = reportList('index flags (skip-worktree / assume-unchanged)',
+  before.indexFlags, after.indexFlags) || worktreeMoved;
+
+changed = changed || worktreeMoved;
+
+// ── rebaseline ───────────────────────────────────────────────────────────────
+//
+// The exit #688 was missing. `verify` and `release` both assume a moved HEAD is
+// UNEXPLAINED, which is right for the case they exist for and wrong for the
+// commonest case in any run of length: the arming session merges its own branch,
+// or switches branches, and then has nowhere to go but
+// `guard:snapshot -- --force` — a flag whose own text warns against itself.
+//
+// A caller who reaches for `--force` twice stops reading what it discards. That
+// converts a control into a ritual, which is the failure mode this whole tool is
+// an argument against. So the legitimate move gets a first-class command, and it
+// costs exactly the three steps of judgement the honest sequence already
+// required: enumerate the delta, confirm the commits are yours, record that you
+// did. The difference is that the tool now performs all three instead of
+// assuming them.
+if (command === 'rebaseline') {
+  if (!changed) {
+    if (!QUIET) {
+      console.log(`repo-guard: nothing moved — the baseline already matches ${after.head.slice(0, 8)}` +
+        ` on ${after.branch}. Snapshot left as it is.`);
+    }
+    process.exit(0);
+  }
+
+  // A worktree move is never re-baselineable. "I moved HEAD deliberately" is a
+  // claim about history; it says nothing about file contents, and accepting one
+  // as cover for the other would launder exactly the stray write (#493) the
+  // guard was built to catch. Refuse, and keep the baseline so the caller can
+  // still `guard:verify` after cleaning up.
+  if (worktreeMoved) {
+    console.error('\nrepo-guard: the WORKING TREE moved, not just HEAD.');
+    console.error('`rebaseline` accepts a deliberate HEAD move and nothing else — a content, status');
+    console.error('or index-flag change is the case this guard exists for, and accepting it here');
+    console.error('would rebaseline a stray write as the new normal.');
+    console.error('\nInspect it first:  git status --porcelain -uall  /  git diff');
+    console.error('The snapshot was KEPT, so `npm run guard:verify` still works after you clean up.');
+    process.exit(1);
+  }
+
+  const accepted = values['--accept'];
+  if (!accepted) {
+    console.error('\nrepo-guard: HEAD moved. Nothing has been accepted yet.');
+    console.error('Read the commits above. Every one of them must be yours — a commit you did not');
+    console.error('make is the thing this guard is for, and accepting it here hides it permanently.');
+    console.error('\nIf they are all yours, re-run naming the HEAD you just read:');
+    console.error(`  npm run guard:rebaseline -- --accept=${after.head}`);
+    console.error('  npm run guard:rebaseline -- ' +
+      `--accept=${after.head} --reason="merged my own PR"`);
+    console.error('\nThe sha is required so the acknowledgement cannot be typed without reading it,');
+    console.error('and so the transcript records WHICH move was accepted — which `--force` does not.');
+    process.exit(2);
+  }
+
+  // Prefix match, minimum 7, so a caller may paste the abbreviated sha git
+  // itself printed. Shorter than 7 is not an acknowledgement of anything.
+  if (accepted.length < 7 || !after.head.startsWith(accepted)) {
+    die(`you accepted '${accepted}', but HEAD is ${after.head}.\n` +
+      (accepted.length < 7
+        ? 'A sha shorter than 7 characters is not specific enough to be an acknowledgement.\n'
+        : 'HEAD moved again between reading it and accepting it, or the sha was mistyped.\n') +
+      'Re-run `npm run guard:rebaseline` with no --accept to see the current delta.');
+  }
+
+  writeSnapshot(after, {
+    rebaselinedFrom: {
+      head: before.head,
+      branch: before.branch,
+      takenAt: before.takenAt ?? null,
+      acceptedCommits: addedCommits,
+      fastForward,
+      reason: values['--reason'] ?? null,
+    },
+    // Preserved so a chain of re-armings stays visible rather than each one
+    // erasing the last. `--force` leaves no trace at all, which is finding 1.
+    rebaselineHistory: [...(before.rebaselineHistory ?? []),
+      { from: before.head, to: after.head, reason: values['--reason'] ?? null }],
+  });
+
+  if (!QUIET) {
+    console.log(`\nrepo-guard: re-baselined ${before.head.slice(0, 8)} -> ${after.head.slice(0, 8)}` +
+      ` on ${after.branch}, accepting ${addedCommits.length} commit(s)` +
+      `${values['--reason'] ? ` — ${values['--reason']}` : ''}.`);
+    console.log('The run is guarded again from here. `npm run guard:verify` compares against the new baseline.');
+  }
+  process.exit(0);
+}
 
 // Release only a CLEAN run. Dropping the baseline after a failure destroys the
 // evidence at the exact moment it is needed: you cannot re-verify after a
@@ -375,9 +542,25 @@ if (changed) {
     console.error('  git log --oneline');
     console.error('Inspect them before pushing; there is no earlier revision to reset to.');
   } else if (headMoved) {
-    console.error('Investigate before pushing. A stray commit is recoverable while unpushed:');
-    console.error(`  git log --oneline ${before.head.slice(0, 8)}..HEAD`);
-    console.error(`  git reset --mixed ${before.head.slice(0, 8)}   # keeps the files, drops the commit`);
+    // Two readings, and the tool cannot tell them apart — only the caller knows
+    // whether they made these commits. Printing one recovery command as though
+    // it could is what #688 finding 2 is about: `git reset --mixed` would undo a
+    // merge the operator intended, offered at the moment they are deciding what
+    // to trust. So both exits are named, and the discriminator (the author lines
+    // above) is stated rather than guessed at.
+    console.error('HEAD moved. Read the author of every commit listed above — that is the only');
+    console.error('thing that separates the two cases, and this tool cannot read it for you.');
+    console.error(`\n  If a commit is NOT yours — the case this guard exists for` +
+      `${worktreeMoved ? '' : ' (the tree is otherwise clean, which is exactly how a committed stray write hides)'}:`);
+    console.error(`    git log --oneline ${before.head.slice(0, 8)}..HEAD`);
+    console.error(`    git reset --mixed ${before.head.slice(0, 8)}   # keeps the files, drops the commit`);
+    if (!fastForward) {
+      console.error('    NOTE: the snapshot commit is not an ancestor of HEAD, so that reset would');
+      console.error('    move you onto different history. Inspect before running it.');
+    }
+    console.error('\n  If every commit IS yours — you merged, switched branches, or rebased:');
+    console.error(`    npm run guard:rebaseline -- --accept=${after.head}`);
+    console.error('    (re-arms from here and RECORDS what it accepted, which --force does not)');
   } else {
     // `git reset --mixed` would unstage the caller's own work here, so it must
     // not be suggested when HEAD never moved.

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -231,6 +231,33 @@ function reportList(label, before, after) {
   return true;
 }
 
+/**
+ * Write a baseline, failing closed if it cannot be recorded.
+ *
+ * `provenance` is merged into the file. `snapshot` records none; `rebaseline`
+ * records what it accepted, so a later reader can tell an arming from a
+ * re-arming — the distinction `--force` erases (#688).
+ */
+function writeSnapshot(state, provenance = {}) {
+  try {
+    writeFileSync(
+      SNAPSHOT_PATH,
+      JSON.stringify(
+        { formatVersion: FORMAT_VERSION, ...state, takenAt: new Date().toISOString(), ...provenance },
+        null,
+        2,
+      ) + '\n',
+      'utf8',
+    );
+  } catch (error) {
+    // An uncaught throw here exits 1, which in this tool's vocabulary means
+    // "the repository changed" — the fail-closed contract requires that an
+    // inability to record the baseline reads as uncertainty, not as a verdict.
+    die(`could not write the snapshot to ${SNAPSHOT_PATH}: ${error.message}\n` +
+      'The run is NOT guarded. Fix this before fanning out.');
+  }
+}
+
 if (command === 'snapshot') {
   // Refusing to clobber is what stops a nested or concurrent run from
   // rebaselining the outer run's damage as the new normal.
@@ -245,19 +272,7 @@ if (command === 'snapshot') {
       'Let that run release its own, or `npm run guard:snapshot -- --force` if you know it is dead.');
   }
   const state = captureState();
-  try {
-    writeFileSync(
-      SNAPSHOT_PATH,
-      JSON.stringify({ formatVersion: FORMAT_VERSION, ...state, takenAt: new Date().toISOString() }, null, 2) + '\n',
-      'utf8',
-    );
-  } catch (error) {
-    // An uncaught throw here exits 1, which in this tool's vocabulary means
-    // "the repository changed" — the fail-closed contract requires that an
-    // inability to record the baseline reads as uncertainty, not as a verdict.
-    die(`could not write the snapshot to ${SNAPSHOT_PATH}: ${error.message}\n` +
-      'The run is NOT guarded. Fix this before fanning out.');
-  }
+  writeSnapshot(state);
   if (!QUIET) {
     console.log(`repo-guard: snapshot at ${state.head.slice(0, 8)} on ${state.branch}` +
       ` (${state.status.length} pending change(s), ${state.indexFlags.length} index flag(s))`);

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -125,7 +125,8 @@ const USAGE = `Usage:
   npm run guard:snapshot -- --quiet   suppress the success line (also valid on verify and rebaseline)
   npm run guard:rebaseline -- --accept=<sha> [--reason="..."]
                                       accept the printed move; <sha> must equal the
-                                      current HEAD, so it cannot be typed unread
+                                      current HEAD, so the transcript records WHICH
+                                      move was accepted
 
   (flags must follow \`--\`; npm swallows them otherwise. Valued flags use \`=\`, not a
    space, so the value cannot be mistaken for the command.)`;
@@ -512,6 +513,20 @@ if (command === 'rebaseline') {
     process.exit(1);
   }
 
+  if (!commitsEnumerated && before.head === UNBORN) {
+    // `git log '(unborn)..HEAD'` can never succeed, so the enumeration guard would brick
+    // rebaseline for an operator who armed an empty repository and then made their own
+    // first commits — sending them back to `--force`, the whole point of this command.
+    // Everything present arrived during the run, so enumerate without a range.
+    const all = git(['log', '--format=  %h %an <%ae>  %s'], { cwd: TOPLEVEL, allowFailure: true });
+    if (all && all.trim()) {
+      console.error('\n  the baseline had no commits, so every commit now present arrived during the run:');
+      console.error(all.trimEnd());
+      addedCommits = all.trim().split('\n').filter(Boolean).map((l) => l.trim());
+      commitsEnumerated = true;
+    }
+  }
+
   if (!commitsEnumerated) {
     console.error('\nrepo-guard: git could not list the commits between the baseline and HEAD.');
     console.error('There is nothing to read, so there is nothing to acknowledge. Accepting here would');
@@ -533,8 +548,8 @@ if (command === 'rebaseline') {
     console.error('\nThe sha is required so an acknowledgement cannot be given by reflex, and so the');
     console.error('transcript records WHICH move was accepted — which `--force` does not. It is a');
     console.error('control against ACCIDENT, not against intent: anyone who wants to can substitute');
-    console.error('`$(git rev-parse HEAD)`. What it buys is that the green path is never one paste');
-    console.error('away from a red verify. Read the authors above — and note they may be identical');
+    console.error('`$(git rev-parse HEAD)`. What it buys is that no red `guard:verify` ever prints a');
+    console.error('paste-ready override in its own output. Read the authors above — they may be');
     console.error('to yours, because a subagent commits through this repository\'s own git config.');
     console.error('That is what happened in #493. The content is the test; the author is a hint.');
     process.exit(2);
@@ -613,9 +628,16 @@ if (changed) {
     console.error(`    git log --oneline ${before.head.slice(0, 8)}..HEAD`);
     console.error(`    git reset --mixed ${before.head.slice(0, 8)}   # keeps the files, drops the commit`);
     console.error('    Investigate BEFORE PUSHING — a stray commit is recoverable while unpushed.');
-    if (!fastForward) {
+    if (fastForward === false) {
       console.error('    NOTE: the snapshot commit is not an ancestor of HEAD, so that reset would');
       console.error('    move you onto different history. Inspect before running it.');
+    } else if (fastForward === 'unknown') {
+      // `'unknown'` is TRUTHY, so `if (!fastForward)` suppressed this warning in exactly
+      // the case the three-valued ancestry was introduced to surface — and printed a
+      // `git reset --mixed <sha>` whose target's existence is what 'unknown' doubts.
+      console.error('    NOTE: git could not tell whether that commit is an ancestor, so this reset');
+      console.error(`    may move you onto different history. Confirm it exists first:`);
+      console.error(`      git cat-file -t ${before.head.slice(0, 8)}`);
     }
     if (worktreeMoved) {
       // Advising rebaseline here would advise a command that then refuses: it declines

--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -122,7 +122,7 @@ const USAGE = `Usage:
                                       a branch switch), naming the commits it accepts
 
   npm run guard:snapshot -- --force   replace an existing snapshot (refused by default)
-  npm run guard:snapshot -- --quiet   suppress the success line (also valid on verify)
+  npm run guard:snapshot -- --quiet   suppress the success line (also valid on verify and rebaseline)
   npm run guard:rebaseline -- --accept=<sha> [--reason="..."]
                                       accept the printed move; <sha> must equal the
                                       current HEAD, so it cannot be typed unread
@@ -191,6 +191,22 @@ function git(args, { cwd = undefined, allowFailure = false } = {}) {
     die(`git ${args.join(' ')} failed (exit ${result.status}): ${(result.stderr || '').trim()}`);
   }
   return result.stdout;
+}
+
+/**
+ * Is `maybeAncestor` an ancestor of `descendant`? `true` / `false` / `'unknown'`.
+ *
+ * `git()` discards the exit status under `allowFailure`, so it cannot tell exit 1
+ * ("no") from exit >= 128 ("could not look"). Every other caller only needs the
+ * output; this one is the difference between a claim and a guess.
+ */
+function ancestry(maybeAncestor, descendant) {
+  const result = spawnSync('git', ['merge-base', '--is-ancestor', maybeAncestor, descendant],
+    { encoding: 'utf8', cwd: TOPLEVEL });
+  if (result.error) return 'unknown';
+  if (result.status === 0) return true;
+  if (result.status === 1) return false;
+  return 'unknown';
 }
 
 const TOPLEVEL = git(['rev-parse', '--show-toplevel']).trim();
@@ -362,12 +378,22 @@ for (const field of ['toplevel', 'head', 'branch', 'status', 'contents', 'indexF
 if (before.toplevel !== TOPLEVEL) {
   die(`snapshot was taken in ${before.toplevel}, but this is ${TOPLEVEL}.`);
 }
+// The rebaseline chain is spread at the write site, OUTSIDE writeSnapshot's try/catch.
+// A corrupt `{}` there throws an uncaught TypeError, which exits 1 — and 1 in this
+// tool's vocabulary is the verdict "the repository changed". A malformed snapshot is
+// uncertainty, which is 2. A string is worse: it spreads to its characters and writes
+// garbage history at exit 0.
+if (before.rebaselineHistory !== undefined && !Array.isArray(before.rebaselineHistory)) {
+  die(`snapshot has a malformed 'rebaselineHistory' (${typeof before.rebaselineHistory}) — ` +
+    'refusing to compare against a record this tool did not write.');
+}
 
 const after = captureState();
 let changed = false;
 let headMoved = false;
-let fastForward = false;
+let fastForward = 'created';
 let addedCommits = [];
+let commitsEnumerated = true;
 
 if (before.head !== after.head) {
   changed = true;
@@ -389,11 +415,27 @@ if (before.head !== after.head) {
   // rules out is the other shape: a checkout that moved to unrelated history,
   // where `git reset --mixed <snapshot>` would be destructive rather than
   // merely wrong.
-  fastForward = before.head !== UNBORN
-    && git(['merge-base', '--is-ancestor', before.head, after.head],
-      { cwd: TOPLEVEL, allowFailure: true }) !== null;
-  console.error(`  the snapshot commit IS${fastForward ? '' : ' NOT'} an ancestor of the new HEAD` +
-    `${fastForward ? ' — history was added on top, not replaced' : ' — history diverged or was replaced'}.`);
+  //
+  // Three-valued, because `--is-ancestor` exits 1 for "no" and >= 128 for "could
+  // not tell" — a pruned or corrupt snapshot commit, which is realistic in a tool
+  // whose whole subject is rebases. Collapsing those with `!== null` printed
+  // "history diverged or was replaced" over a question git declined to answer:
+  // a confident wrong claim, and the exact opposite of "evidence, not a verdict".
+  fastForward = before.head === UNBORN
+    ? 'created'
+    : ancestry(before.head, after.head);
+  console.error(`  ${{
+    true: 'the snapshot commit IS an ancestor of the new HEAD — history was added on top',
+    false: 'the snapshot commit is NOT an ancestor of the new HEAD — history diverged or was replaced',
+    created: 'the baseline had no commits, so this history was created, not moved',
+    unknown: 'git could NOT determine ancestry (a pruned or corrupt object?) — treat the reading below as unavailable, not as a "no"',
+  }[fastForward]}.`);
+
+  // The ENUMERATE leg of the acknowledgement rests on this list. If git could not
+  // produce it, `rebaseline` must not go on to accept an empty one — "read the
+  // commits above" printed over nothing, and `acceptedCommits: []` written into
+  // permanent provenance, is a record that says a review happened when none could.
+  commitsEnumerated = range !== null;
 }
 
 if (before.branch !== after.branch) {
@@ -470,6 +512,15 @@ if (command === 'rebaseline') {
     process.exit(1);
   }
 
+  if (!commitsEnumerated) {
+    console.error('\nrepo-guard: git could not list the commits between the baseline and HEAD.');
+    console.error('There is nothing to read, so there is nothing to acknowledge. Accepting here would');
+    console.error('write `acceptedCommits: []` into the record — provenance asserting a review that');
+    console.error('could not happen.');
+    console.error(`\n  git log --oneline ${before.head.slice(0, 8)}..HEAD   # to see why it failed`);
+    process.exit(2);
+  }
+
   const accepted = values['--accept'];
   if (!accepted) {
     console.error('\nrepo-guard: HEAD moved. Nothing has been accepted yet.');
@@ -479,8 +530,13 @@ if (command === 'rebaseline') {
     console.error(`  npm run guard:rebaseline -- --accept=${after.head}`);
     console.error('  npm run guard:rebaseline -- ' +
       `--accept=${after.head} --reason="merged my own PR"`);
-    console.error('\nThe sha is required so the acknowledgement cannot be typed without reading it,');
-    console.error('and so the transcript records WHICH move was accepted — which `--force` does not.');
+    console.error('\nThe sha is required so an acknowledgement cannot be given by reflex, and so the');
+    console.error('transcript records WHICH move was accepted — which `--force` does not. It is a');
+    console.error('control against ACCIDENT, not against intent: anyone who wants to can substitute');
+    console.error('`$(git rev-parse HEAD)`. What it buys is that the green path is never one paste');
+    console.error('away from a red verify. Read the authors above — and note they may be identical');
+    console.error('to yours, because a subagent commits through this repository\'s own git config.');
+    console.error('That is what happened in #493. The content is the test; the author is a hint.');
     process.exit(2);
   }
 
@@ -548,19 +604,29 @@ if (changed) {
     // merge the operator intended, offered at the moment they are deciding what
     // to trust. So both exits are named, and the discriminator (the author lines
     // above) is stated rather than guessed at.
-    console.error('HEAD moved. Read the author of every commit listed above — that is the only');
-    console.error('thing that separates the two cases, and this tool cannot read it for you.');
+    console.error('HEAD moved. Read every commit listed above and decide whether you made it —');
+    console.error('this tool cannot decide that for you. The author line is a HINT, not the test:');
+    console.error('a subagent commits through this repository\'s own git config, so in #493 the');
+    console.error('author was identical to the operator\'s. What the commit CONTAINS is the test.');
     console.error(`\n  If a commit is NOT yours — the case this guard exists for` +
       `${worktreeMoved ? '' : ' (the tree is otherwise clean, which is exactly how a committed stray write hides)'}:`);
     console.error(`    git log --oneline ${before.head.slice(0, 8)}..HEAD`);
     console.error(`    git reset --mixed ${before.head.slice(0, 8)}   # keeps the files, drops the commit`);
+    console.error('    Investigate BEFORE PUSHING — a stray commit is recoverable while unpushed.');
     if (!fastForward) {
       console.error('    NOTE: the snapshot commit is not an ancestor of HEAD, so that reset would');
       console.error('    move you onto different history. Inspect before running it.');
     }
-    console.error('\n  If every commit IS yours — you merged, switched branches, or rebased:');
-    console.error(`    npm run guard:rebaseline -- --accept=${after.head}`);
-    console.error('    (re-arms from here and RECORDS what it accepted, which --force does not)');
+    if (worktreeMoved) {
+      // Advising rebaseline here would advise a command that then refuses: it declines
+      // any worktree change. Incoherent advice at the moment of decision is the failure
+      // this file already fixed once, for the occupied-slot refusal.
+      console.error('\n  The working tree moved too, so `guard:rebaseline` would refuse. Settle that first.');
+    } else {
+      console.error('\n  If every commit IS yours — you merged, switched branches, or rebased:');
+      console.error('    npm run guard:rebaseline    # prints the delta and refuses; read it, then accept');
+      console.error('    (re-arms from here and RECORDS what it accepted, which --force does not)');
+    }
   } else {
     // `git reset --mixed` would unstage the caller's own work here, so it must
     // not be suggested when HEAD never moved.

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -573,3 +573,264 @@ test('the snapshot lives outside the working tree, so it cannot dirty it', async
   assert.equal(r.status, 0, r.stderr);
   assert.ok(existsSync(snapshotPath(dir)), 'verify keeps the snapshot by default');
 });
+
+// ── rebaseline: the exit for a legitimate mover (#688) ──────────────────────
+//
+// The gap these cover: `verify` and `release` both treat a moved HEAD as
+// unexplained, which is right for a stray agent commit and wrong for the
+// commonest event in any long run — the arming session merging its own branch.
+// The only way through was `guard:snapshot -- --force`, a flag whose own text
+// warns against itself, and which leaves a transcript indistinguishable from a
+// careless rebaseline over an agent's commit.
+//
+// The tests that matter most here are the REFUSALS. A re-arming command that
+// accepts too much is worse than no command at all, because it launders the
+// exact write (#493) the guard was built to catch — so each of the four things
+// it must refuse gets its own test.
+
+/** Move HEAD the way an operator legitimately does: merge your own branch. */
+function mergeOwnBranch(dir) {
+  git(dir, ['checkout', '-q', '-b', 'feat']);
+  writeFileSync(join(dir, 'src', 'b.txt'), 'mine\n', 'utf8');
+  git(dir, ['add', '--', 'src/b.txt']);
+  git(dir, ['commit', '-m', 'my own work']);
+  git(dir, ['checkout', '-q', 'main']);
+  git(dir, ['merge', '--no-ff', '-m', 'merge my own branch', 'feat']);
+  return git(dir, ['rev-parse', 'HEAD']);
+}
+
+test('rebaseline re-arms after the arming session merges its own branch', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const head = mergeOwnBranch(dir);
+
+  const r = guard(dir, ['rebaseline', `--accept=${head}`, '--reason=merged my own PR']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /re-baselined/);
+  // And the guard is live again from the new baseline, rather than disarmed.
+  assert.equal(guard(dir, ['verify']).status, 0, 'verify should pass against the new baseline');
+});
+
+test('rebaseline RECORDS what it accepted — the thing --force cannot do', async (t) => {
+  // Finding 1: `--force` exists but is indistinguishable in the transcript from
+  // a careless rebaseline over an agent's stray commit. Provenance is the whole
+  // difference between the two, so it is asserted rather than assumed.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const before = git(dir, ['rev-parse', 'HEAD']);
+  const head = mergeOwnBranch(dir);
+
+  guard(dir, ['rebaseline', `--accept=${head}`, '--reason=merged my own PR']);
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+
+  assert.equal(snap.head, head, 'the new baseline is the new HEAD');
+  assert.equal(snap.rebaselinedFrom.head, before, 'it records where it came from');
+  assert.equal(snap.rebaselinedFrom.reason, 'merged my own PR');
+  assert.equal(snap.rebaselinedFrom.fastForward, true);
+  assert.equal(snap.rebaselinedFrom.acceptedCommits.length, 2,
+    'both the merge and the commit it brought in are named');
+  assert.ok(snap.rebaselinedFrom.acceptedCommits.every((line) => line.includes('Fixture')),
+    'the author of each accepted commit is recorded, since that is the discriminator');
+  assert.equal(snap.rebaselineHistory.length, 1);
+});
+
+test('a second rebaseline appends to the history rather than erasing the first', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  guard(dir, ['rebaseline', `--accept=${mergeOwnBranch(dir)}`, '--reason=first']);
+
+  git(dir, ['checkout', '-q', '-b', 'feat2']);
+  writeFileSync(join(dir, 'src', 'c.txt'), 'more\n', 'utf8');
+  git(dir, ['add', '--', 'src/c.txt']);
+  git(dir, ['commit', '-m', 'more of my own work']);
+  git(dir, ['checkout', '-q', 'main']);
+  git(dir, ['merge', '--no-ff', '-m', 'merge again', 'feat2']);
+  guard(dir, ['rebaseline', `--accept=${git(dir, ['rev-parse', 'HEAD'])}`, '--reason=second']);
+
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+  assert.deepEqual(snap.rebaselineHistory.map((h) => h.reason), ['first', 'second'],
+    'a chain of re-armings stays visible; each one must not overwrite the last');
+});
+
+// ── the four refusals ───────────────────────────────────────────────────────
+
+test('REFUSES without --accept: the delta must be read before it is accepted', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const head = mergeOwnBranch(dir);
+
+  const r = guard(dir, ['rebaseline']);
+
+  assert.equal(r.status, 2, 'no acknowledgement means the question is unanswered, not answered no');
+  assert.match(r.stderr, /Nothing has been accepted yet/);
+  assert.match(r.stderr, /commits added:/, 'it must print what it is asking about');
+  assert.ok(r.stderr.includes(head), 'and the exact sha to paste back');
+  assert.ok(existsSync(snapshotPath(dir)), 'the original baseline survives a refusal');
+});
+
+test('REFUSES a sha that is not the current HEAD', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const before = git(dir, ['rev-parse', 'HEAD']);
+  mergeOwnBranch(dir);
+
+  // Accepting the OLD head is the plausible mistake: it is the sha printed first.
+  const r = guard(dir, ['rebaseline', `--accept=${before}`]);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /but HEAD is/);
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+  assert.equal(snap.head, before, 'the baseline is untouched by a refused acceptance');
+});
+
+test('REFUSES a sha too short to be an acknowledgement of anything', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const head = mergeOwnBranch(dir);
+
+  // A 6-character prefix of the REAL head: correct as far as it goes, and still
+  // refused. Otherwise `--accept=a` would pass on roughly one repo in sixteen.
+  const r = guard(dir, ['rebaseline', `--accept=${head.slice(0, 6)}`]);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /not specific enough/);
+});
+
+test('REFUSES when the WORKING TREE moved, not just HEAD', async (t) => {
+  // The load-bearing refusal. "I moved HEAD deliberately" is a claim about
+  // history and says nothing about file contents; accepting a content change
+  // under it would rebaseline a stray write (#493) as the new normal.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const head = mergeOwnBranch(dir);
+  writeFileSync(join(dir, 'src', 'a.txt'), 'someone else wrote this\n', 'utf8');
+
+  const r = guard(dir, ['rebaseline', `--accept=${head}`]);
+
+  assert.equal(r.status, 1, 'this is the case the guard exists for — it must go red');
+  assert.match(r.stderr, /WORKING TREE moved/);
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+  assert.notEqual(snap.head, head, 'the baseline must NOT have been moved');
+});
+
+test('rebaseline with no snapshot is not a synonym for snapshot', async (t) => {
+  // Silently arming here would make `guard:rebaseline` a second spelling of
+  // `guard:snapshot` that no longer means "I accepted a move".
+  const dir = makeRepo(t);
+
+  const r = guard(dir, ['rebaseline', `--accept=${git(dir, ['rev-parse', 'HEAD'])}`]);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /nothing to re-baseline FROM/);
+  assert.ok(!existsSync(snapshotPath(dir)), 'it must not have armed one');
+});
+
+test('rebaseline on an unmoved repository changes nothing', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const armed = readFileSync(snapshotPath(dir), 'utf8');
+
+  const r = guard(dir, ['rebaseline']);
+
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /nothing moved/);
+  assert.equal(readFileSync(snapshotPath(dir), 'utf8'), armed,
+    'a no-op rebaseline must not rewrite takenAt or add empty provenance');
+});
+
+// ── the guard still guards (#688 AC3) ───────────────────────────────────────
+
+test('AC3: an agent commit the operator did not make still goes RED', async (t) => {
+  // Everything above adds an exit. This asserts the exit did not become a hole:
+  // the case the whole tool exists for must still be caught, and `verify` must
+  // still name the recovery for a commit that is not yours.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const before = git(dir, ['rev-parse', 'HEAD']);
+
+  writeFileSync(join(dir, 'src', 'stray-fixture.sh'), '#!/bin/sh\necho oops\n', 'utf8');
+  git(dir, ['add', '--', 'src/stray-fixture.sh']);
+  git(dir, ['-c', 'user.name=Subagent', '-c', 'user.email=agent@example.invalid',
+    'commit', '-m', 'add fixture']);
+
+  assert.equal(git(dir, ['status', '--porcelain']), '',
+    'precondition: git status reads CLEAN, which is why this needs a guard at all');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1, 'a committed stray write must still be caught');
+  assert.match(r.stderr, /HEAD moved/);
+  assert.match(r.stderr, /Subagent/, 'the author is printed — it is the discriminator');
+  assert.ok(r.stderr.includes(`git reset --mixed ${before.slice(0, 8)}`),
+    'the recovery for a commit that is NOT yours must still be named');
+  assert.ok(existsSync(snapshotPath(dir)), 'and the baseline is kept for a re-verify');
+});
+
+test('AC3: --release still refuses to drop the baseline over an agent commit', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  writeFileSync(join(dir, 'src', 'stray.txt'), 'oops\n', 'utf8');
+  git(dir, ['add', '--', 'src/stray.txt']);
+  git(dir, ['commit', '-m', 'stray']);
+
+  const r = guard(dir, ['verify', '--release']);
+
+  assert.equal(r.status, 1);
+  assert.ok(existsSync(snapshotPath(dir)), 'release must not consume a dirty baseline');
+});
+
+test('verify names BOTH exits when HEAD moves, and prefers neither', async (t) => {
+  // Finding 2: the old message offered `git reset --mixed <snapshot>` alone,
+  // which would undo a merge the operator intended — wrong advice delivered at
+  // the moment they are deciding what to trust.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const head = mergeOwnBranch(dir);
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1, 'a moved HEAD is still a change; naming the exit is not accepting it');
+  assert.match(r.stderr, /If a commit is NOT yours/);
+  assert.match(r.stderr, /If every commit IS yours/);
+  assert.ok(r.stderr.includes(`--accept=${head}`), 'the rebaseline exit is copy-pasteable');
+  assert.match(r.stderr, /IS an ancestor of the new HEAD/,
+    'ancestry is reported as evidence for the reader to weigh');
+});
+
+test('a replaced history is reported as NOT an ancestor', async (t) => {
+  // The reset advice is actively destructive here, so the message says so.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  git(dir, ['checkout', '-q', '--orphan', 'other']);
+  writeFileSync(join(dir, 'src', 'a.txt'), 'unrelated\n', 'utf8');
+  git(dir, ['add', '--', 'src/a.txt']);
+  git(dir, ['commit', '-m', 'unrelated root']);
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /NOT an ancestor of the new HEAD/);
+  assert.match(r.stderr, /move you onto different history/);
+});
+
+test('--accept given without a value says so, rather than "unknown argument"', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+
+  const r = guard(dir, ['rebaseline', '--accept']);
+
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /needs a value/);
+});
+
+test('rebaseline rejects flags that belong to another subcommand', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+
+  for (const bad of ['--release', '--force', '--acccept=abcdefg']) {
+    const r = guard(dir, ['rebaseline', bad]);
+    assert.equal(r.status, 2, `${bad} should be refused`);
+    assert.match(r.stderr, /unknown argument/);
+  }
+});

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -761,7 +761,9 @@ test('AC3: an agent commit the operator did not make still goes RED', async (t) 
 
   assert.equal(r.status, 1, 'a committed stray write must still be caught');
   assert.match(r.stderr, /HEAD moved/);
-  assert.match(r.stderr, /Subagent/, 'the author is printed — it is the discriminator');
+  assert.match(r.stderr, /Subagent/,
+    'the author is printed as a HINT — in #493 it was identical to the operator\'s, because a '
+    + 'subagent commits through this repository\'s own git config');
   assert.ok(r.stderr.includes(`git reset --mixed ${before.slice(0, 8)}`),
     'the recovery for a commit that is NOT yours must still be named');
   assert.ok(existsSync(snapshotPath(dir)), 'and the baseline is kept for a re-verify');
@@ -786,16 +788,116 @@ test('verify names BOTH exits when HEAD moves, and prefers neither', async (t) =
   // the moment they are deciding what to trust.
   const dir = makeRepo(t);
   guard(dir, ['snapshot']);
-  const head = mergeOwnBranch(dir);
+  mergeOwnBranch(dir);
 
   const r = guard(dir, ['verify']);
 
   assert.equal(r.status, 1, 'a moved HEAD is still a change; naming the exit is not accepting it');
   assert.match(r.stderr, /If a commit is NOT yours/);
   assert.match(r.stderr, /If every commit IS yours/);
-  assert.ok(r.stderr.includes(`--accept=${head}`), 'the rebaseline exit is copy-pasteable');
+  assert.match(r.stderr, /Investigate BEFORE PUSHING/,
+    'pushing is the irreversibility boundary and the advice must say so');
   assert.match(r.stderr, /IS an ancestor of the new HEAD/,
     'ancestry is reported as evidence for the reader to weigh');
+});
+
+test('THE HOLE: verify must not hand out a paste-ready override', async (t) => {
+  // An earlier version printed `guard:rebaseline -- --accept=<full HEAD>` in the
+  // FAILURE output. For the #493 case — a subagent commits, the tree reads clean —
+  // the red verify therefore ended with a command that makes the next verify green,
+  // one paste away. A guard whose own failure message carries its override is not a
+  // guard, and the test that used to live here asserted the paste-ready sha as a
+  // REQUIREMENT, cementing the hole against repair.
+  //
+  // The acknowledgement is a control against ACCIDENT, not intent: anyone can type
+  // `$(git rev-parse HEAD)`. What it buys is exactly that the green path is never
+  // sitting in the red output, and that is what this pins.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  writeFileSync(join(dir, 'src', 'stray-fixture.sh'), '#!/bin/sh\n', 'utf8');
+  git(dir, ['add', '--', 'src/stray-fixture.sh']);
+  git(dir, ['commit', '-m', 'stray']);
+  const head = git(dir, ['rev-parse', 'HEAD']);
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.ok(!r.stderr.includes(`--accept=${head}`),
+    'verify must not print a paste-ready --accept for the very commit it is reporting');
+  assert.ok(!r.stderr.includes(`--accept=${head.slice(0, 8)}`), 'not an abbreviated one either');
+  assert.match(r.stderr, /npm run guard:rebaseline {4}#/,
+    'it may still NAME the command — the caller must fetch the sha themselves');
+});
+
+test('verify does not advise rebaseline when it would refuse', async (t) => {
+  // Both moved. Advising a command that then exits 1 is incoherent advice at the
+  // moment of decision, which is the failure this file already fixed once for the
+  // occupied-slot refusal.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  mergeOwnBranch(dir);
+  writeFileSync(join(dir, 'src', 'a.txt'), 'someone else wrote this\n', 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /would refuse. Settle that first/);
+  assert.ok(!r.stderr.includes('If every commit IS yours'),
+    'the rebaseline exit must not be offered when the tree also moved');
+  assert.ok(!/the tree is otherwise clean/.test(r.stderr),
+    'and it must not claim the tree is clean when it is not');
+});
+
+test('an unanswerable ancestry is reported as unknown, not as "no"', async (t) => {
+  // `git merge-base --is-ancestor` exits 1 for "not an ancestor" and >= 128 for
+  // "could not look" — a pruned or corrupt object, realistic in a tool whose whole
+  // subject is rebases. Collapsing them printed "history diverged or was replaced"
+  // over a question git declined to answer.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+  snap.head = '0'.repeat(40);   // well-formed, and not an object in this repository
+  writeFileSync(snapshotPath(dir), JSON.stringify(snap), 'utf8');
+
+  const r = guard(dir, ['verify']);
+
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /could NOT determine ancestry/);
+  assert.ok(!/history diverged or was replaced/.test(r.stderr),
+    'a question git refused to answer must not be reported as an answer');
+});
+
+test('rebaseline refuses when it could not enumerate the commits', async (t) => {
+  // The ENUMERATE leg of the acknowledgement rests on that list. Accepting an empty
+  // one writes `acceptedCommits: []` into permanent provenance — a record asserting
+  // a review that could not have happened.
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+  snap.head = '0'.repeat(40);
+  writeFileSync(snapshotPath(dir), JSON.stringify(snap), 'utf8');
+
+  const r = guard(dir, ['rebaseline', `--accept=${git(dir, ['rev-parse', 'HEAD'])}`]);
+
+  assert.equal(r.status, 2, 'no evidence means the question is unanswered');
+  assert.match(r.stderr, /nothing to acknowledge/);
+  const after = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+  assert.equal(after.head, '0'.repeat(40), 'the baseline must be untouched');
+});
+
+test('a malformed rebaselineHistory exits 2, not 1 — uncertainty is not a verdict', async (t) => {
+  const dir = makeRepo(t);
+  guard(dir, ['snapshot']);
+
+  for (const corrupt of [{}, 'abc', 42]) {
+    const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+    snap.rebaselineHistory = corrupt;
+    writeFileSync(snapshotPath(dir), JSON.stringify(snap), 'utf8');
+
+    const r = guard(dir, ['verify']);
+    assert.equal(r.status, 2, `${JSON.stringify(corrupt)} must read as uncertainty, not "changed"`);
+    assert.match(r.stderr, /malformed 'rebaselineHistory'/);
+  }
 });
 
 test('a replaced history is reported as NOT an ancestor', async (t) => {

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -762,8 +762,8 @@ test('AC3: an agent commit the operator did not make still goes RED', async (t) 
   assert.equal(r.status, 1, 'a committed stray write must still be caught');
   assert.match(r.stderr, /HEAD moved/);
   assert.match(r.stderr, /Subagent/,
-    'the author is printed as a HINT — in #493 it was identical to the operator\'s, because a '
-    + 'subagent commits through this repository\'s own git config');
+    'the author is printed as a HINT, never as the discriminator — in #493 it was identical '
+    + 'to the operator\'s, because a subagent commits through this repository\'s own git config');
   assert.ok(r.stderr.includes(`git reset --mixed ${before.slice(0, 8)}`),
     'the recovery for a commit that is NOT yours must still be named');
   assert.ok(existsSync(snapshotPath(dir)), 'and the baseline is kept for a re-verify');
@@ -822,9 +822,12 @@ test('THE HOLE: verify must not hand out a paste-ready override', async (t) => {
   const r = guard(dir, ['verify']);
 
   assert.equal(r.status, 1);
-  assert.ok(!r.stderr.includes(`--accept=${head}`),
-    'verify must not print a paste-ready --accept for the very commit it is reporting');
-  assert.ok(!r.stderr.includes(`--accept=${head.slice(0, 8)}`), 'not an abbreviated one either');
+  // The token itself, not two of its lengths. Asserting only the 40- and 8-character
+  // forms left a 7-character gap: `--accept=${head.slice(0, 7)}` is paste-ready AND
+  // accepted (`accepted.length < 7` admits exactly 7) while containing neither. Verify's
+  // naming line carries no `--accept=` substring at all, so the strong form is free.
+  assert.ok(!r.stderr.includes('--accept='),
+    'verify must not print a paste-ready --accept at ANY abbreviation length');
   assert.match(r.stderr, /npm run guard:rebaseline {4}#/,
     'it may still NAME the command — the caller must fetch the sha themselves');
 });
@@ -865,6 +868,48 @@ test('an unanswerable ancestry is reported as unknown, not as "no"', async (t) =
   assert.match(r.stderr, /could NOT determine ancestry/);
   assert.ok(!/history diverged or was replaced/.test(r.stderr),
     'a question git refused to answer must not be reported as an answer');
+
+  // The reason the rendering alone is not enough: `'unknown'` is TRUTHY, so an
+  // `if (!fastForward)` guard on the reset-safety NOTE suppresses it in exactly the case
+  // the three-valued ancestry exists to surface — and prints `git reset --mixed <sha>`
+  // whose target's existence is what 'unknown' doubts. Without this assertion both the
+  // buggy and the fixed form pass.
+  assert.match(r.stderr, /git could not tell whether that commit is an ancestor/,
+    'the reset advice must be qualified when ancestry is unknown');
+  assert.match(r.stderr, /git cat-file -t/, 'and must say how to check');
+});
+
+test('an unborn baseline can still be re-baselined, without an invalid range', async (t) => {
+  // `git log '(unborn)..HEAD'` can never succeed, so the enumeration guard would brick
+  // rebaseline for an operator who armed an empty repository and then made their own
+  // first commits — back to `--force`, which is the whole point of this command. And the
+  // refusal would print that unrunnable range as copy-pasteable advice, the defect class
+  // the unborn branch of verify's message already exists to forbid.
+  const dir = mkdtempSync(join(tmpdir(), 'repo-guard-'));
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  git(dir, ['init', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Fixture']);
+
+  assert.equal(guard(dir, ['snapshot']).status, 0, 'an empty repo is a legitimate baseline');
+
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(join(dir, 'src', 'a.txt'), 'mine\n', 'utf8');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-m', 'my own first commit']);
+
+  const refusal = guard(dir, ['rebaseline']);
+  assert.equal(refusal.status, 2);
+  assert.match(refusal.stderr, /every commit now present arrived during the run/);
+  assert.match(refusal.stderr, /my own first commit/, 'the commits must actually be listed');
+  assert.ok(!refusal.stderr.includes('(unborn)..'),
+    'an invalid revision range must never be printed as advice');
+
+  const r = guard(dir, ['rebaseline', `--accept=${git(dir, ['rev-parse', 'HEAD'])}`]);
+  assert.equal(r.status, 0, r.stderr);
+  const snap = JSON.parse(readFileSync(snapshotPath(dir), 'utf8'));
+  assert.equal(snap.rebaselinedFrom.acceptedCommits.length, 1,
+    'the accepted commit is recorded, not an empty list');
 });
 
 test('rebaseline refuses when it could not enumerate the commits', async (t) => {


### PR DESCRIPTION
## Summary

`verify` and `release` both treat a moved HEAD as **unexplained**. That is right for the case the guard exists for — a subagent that committed, leaving a tree `git status` reads as clean — and wrong for the commonest event in any run of length: the arming session merges its own branch, switches branches, or rebases.

Until now the only way through was `guard:snapshot -- --force`: a flag whose own text warns against itself in the same breath, and whose transcript is indistinguishable from a careless rebaseline over an agent's stray commit. A caller who reaches for `--force` twice stops reading what it discards, and the control becomes a ritual — the shape this whole tool is an argument against.

Hit live again while preparing this batch: the session armed a snapshot, then legitimately created a branch and committed twice.

## `npm run guard:rebaseline`

It costs exactly the three steps of judgement the honest sequence already required. The difference is that the tool performs them instead of assuming them.

```console
$ npm run guard:rebaseline

  HEAD moved: ca73cf4f -> ae6c1fa8
  commits added:
  ae6c1fa Tester <t@t>  merge my own branch
  2d31fe2 Tester <t@t>  my own work
  the snapshot commit IS an ancestor of the new HEAD — history was added on top, not replaced.

repo-guard: HEAD moved. Nothing has been accepted yet.
Read the commits above. Every one of them must be yours — a commit you did not
make is the thing this guard is for, and accepting it here hides it permanently.

If they are all yours, re-run naming the HEAD you just read:
  npm run guard:rebaseline -- --accept=ae6c1fa8f5283ca48ae6ac50de39a7a63ae7dba0
...
exit 2
```

- **Enumerate** — commits with author *and email*, plus whether the snapshot commit is an ancestor of the new HEAD. Ancestry is **evidence, not a verdict**: an agent's commit on the current branch is a descendant too. What it rules out is a checkout onto unrelated history, where the reset advice would be destructive rather than merely wrong.
- **Confirm** — without `--accept=<sha>` it refuses, exit 2. The sha must equal the current HEAD, so the acknowledgement cannot be typed unread; a sha under 7 characters is refused as not specific enough to acknowledge anything (otherwise `--accept=a` passes on roughly one repo in sixteen).
- **Record** — the new baseline carries `rebaselinedFrom` (previous head, accepted commit lines, ancestry reading, optional `--reason`) and a `rebaselineHistory` that **appends**. That is the entire difference from `--force`, which leaves no trace.

It **refuses any worktree, content, or index-flag change** — exit 1, baseline kept. "I moved HEAD deliberately" is a claim about history and says nothing about file contents; accepting one as cover for the other would launder exactly the stray write (#493) the guard was built to catch.

## Finding 2: the recovery advice was wrong for this case

`verify` offered `git reset --mixed <snapshot>` alone, which would undo a merge the operator intended — wrong advice at the moment they are deciding what to trust. Both exits are now named, **neither preferred**, and the discriminator is stated rather than guessed at: read the author of every commit, because the tool cannot read it for you.

## Verified by mutation, against the command CI runs

Tests go **30 → 45**. Four additions are REFUSALS, because a re-arming command that accepts too much is worse than no command at all.

| mutation | result |
|---|---|
| `if (worktreeMoved) {` → `if (false) {` — let rebaseline swallow a stray write | `MUTANT KILLED by 1 failing test(s)` |
| `accepted.length < 7 \|\| !after.head.startsWith(accepted)` → `false` — accept any sha | `MUTANT KILLED by 2 failing test(s)` |
| delete `headMoved = true;` — blind the guard to a moved HEAD | `MUTANT KILLED by 5 failing test(s)` |

## Acceptance criteria

- [x] A supported re-baseline that **names what moved** — prints the `snapshot..HEAD` commit list and requires it acknowledged, rather than silently accepting `--force`
- [x] `verify` distinguishes "HEAD moved" from "worktree content moved"; the reset advice is no longer offered as the only reading
- [x] A mutation shows the guard still goes red for the case it exists for — two tests labelled AC3 (an agent commit still red; `--release` still refuses a dirty baseline), plus the three mutants above
- [x] `CLAUDE.md` § Guarding a Multi-Agent Run gains the rule for when your own run merges

The first commit is a pure extraction (`writeSnapshot()`) with no behaviour change, so the feature diff is readable on its own.

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmu8MKEFniwX7WrjV1iXr


---

## Adversarial review found a BLOCKING hole, and it is fixed here

Not a bug in the new command — the new command **advertised in the wrong place**.

`verify`'s *failure* output printed the remediation pre-filled: `npm run guard:rebaseline -- --accept=<full HEAD>`. For the exact #493 state — a subagent commits, the tree reads clean afterwards — the red verify therefore ended with a paste-complete command that makes the next verify green:

```console
$ npm run guard:snapshot
$ git commit -m 'stray fixture'          # the agent's commit; tree reads clean
$ npm run guard:verify                   # exit 1 — and prints the override, pre-filled
$ npm run guard:rebaseline -- --accept=<paste>
$ npm run guard:verify                   # exit 0, "unchanged" — laundered
```

Under `main` no failure message ever advised a green path, only recovery. Worse, the test shipped alongside it **asserted the pre-filled sha as a requirement** — "the rebaseline exit is copy-pasteable" — cementing the hole against repair. That test is inverted and renamed `THE HOLE`.

The population that runs `guard:verify` here is largely orchestrators following the bracket protocol in `CLAUDE.md`. This file's own header states the founding lesson: *"the containment cannot be a sentence in a prompt, because the agent complied with the sentence."* Printing the override and asking the reader not to use it **is** that sentence.

`verify` now names the command without a sha, and does not name it at all when the working tree also moved — where `rebaseline` refuses anyway, so the advice was incoherent at the moment of decision.

```console
$ npm run mutation-check -- --file scripts/repo-guard.js \
    --replace "<the placeholder line>"::"<the pre-filled --accept line>" \
    --test 'npm run test:scripts' --expect-killed-by 1
MUTANT KILLED by 1 failing test(s) — the check can fail.
```

### The claimed property was overstated, in four places

*"The sha is required so the acknowledgement cannot be typed without reading it"* is false as written — anyone can substitute `$(git rev-parse HEAD)`. It is a control against **accident, not intent**. What it actually buys is that the green path is never sitting in the red output. Corrected in the in-code message, the rebaseline refusal, `CLAUDE.md`, and the tests.

### The discriminator was wrong about its own founding incident

The message said the author line *"is the only thing that separates the two cases"*. In #493 the subagent committed through **this repository's own git config**, so the author was identical to the operator's — and the AC3 fixture flattered the mechanism by giving the agent a distinct name. The author is now stated as a hint, with the reason, and the commit's *content* named as the test.

### Two more from the same review

- **`--is-ancestor` conflated "no" with "could not look."** It exits 1 for the first and ≥128 for the second — a pruned or corrupt object, realistic in a tool whose subject is rebases. `!== null` collapsed them and printed "history diverged or was replaced" over a question git declined to answer: a confident wrong claim, and the opposite of the "evidence, not a verdict" the code claims. Now three-valued. The same collapse made a failed `git log` yield `acceptedCommits: []` — provenance asserting a review that could not have happened — so `rebaseline` refuses when it could not enumerate.
- **`rebaselineHistory` was spread unvalidated**, at the write site *outside* `writeSnapshot`'s try/catch. A corrupt `{}` threw an uncaught TypeError → exit 1, which in this tool's vocabulary is the verdict "the repository changed". A string was worse: it spread to its characters and wrote garbage history at exit 0. Validated now, exiting 2.

Also restores **"Investigate BEFORE PUSHING — recoverable while unpushed"**, which the message rewrite dropped. Pushing is the irreversibility boundary.

Tests **45 → 50**.

### Known, not fixed here

Two unasserted behaviours the reviewer named: `takenAt ?? null` in `rebaselinedFrom`, and last-wins for a duplicate `--accept=`. Both cosmetic. Also unchanged and inherited from `main`: a `skip-worktree` bit set *before* arming is invisible to snapshot, verify and rebaseline alike — `rebaseline` adds no new reach into it, because its refusal predicate is exactly `verify`'s.


---

## Round two: no blocking findings, four non-blocking, all fixed

The B1 repair was confirmed real rather than cosmetic. The reviewer's argument for why the two-step holds is worth keeping: the paste-ready token can now only be *obtained* by running the command whose entire output **is** the evidence, so the evidence-coupled route is the path of least resistance. Pre-filling nowhere would have pushed every caller to `--accept=$(git rev-parse HEAD)`, bypassing the display entirely. Stated floor, so nobody overclaims later: verify's red output necessarily names the new HEAD in its `HEAD moved: … -> yyyyyyyy` line, so the raw material is one string-concatenation away — never one paste. That is exactly what "control against accident, not intent" licenses.

**A real bug, not wording.** Making ancestry three-valued fixed the *claim* and left its *consumer* coercing:

```js
if (!fastForward) { /* ...that reset would move you onto different history... */ }
```

`'unknown'` is **truthy**, so the destructive-reset warning was suppressed in precisely the case the three-valued reading exists to surface — while the advice above it still printed `git reset --mixed <sha>` whose target's very *existence* is what `'unknown'` doubts. The rendering said "treat the reading below as unavailable, not as a no", and the code below behaved as though it were a yes. The existing test asserted only the rendering line, so both forms passed it.

**`THE HOLE` had a seven-character gap.** It asserted absence of the 40- and 8-character forms; `--accept=${after.head.slice(0, 7)}` is paste-ready **and accepted** (`accepted.length < 7` admits exactly 7) while containing neither. It now asserts absence of `--accept=` outright.

**An unborn baseline was bricked**, with unrunnable advice. `git log '(unborn)..HEAD'` can never succeed, so the enumeration guard refused rebaseline outright for an operator who armed an empty repo and made their own first commits — back to `--force`, the whole point of the command — and printed that invalid range as copy-pasteable advice.

**The wording sweep missed a fifth site, and it was the one the tool emits.** `USAGE` still read "so it cannot be typed unread", and `die()` appends USAGE to every argument error. Swept by grep this round rather than by memory.

### Note on one mutant that survived

```
--replace 'if (fastForward === false) {'::'if (!fastForward) {'   → MUTANT SURVIVED
```

That is an **equivalent mutant**, not a coverage gap: with the `else if (fastForward === 'unknown')` branch in place, `!fastForward` and `=== false` behave identically for all four values. The honest instrument for that line is deleting the `else if`, which parses, runs to completion, and dies to exactly one test:

```
--delete-matching "} else if (fastForward === 'unknown') {"       → MUTANT KILLED by 1
```

Recorded because a surviving mutant normally indicts the fixture, and here it indicted the mutation.

Tests **50 → 51**.