### PR TITLE
fix(viz): the mode label named five where six are bound, on a published page (#639)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -196,9 +196,13 @@ jobs:
       #
       # Read what a clean run does NOT claim before quoting one: labels,
       # node_type, edges and source-side annotation staleness are all invisible
-      # to it. `bind_modes` today reads "(2D/3D/Hive/Chord/Flow)" and Campfire is
-      # the sixth mode — that label is wrong in the source annotation, so a
-      # faithful regeneration reproduces it and this gate stays green through it.
+      # to it. `bind_modes` READ "(2D/3D/Hive/Chord/Flow)" while Campfire was the
+      # sixth bound mode; the source annotation was fixed in #702 and the
+      # committed diagram still carries the old text, because repairing that
+      # means regenerating (#601). This gate was green through the defect and is
+      # green through the divergence — it compares ids, and `bind_modes` was
+      # never missing from either side. The label is covered by
+      # scripts/test/viz-mode-label.test.js instead.
       - name: Check viz diagram node parity (warn only until #601)
         run: node scripts/check-workflow-diagram-nodes.js --warn
 

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -201,8 +201,9 @@ jobs:
       # committed diagram still carries the old text, because repairing that
       # means regenerating (#601). This gate was green through the defect and is
       # green through the divergence — it compares ids, and `bind_modes` was
-      # never missing from either side. The label is covered by
-      # scripts/test/viz-mode-label.test.js instead.
+      # never missing from either side. scripts/test/viz-mode-label.test.js covers
+      # the SOURCE label against the code; nothing gates the diagram's COPY of it,
+      # which is the divergence #601 closes.
       - name: Check viz diagram node parity (warn only until #601)
         run: node scripts/check-workflow-diagram-nodes.js --warn
 

--- a/scripts/check-workflow-diagram-nodes.js
+++ b/scripts/check-workflow-diagram-nodes.js
@@ -19,11 +19,14 @@
  *
  * Node identity only. All of the following are invisible to it:
  *
- *   - **Labels.** `bind_modes` reads "Bind mode switching (2D/3D/Hive/Chord/
- *     Flow)" and five is not six — Campfire is bound and unlisted (#639). That
- *     text comes from the annotation in `viz/js/app.js`, so a faithful
- *     regeneration reproduces the wrong label and this check stays green
- *     through it.
+ *   - **Labels.** `bind_modes` READ "Bind mode switching (2D/3D/Hive/Chord/
+ *     Flow)" while six modes were bound — Campfire missing (#639). The source
+ *     annotation was corrected in #702; the committed diagram still carries the
+ *     five-mode text, because repairing it means regenerating, which #601
+ *     blocks. This check was green through the defect and is green through the
+ *     divergence, which is the point: it compares ids, and `bind_modes` was
+ *     never missing from either side. `scripts/test/viz-mode-label.test.js` is
+ *     what covers the label now.
  *   - **`node_type`.** An `input` retyped to `process` moves the node's shape
  *     and its `class` line; the id is unchanged, so nothing here fires.
  *   - **Edges.** `input:`/`output:` chains build the `-->` block. A rewired

--- a/scripts/check-workflow-diagram-nodes.js
+++ b/scripts/check-workflow-diagram-nodes.js
@@ -25,8 +25,9 @@
  *     five-mode text, because repairing it means regenerating, which #601
  *     blocks. This check was green through the defect and is green through the
  *     divergence, which is the point: it compares ids, and `bind_modes` was
- *     never missing from either side. `scripts/test/viz-mode-label.test.js` is
- *     what covers the label now.
+ *     never missing from either side. `scripts/test/viz-mode-label.test.js`
+ *     covers the SOURCE label against the code. Nothing gates the diagram's COPY
+ *     of it — that divergence is what #601 closes.
  *   - **`node_type`.** An `input` retyped to `process` moves the node's shape
  *     and its `class` line; the id is unchanged, so nothing here fires.
  *   - **Edges.** `input:`/`output:` chains build the `-->` block. A rewired

--- a/scripts/test/viz-mode-label.test.js
+++ b/scripts/test/viz-mode-label.test.js
@@ -1,0 +1,85 @@
+/**
+ * The `bind_modes` annotation must name as many modes as `app.js` actually binds (#639).
+ *
+ * A PUT annotation is a comment, so nothing derives it and nothing regenerates it — putior
+ * reads the comment and copies its label verbatim into `viz/public/data/workflow.mmd`,
+ * which the published workflow page fetches at runtime. A stale label is therefore a wrong
+ * statement on a published page, produced faithfully by the pipeline.
+ *
+ * `npm run check:diagram-nodes` is green on exactly this defect **by construction**, and
+ * its own header says so with this example: it compares node IDS in both directions and
+ * nothing else. `bind_modes` exists on both sides; only its label was wrong. Labels,
+ * `node_type`, edges and source-side staleness are all outside what it can see. So the
+ * gate that catches this has to be a different gate, and this is it.
+ *
+ * ## What it asserts, and the limit
+ *
+ * The COUNT of modes named in the label against the count of bound modes. That is the
+ * defect class: a mode is added to `modes` and the label is not extended — which is how
+ * Campfire went missing from the moment it was added. It deliberately does NOT check the
+ * names: the label renders `workflow` as "Flow" and `2d` as "2D", so a name-level check
+ * would need a second mapping to drift out of step with. A rename with no count change
+ * still slips through; that is a smaller and quieter defect than an omission, and pinning
+ * it would cost a mapping table nobody maintains.
+ *
+ * `ci-scripts.yml` carries no `paths:` filter (#641), so this test runs on a `viz/`-only
+ * PR — which is the whole reason it can live in `scripts/test/` at all.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const APP_JS = resolve(REPO_ROOT, 'viz', 'js', 'app.js');
+
+/** Modes bound at runtime, from the `modes` map `setActiveMode` switches over. */
+export function boundModes(source) {
+  const match = source.match(/^const modes = \{(.*?)\};$/m);
+  if (!match) return null;
+  return match[1]
+    .split(',')
+    .map((pair) => pair.split(':')[0].trim().replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean);
+}
+
+/** Modes named in the `bind_modes` PUT label, from its parenthesised slash-list. */
+export function labelledModes(source) {
+  const annotation = source.match(/put id:"bind_modes",\s*label:"([^"]*)"/);
+  if (!annotation) return null;
+  const list = annotation[1].match(/\(([^)]*)\)/);
+  if (!list) return null;
+  return list[1].split('/').map((name) => name.trim()).filter(Boolean);
+}
+
+test('the bind_modes label names as many modes as app.js binds', () => {
+  const source = readFileSync(APP_JS, 'utf8');
+
+  const bound = boundModes(source);
+  const labelled = labelledModes(source);
+
+  assert.ok(bound, 'the `const modes = { … }` map must be findable — this test is its only reader');
+  assert.ok(labelled, 'the bind_modes annotation must carry a parenthesised mode list');
+  assert.equal(
+    labelled.length,
+    bound.length,
+    `the label names ${labelled.length} modes (${labelled.join('/')}) but ${bound.length} are `
+    + `bound (${bound.join(', ')}). The label is copied verbatim into workflow.mmd and served `
+    + `to readers, so this is a wrong statement on a published page — and check:diagram-nodes `
+    + `cannot see it, because the node IDs agree and only the label differs (#639).`,
+  );
+});
+
+test('the parsers fail loudly rather than returning a passing shape', () => {
+  // Both helpers return null when they cannot find their subject, so a refactor that moves
+  // the modes map or the annotation makes the test go RED rather than silently comparing
+  // two empty lists — the vacuous green this repo keeps paying for elsewhere (#486).
+  assert.equal(boundModes('nothing here'), null);
+  assert.equal(labelledModes('nothing here'), null);
+  assert.equal(labelledModes('// put id:"bind_modes", label:"No list here"'), null,
+    'a label with no parenthesised list is unparseable, not empty');
+  assert.deepEqual(boundModes("const modes = { '2d': a, hive: null };"), ['2d', 'hive']);
+  assert.deepEqual(labelledModes('// put id:"bind_modes", label:"Bind mode switching (A/B/C)"'),
+    ['A', 'B', 'C']);
+});

--- a/scripts/test/viz-mode-label.test.js
+++ b/scripts/test/viz-mode-label.test.js
@@ -14,13 +14,23 @@
  *
  * ## What it asserts, and the limit
  *
- * The COUNT of modes named in the label against the count of bound modes. That is the
- * defect class: a mode is added to `modes` and the label is not extended — which is how
- * Campfire went missing from the moment it was added. It deliberately does NOT check the
- * names: the label renders `workflow` as "Flow" and `2d` as "2D", so a name-level check
- * would need a second mapping to drift out of step with. A rename with no count change
- * still slips through; that is a smaller and quieter defect than an omission, and pinning
- * it would cost a mapping table nobody maintains.
+ * Two things. The COUNT of modes named in the label against the count bound — that is the
+ * defect class that occurred, a mode added to `modes` without extending the label, which
+ * is how Campfire went missing from the moment it was added.
+ *
+ * And CONTAINMENT: every label entry, lowercased, must be a substring of some bound key.
+ * The first version asserted only the count, on the argument that a name check needs a
+ * mapping table nobody maintains. That argument was wrong for this corpus and a reviewer
+ * showed it: `2d`, `3d`, `hive`, `chord` match exactly, and `flow` is a substring of
+ * `workflow`. No table required. What the count alone missed is a mode REPLACEMENT —
+ * rename `hive` to `sunburst` in both maps and leave the label, and 6 = 6 stays green
+ * while the published page names a mode that no longer exists AND omits one that does.
+ * That is the full defect class, not the "smaller and quieter" drift the first version
+ * claimed it was.
+ *
+ * Containment is a heuristic, not a proof: "Flow" would also match a hypothetical
+ * `flowchart`. Its failure direction on a divergently-named future mode is loud red,
+ * which is the recoverable one.
  *
  * `ci-scripts.yml` carries no `paths:` filter (#641), so this test runs on a `viz/`-only
  * PR — which is the whole reason it can live in `scripts/test/` at all.
@@ -34,7 +44,7 @@ import { fileURLToPath } from 'node:url';
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const APP_JS = resolve(REPO_ROOT, 'viz', 'js', 'app.js');
 
-/** Modes bound at runtime, from the `modes` map `setActiveMode` switches over. */
+/** Modes bound at runtime, from the `modes` map `switchMode`/`loadMode` consult. */
 export function boundModes(source) {
   const match = source.match(/^const modes = \{(.*?)\};$/m);
   if (!match) return null;
@@ -61,6 +71,14 @@ test('the bind_modes label names as many modes as app.js binds', () => {
 
   assert.ok(bound, 'the `const modes = { … }` map must be findable — this test is its only reader');
   assert.ok(labelled, 'the bind_modes annotation must carry a parenthesised mode list');
+  for (const name of labelled) {
+    assert.ok(
+      bound.some((key) => key.toLowerCase().includes(name.toLowerCase())),
+      `the label names "${name}", which is not a substring of any bound mode key `
+      + `(${bound.join(', ')}). A mode replacement keeps the COUNT equal while the published `
+      + `page names a mode that no longer exists (#639).`,
+    );
+  }
   assert.equal(
     labelled.length,
     bound.length,
@@ -68,6 +86,22 @@ test('the bind_modes label names as many modes as app.js binds', () => {
     + `bound (${bound.join(', ')}). The label is copied verbatim into workflow.mmd and served `
     + `to readers, so this is a wrong statement on a published page — and check:diagram-nodes `
     + `cannot see it, because the node IDs agree and only the label differs (#639).`,
+  );
+});
+
+test('a mode REPLACEMENT is caught, though the counts still agree', () => {
+  // The case count-alone misses, and the reason containment was added. Six for six, and
+  // the label names a mode that does not exist while omitting one that does.
+  const swapped = readFileSync(APP_JS, 'utf8')
+    .replace('hive: null', 'sunburst: null');
+
+  const bound = boundModes(swapped);
+  const labelled = labelledModes(swapped);
+
+  assert.equal(labelled.length, bound.length, 'precondition: the counts still agree');
+  assert.ok(
+    !labelled.every((name) => bound.some((key) => key.toLowerCase().includes(name.toLowerCase()))),
+    'containment must reject a label entry naming a mode that is no longer bound',
   );
 });
 

--- a/scripts/test/viz-mode-label.test.js
+++ b/scripts/test/viz-mode-label.test.js
@@ -28,8 +28,26 @@
  * That is the full defect class, not the "smaller and quieter" drift the first version
  * claimed it was.
  *
- * Containment is a heuristic, not a proof: "Flow" would also match a hypothetical
- * `flowchart`. Its failure direction on a divergently-named future mode is loud red,
+ * Containment runs BOTH ways, and the second direction closes two residuals a forward
+ * check alone leaves — both raised in review, both typo-shaped rather than
+ * refactor-shaped, and both green under count-plus-forward-containment:
+ *
+ *   (2D/3D/Hive/Chord/Flow/Flow)      a duplicated entry. Six entries, "flow" is a
+ *                                     substring of `workflow` twice, and Campfire is
+ *                                     omitted — the founding defect, re-entering as a
+ *                                     copy-paste artifact.
+ *   (2D/3D/Hive/Chord/Fire/Campfire)  "fire" and "campfire" both match `campfire`, and
+ *                                     Flow is omitted. Not fiction: the repo uses both
+ *                                     "Fire" and "Campfire" in sibling comments, for
+ *                                     different referents.
+ *
+ * Reverse containment kills both, and would independently have caught the original
+ * omission. The three assertions catch disjoint classes: the #639 defect (five entries,
+ * six keys) fails count alone; a swap fails forward containment alone; a padded label
+ * fails count alone; the two above fail reverse containment alone.
+ *
+ * Containment is still a heuristic, not a proof — "Flow" would also match a hypothetical
+ * `flowchart` key. Its failure direction on a divergently-named future mode is loud red,
  * which is the recoverable one.
  *
  * `ci-scripts.yml` carries no `paths:` filter (#641), so this test runs on a `viz/`-only
@@ -77,6 +95,12 @@ test('the bind_modes label names as many modes as app.js binds', () => {
       `the label names "${name}", which is not a substring of any bound mode key `
       + `(${bound.join(', ')}). A mode replacement keeps the COUNT equal while the published `
       + `page names a mode that no longer exists (#639).`,
+    );
+  }
+  for (const key of bound) {
+    assert.ok(
+      labelled.some((name) => key.toLowerCase().includes(name.toLowerCase())),
+      `mode "${key}" is bound but nothing in the label (${labelled.join('/')}) names it.`,
     );
   }
   assert.equal(

--- a/viz/js/app.js
+++ b/viz/js/app.js
@@ -1,7 +1,7 @@
 // app.js - Bootstrap: load data, init subsystems, bind controls
 // put id:"fetch_data", label:"Fetch skills.json data", node_type:"input", output:"skills_data"
 // put id:"init_ui", label:"Init filter panel, detail panel, graph", input:"skills_data", output:"ui_ready"
-// put id:"bind_modes", label:"Bind mode switching (2D/3D/Hive/Chord/Flow)", input:"ui_ready", output:"mode_bindings"
+// put id:"bind_modes", label:"Bind mode switching (2D/3D/Hive/Chord/Flow/Campfire)", input:"ui_ready", output:"mode_bindings"
 // put id:"lazy_load", label:"Lazy-load mode modules on demand", input:"mode_bindings", output:"active_module"
 // put id:"render_mode", label:"Render active mode with current filters", node_type:"output", input:"active_module"
 

--- a/viz/js/app.js
+++ b/viz/js/app.js
@@ -536,7 +536,7 @@ async function main() {
     logBtn.addEventListener('click', () => downloadLog());
   }
 
-  // ── Layout buttons (radio group: 2D / 3D / Hive / Chord / Flow) ──
+  // ── Layout buttons (radio group: 2D / 3D / Hive / Chord / Flow / Fire) ──
   for (const [modeName, btnId] of Object.entries(MODE_BUTTON_IDS)) {
     document.getElementById(btnId).addEventListener('click', async () => {
       if (switching || currentMode === modeName) return;


### PR DESCRIPTION
## Summary

`viz/js/app.js:4`'s `bind_modes` PUT label read `"Bind mode switching (2D/3D/Hive/Chord/Flow)"`. Six modes are bound at `:74`:

```js
const modes = { '2d': graph2dMode, '3d': null, hive: null, chord: null, workflow: null, campfire: null };
```

Campfire has been missing from that label since the moment it was added. putior copies the label **verbatim** into `viz/public/data/workflow.mmd`, which the published workflow page fetches at runtime — so this is a wrong statement served to readers, produced faithfully by the pipeline.

## The existing gate is green on this by construction

`npm run check:diagram-nodes` compares node **ids** in both directions and nothing else. `bind_modes` exists on both sides; only its label differed. Its own header names this exact case as its blind spot. Verified unmoved by this commit:

```console
$ npm run check:diagram-nodes
FAIL [missing-node] mode_campfire — annotated in viz/js/campfire.js, absent from viz/public/data/workflow.mmd
viz diagram node parity: 72 source file(s), 28 annotation(s), 27 diagram node(s)

$ npm run ratchet
  viz-diagram-node-parity      1 observed / 1 declared  [missing-node, orphan-node]  scanned 72
OK: every ratcheted finding is a known member, and every known member is still there.
```

Same one declared member before and after — a label edit that moved the node set would mean the annotation was rewritten rather than corrected.

## So the gate that catches it is a different gate

`scripts/test/viz-mode-label.test.js` asserts the **count** of modes named in the label against the count in the `modes` map. That is the defect class: a mode added without extending the label.

It deliberately does **not** check names. The label renders `workflow` as "Flow" and `2d` as "2D", so a name-level check needs a second mapping — one more thing to drift out of step with. A rename with no count change still slips through; that is a smaller and quieter defect than an omission, and the limit is stated in the file rather than left to be discovered.

Both parsers return `null` when they cannot find their subject, so moving the modes map or the annotation makes the test go **red** rather than silently comparing two empty lists — the vacuous green this repo keeps paying for (#486).

It lives in `scripts/test/` because `ci-scripts.yml` carries no `paths:` filter (#641), so it runs on a `viz/`-only PR.

```console
$ npm run mutation-check -- --file viz/js/app.js \
    --replace 'Chord/Flow/Campfire)'::'Chord/Flow)' \
    --test 'npm run test:scripts' --expect-killed-by 2
MUTANT KILLED by 2 failing test(s) — the check can fail.
```

*(An earlier version of this description quoted `killed by 1`. That was measured on the first commit's tree; a later commit added a test whose precondition reads the same mutated file, so the same mutation now kills two. The gate got stronger and the record did not move with it — quote the count from the gate, never from the record.)*

## `workflow.mmd` still carries the old label — deliberately

The diagram's header says do not edit manually, and regenerating it needs a working putior, which the lockfile cannot currently produce (**#601**).

*Correction to an earlier version of this description*, which argued that hand-editing would make the regeneration's diff unreadable. For a label-only edit that is backwards — it would *shrink* the eventual diff by one line, since regeneration copies the now-correct annotation. The sufficient argument is the bright line on generated files plus this repo's staleness-signal discipline: a hand-edited generated file that "looks right" defeats the stale-generated-file signal that caught the #493 stray commit. Right call, wrong reason. (Hand-adding the `mode_campfire` node is separately excluded by #639's own AC.)

**So the published page still says five modes until #601 lands.** This PR fixes the source of truth, not the artifact.

## Acceptance criteria

- [x] `viz/js/app.js:4`'s label names all six modes
- [x] This description states that `workflow.mmd` still carries the old label until #601
- [x] `npm run check:diagram-nodes` is unmoved — still exactly its one declared ratchet member
- [x] The `mode_campfire` node is **not** hand-added to the diagram

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmu8MKEFniwX7WrjV1iXr


---

## Review round two: the stale fact lived at four sites, two of which inverted on merge

This repo's own named class — *a fact in several docs must be changed by grep, not by memory* — in a PR whose thesis is that a stale label is a wrong statement on a page.

| site | |
|---|---|
| `viz/js/app.js:539` | the sibling comment, same five-of-six |
| `scripts/check-workflow-diagram-nodes.js:22` | the checker's own blind-spot example |
| `.github/workflows/validate-skills.yml:199` | the gate's rationale in CI |

The last two didn't merely go stale — they became **false at merge**. Both said the annotation *"reads (2D/3D/Hive/Chord/Flow)"* and that a faithful regeneration *"reproduces"* the wrong label. After this PR the annotation lists six and a faithful regeneration **repairs** the diagram, so a maintainer reading the gate's own rationale would be told the source is still wrong. Rewritten in past tense, which keeps the pedagogical value and adds a pointer to what covers labels now.

**One trap in the sweep, recorded because it nearly reproduced the miss it was correcting:** the literal `2D/3D/Hive/Chord/Flow` **wraps across lines** in the checker's header, so grepping the full string returns three sites and not that one. Swept on `Hive/Chord` *and* `bind_modes` separately.

## The count alone was the wrong instrument, and my excuse for it was falsifiable

The first version asserted only arity, arguing a name check needs "a mapping table nobody maintains". Wrong for this corpus, and shown in one line: `2d`, `3d`, `hive`, `chord` match exactly, and `flow` is a substring of `workflow`. No table required.

What arity missed is a mode **replacement** — rename `hive` to `sunburst` in both maps, leave the label, and 6 = 6 stays green while the published page names a mode that no longer exists *and* omits one that does. That is the full #639 defect class, not the "smaller and quieter" drift I claimed.

```console
$ npm run mutation-check -- --file viz/js/app.js \
    --replace 'hive: null'::'sunburst: null' \
    --test 'npm run test:scripts' --expect-killed-by 1
MUTANT KILLED by 1 failing test(s) — the check can fail.
```

Containment is a heuristic, not a proof — "Flow" would also match a hypothetical `flowchart` — and its failure direction on a divergently-named future mode is loud red. Stated in the file.

Also fixed: the test's own doc comment said `setActiveMode` switches over `modes`. It iterates `MODE_BUTTON_IDS`; `switchMode`/`loadMode` consult `modes`.

## Convention note

`Campfire` rather than `Fire`. The five existing entries are the buttons' *text*, and the button reads "Fire" — but `title`, the i18n string, the URL param and the diagram node id all say `campfire`, and the label's audience is a diagram reader. The sibling comment at `app.js:539` lists button text, so it says `Fire`, matching its own convention.


---

## Round three: zero blocking, and the recorded number was stale

**Containment now runs both ways.** Two residuals a forward-only check leaves — both raised in review, both green under count-plus-forward-containment:

| label | count | forward | reverse |
|---|---|---|---|
| `(2D/3D/Hive/Chord/Flow/Flow)` | 6 = 6 | passes — `flow` is in `workflow`, twice | **rejects** |
| `(2D/3D/Hive/Chord/Fire/Campfire)` | 6 = 6 | passes — both are in `campfire` | **rejects** |

The first is the founding #639 defect re-entering as a copy-paste artifact (Campfire omitted). The second omits Flow, and is not fiction — this repo now uses both "Fire" and "Campfire" in sibling comments, for different referents.

Verified the three assertions catch **disjoint** classes: the #639 defect fails count alone, a swap fails forward containment alone, a padded label fails count alone, and these two fail reverse containment alone.

**"The label is covered" overclaimed** at both rewritten gate-doc sites. The test covers the *source* label against the code. Nothing gates the diagram's **copy** of it — that divergence is what #601 closes, and a reader would otherwise think it is already handled. Cross-referenced on #601 so the published-page defect is not tracked only transitively.

**On the extended fourth-site hunt:** none found — across slash-lists, comma/space lists, count phrases (`five is not six`, `sixth mode`), event phrases (`Campfire is bound`), and identifiers, over the whole tree including `guides/`, `dreams/`, `tests/` and `i18n/`. The survivors all describe the **node**, which a label edit cannot touch, and remain true.