### PR TITLE
docs: two pieces of written guidance contradicted what this repo actually does (#689, #643)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,17 +138,35 @@ of them recorded where a later session would find them.
 The rule, in the order it must be applied:
 
 1. **Is it one of the five required contexts** — `line-endings`, `integrity`, `skills`,
-   `scripts-test`, `cli-test`? Then it is not a judgement call: the merge is refused for everyone
-   except the `bypass_actors` maintainer, and bypassing a red required check is never covered by
-   the standing merge allowance.
+   `scripts-test`, `cli-test`? Then it is not a judgement call — **fix it or re-run it (step 3);
+   it is never a merge-anyway case.** All five are ordinary retriable workflows, so an
+   infrastructure red there clears with `gh run rerun --failed`; there is no situation in which
+   the right answer is to merge past one. The merge is refused for everyone except the
+   `bypass_actors` maintainer, and bypassing a red required check is outside the standing
+   allowance. (That allowance, stated here because it was previously only in an operator's
+   session memory and a rule may not cite an authority its reader cannot open: a PR whose
+   checks are green AND which has been reviewed may be merged without asking. Green but
+   unreviewed is not covered, and neither is anything in this section.)
 2. **Did the tool fail, or did it find something?** Read the log, not the conclusion. A
    dependency install that 503s, a runner that dies, an API that is down — that is the tool
    failing. Anything the check *reports about the diff* is a finding, and a finding is never
    merged past.
+
+   There is a third case the dichotomy hides: a failure that REPRODUCES on retry but is
+   environmental — a flake, or a live dependency of the *test* being down. The runner ran and
+   the install succeeded, so it is not the tool failing; it says nothing about the diff, so it
+   is not a finding. It is a defect in the CHECK. Fix the check; do not merge past it and do
+   not file it as a tool failure.
 3. **If the tool failed: can it be re-run?** Prefer re-running to reasoning. Every check in
-   `.github/workflows/` is retriable with `gh run rerun --failed`. **CodeQL default setup is
-   not** — its runs are `event: dynamic` and `gh run rerun` refuses them, bare or `--failed`, so
-   a transient red there can only be cleared by a new commit or a PR close/reopen.
+   `.github/workflows/` is retriable with `gh run rerun --failed` — for 30 days, after which a
+   stale PR's failed run needs a new commit like any other. **CodeQL default setup is not
+   retriable at all** — its runs are `event: dynamic` and `gh run rerun` refuses them, bare or
+   `--failed`. A transient red there clears only with a new commit, or *reportedly* a PR
+   close/reopen (asserted, never measured — try it, do not plan around it).
+
+   **Try the escape before reasoning about the exception.** Step 4 is for when the escape is
+   unavailable too, which is the case #640 actually was: the outage that reddened the check was
+   still running, so the paths that would have cleared it were failing in the same window.
 4. **If it cannot be re-run: record the four facts before merging**, on the PR, in these words —
    which log line shows the failure is the tool's; that the check is not required; that every
    repo-owned workflow is green on the same SHA; and how the check will be re-exercised

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,48 @@ The file also carries the **advisory-gate inventory**, checked rather than writt
 
 Negative evidence is `scripts/envelopes/debt-ratchet.mjs` (`npm run gate-envelope`), which mutates the real corpus against `npm run ratchet` — the command CI runs, not the inner script. Its `expect: null` case pins the scope boundary as a measurement: a new body divergence must **not** move the ratchet.
 
+## Merging With a Red Check
+
+A red check is not one situation. **The tool found something** and **the tool could not run** need
+opposite responses, and only the second is ever a merge-anyway case. Until #643 that distinction
+was unwritten, and PR #640 was merged at `UNSTABLE` on four judgements made in the moment, none
+of them recorded where a later session would find them.
+
+The rule, in the order it must be applied:
+
+1. **Is it one of the five required contexts** — `line-endings`, `integrity`, `skills`,
+   `scripts-test`, `cli-test`? Then it is not a judgement call: the merge is refused for everyone
+   except the `bypass_actors` maintainer, and bypassing a red required check is never covered by
+   the standing merge allowance.
+2. **Did the tool fail, or did it find something?** Read the log, not the conclusion. A
+   dependency install that 503s, a runner that dies, an API that is down — that is the tool
+   failing. Anything the check *reports about the diff* is a finding, and a finding is never
+   merged past.
+3. **If the tool failed: can it be re-run?** Prefer re-running to reasoning. Every check in
+   `.github/workflows/` is retriable with `gh run rerun --failed`. **CodeQL default setup is
+   not** — its runs are `event: dynamic` and `gh run rerun` refuses them, bare or `--failed`, so
+   a transient red there can only be cleared by a new commit or a PR close/reopen.
+4. **If it cannot be re-run: record the four facts before merging**, on the PR, in these words —
+   which log line shows the failure is the tool's; that the check is not required; that every
+   repo-owned workflow is green on the same SHA; and how the check will be re-exercised
+   afterwards (for CodeQL, it re-runs on `main`, and the merge commit's own result is the
+   confirmation).
+
+**`CodeQL: neutral` is not evidence that code scanning passed.** The aggregate check by that name
+comes from the `github-advanced-security` app and reports `neutral` while the per-language
+`Analyze (…)` runs — a different app, `github-actions` — report `failure`. A reader checking "is
+CodeQL green" sees the wrong one. Read the `Analyze (…)` runs:
+
+```bash
+gh api repos/pjt222/agent-almanac/commits/SHA/check-runs \
+  --jq '.check_runs[] | select(.name|test("Analyze")) | "\(.name)\t\(.conclusion)"'
+```
+
+Deliberately still open on #643: whether default setup stays at all. A committed `codeql.yml`
+produces retriable runs and removes step 3's exception; default setup is lower maintenance and
+commits no workflow YAML into a repo that auto-commits. That is a maintainer trade, not a
+technical one, and the rule above holds under either answer — only step 3's exception changes.
+
 ## Guarding a Multi-Agent Run
 
 `git status` cannot see a subagent that **committed**. Bracket any fan-out with Bash access in this repo:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ comes from the `github-advanced-security` app and reports `neutral` while the pe
 CodeQL green" sees the wrong one. Read the `Analyze (…)` runs:
 
 ```bash
-gh api repos/pjt222/agent-almanac/commits/SHA/check-runs \
+gh api --paginate repos/pjt222/agent-almanac/commits/SHA/check-runs \
   --jq '.check_runs[] | select(.name|test("Analyze")) | "\(.name)\t\(.conclusion)"'
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,10 +24,18 @@ If you find a security issue, open a [GitHub issue](https://github.com/pjt222/ag
 - CodeQL uses GitHub's **server-managed default setup**, which commits no workflow YAML — so
   grepping `.github/workflows/` for it finds nothing. It runs on a **weekly** schedule and on
   pushes and pull requests against the default branch.
-- **It does not run on pull requests from forks.** Measured, not assumed: our first external
-  contribution (PR #589) reports *no checks at all*, while a same-day pull request from a local
-  branch reports ten. If you are contributing from a fork, expect our automation to have told us
-  nothing about your change — tracked as issue #689.
+- **Fork pull requests reported nothing, and the setting that caused it has since changed.**
+  Measured on 2026-08-19: our first external contribution (PR #589) reported *no checks at all* —
+  0 workflow runs, 0 check-runs, 0 check-suites — while a same-day pull request from a local
+  branch reported ten. The cause was the fork-PR approval policy, not CodeQL specifically:
+  nothing ran until a maintainer approved it, and nobody did.
+  On 2026-08-20 that policy was changed to its loosest value,
+  `first_time_contributors_new_to_github` (#689), so a returning contributor's PR should now
+  report checks without waiting for approval. **That has not yet been measured** — #589 is
+  closed and remains the only fork PR in this repository's history, so the next external
+  contribution is the measurement. Until then, treat "will my PR report checks?" as *unknown*
+  rather than as either yes or no, and read the live setting rather than this paragraph:
+  `gh api repos/pjt222/agent-almanac/actions/permissions/fork-pr-contributor-approval`
 - The exact event coverage is GitHub's to define and ours only to read. Prefer the live
   configuration over this file: `gh api repos/pjt222/agent-almanac/code-scanning/default-setup`
   (needs `security-events` access, so an external reader will likely get a 403 — the schedule and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,9 +42,12 @@ If you find a security issue, open a [GitHub issue](https://github.com/pjt222/ag
   `gh api repos/pjt222/agent-almanac/actions/permissions/fork-pr-contributor-approval`, though
   that endpoint needs admin rights — an external reader gets `401`/`403`, so ask us rather than
   assuming this paragraph has gone stale.
-- **CodeQL separately does not run on fork pull requests**, independently of the approval policy
-  above. So even once validators report on your PR, expect no code-scanning result from it; ours
-  runs on the weekly schedule and on the merge commit.
+- **CodeQL default setup separately does not run on fork pull requests**, independently of the
+  approval policy above — its PR scanning covers pull requests against the default or protected
+  branches, [excluding those from forks](https://docs.github.com/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning).
+  So even once validators report on your PR, expect no code-scanning result from it; ours runs
+  on the weekly schedule and on the merge commit. (Scoped to *default setup* deliberately: a
+  committed `codeql.yml` would be a different mechanism with different event coverage.)
 - The exact event coverage is GitHub's to define and ours only to read. Prefer the live
   configuration over this file: `gh api repos/pjt222/agent-almanac/code-scanning/default-setup`
   (needs `security-events` access, so an external reader will likely get a 403 — the schedule and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,17 +27,26 @@ If you find a security issue, open a [GitHub issue](https://github.com/pjt222/ag
 - **Fork pull requests reported nothing, and the setting that caused it has since changed.**
   Measured on 2026-08-19: our first external contribution (PR #589) reported *no checks at all* —
   0 workflow runs, 0 check-runs, 0 check-suites — while a same-day pull request from a local
-  branch reported ten. The cause was the fork-PR approval policy, not CodeQL specifically:
-  nothing ran until a maintainer approved it, and nobody did.
+  branch reported ten. The LIKELY cause is the fork-PR approval policy rather than CodeQL
+  specifically — but that is a mechanism we inferred, not one we measured: the setting was not
+  API-readable at the time, and the approval queue showed zero `action_required` runs, meaning
+  GitHub never engaged Actions on that commit at all. If the attribution is wrong, loosening the
+  policy will not have fixed the silence, which is the other reason the measurement below
+  matters.
   On 2026-08-20 that policy was changed to its loosest value,
   `first_time_contributors_new_to_github` (#689), so a returning contributor's PR should now
   report checks without waiting for approval. **That has not yet been measured** — #589 is
   closed and remains the only fork PR in this repository's history, so the next external
   contribution is the measurement. Until then, treat "will my PR report checks?" as *unknown*
-  rather than as either yes or no, and read the live setting rather than this paragraph:
-  `gh api repos/pjt222/agent-almanac/actions/permissions/fork-pr-contributor-approval`
+  rather than as either yes or no. The live setting is at
+  `gh api repos/pjt222/agent-almanac/actions/permissions/fork-pr-contributor-approval`, though
+  that endpoint needs admin rights — an external reader gets `401`/`403`, so ask us rather than
+  assuming this paragraph has gone stale.
+- **CodeQL separately does not run on fork pull requests**, independently of the approval policy
+  above. So even once validators report on your PR, expect no code-scanning result from it; ours
+  runs on the weekly schedule and on the merge commit.
 - The exact event coverage is GitHub's to define and ours only to read. Prefer the live
   configuration over this file: `gh api repos/pjt222/agent-almanac/code-scanning/default-setup`
   (needs `security-events` access, so an external reader will likely get a 403 — the schedule and
-  the fork exclusion above are the parts that affect you)
+  the two fork exclusions above are the parts that affect you)
 - Dependabot is configured to monitor GitHub Actions and npm dependencies for known vulnerabilities

--- a/guides/protecting-github-repositories.md
+++ b/guides/protecting-github-repositories.md
@@ -137,11 +137,15 @@ Apply top to bottom. The **essential** tier is zero-downside and does not break 
 
   ```bash
   # 1. workflows a fork PR can trigger. ANCHORED, and both extensions — see the trap below
-  rg -l '^\s*pull_request:|^\s*on:.*\bpull_request\b' .github/workflows/*.yml .github/workflows/*.yaml
-  # 2. the two triggers that BREAK the predicate — any hit here and step 1 is not the answer
-  rg -n 'pull_request_target|workflow_run' .github/workflows/
+  rg -l '^\s*pull_request:|^\s*on:.*\bpull_request\b|^\s*-\s*pull_request\s*$' \
+     -g '*.yml' -g '*.yaml' .github/workflows/
+  # 2. triggers an OUTSIDER can fire that run base-context code WITH secrets.
+  #    Any hit and step 1 is not the answer for this repo.
+  rg -n 'pull_request_target|workflow_run|issue_comment' .github/workflows/
   # 3. workflows that carry secrets, including inherited ones
-  rg -l 'secrets\.|secrets:\s*inherit' .github/workflows/*.yml .github/workflows/*.yaml
+  rg -l 'secrets\.|secrets:\s*inherit' -g '*.yml' -g '*.yaml' .github/workflows/
+  # 4. the high-severity question, asked WITHOUT relying on the census above
+  rg -n 'self-hosted' .github/workflows/
   ```
 
   **Check the ruler before believing it.** The obvious first command, `rg '^\s*pull_request'`,
@@ -150,12 +154,33 @@ Apply top to bottom. The **essential** tier is zero-downside and does not break 
   this guide names two sections up as the documented privilege-escalation pattern — so an
   unanchored scan files your most dangerous workflow among the read-only validators. And it
   misses `on: [push, pull_request]` and `on: pull_request` entirely, because neither puts the
-  word at the start of a line. Globbing `*.yml` alone misses `.yaml`, which Actions accepts.
+  word at the start of a line.
 
-  Command 2 is not optional. A `pull_request_target` workflow is privileged regardless of the
-  approval policy, and a `workflow_run` workflow chained off a PR-triggered one extends
-  reachability *with* secrets — the pwn-request escalation. Either one and the reachability
-  argument below does not apply to your repo.
+  Two more rulers to check, both learned by tripping them. Pass the directory with `-g`
+  filters rather than shell globs: under **zsh**, `.github/workflows/*.yaml` matching nothing
+  *skips the whole command* with `no matches found`, which reads at a glance like a clean scan.
+  And these greps are heuristics for the common YAML styles — a block sequence (`on:` then
+  `- pull_request` on its own line) is covered by the third alternation above, but a multi-line
+  flow sequence is not. **Parse rather than grep to settle it**: `yq '.on' <file>`, or
+  `actionlint`.
+
+  Which is why command 4 exists and does not depend on the census at all. Self-hosted runners
+  are the high-severity case, so ask that question directly on the whole directory instead of
+  inheriting whatever the trigger scan missed.
+
+  Command 2 is not optional, and the list in it is **not closed**. The principle it samples:
+  *any trigger an outsider can fire runs base-context code with secrets, and the question is
+  whether attacker-controlled payload reaches a shell or a checkout.* `pull_request_target` is
+  privileged regardless of the approval policy; `workflow_run` chained off a PR-triggered
+  workflow extends reachability *with* secrets (the pwn-request escalation); and
+  `issue_comment` fires on **any** user's comment on any issue or PR, which makes the
+  comment-body-into-`run:` and `ok-to-test`-checkout patterns the most-exploited of the class.
+  `issues`, `fork` and `watch` are the exotic tail. Any hit and the reachability argument below
+  does not apply to your repo.
+
+  Two that look like members and are not, stated so the list is not padded:
+  `repository_dispatch` needs a token with repo write, which an outsider does not have, and
+  `merge_group` fires from a maintainer-controlled queue.
 
   Here that returns twelve `pull_request`-triggered workflows, every one a read-only validator; **zero** `pull_request_target` or `workflow_run` workflows; and two secret-bearing ones (`release.yml`, `update-readmes.yml`) plus the Pages deploy — **none of which carries a `pull_request` trigger at all**. So this repo does touch secrets and does deploy; a fork PR simply cannot reach any of it.
 

--- a/guides/protecting-github-repositories.md
+++ b/guides/protecting-github-repositories.md
@@ -131,7 +131,20 @@ Apply top to bottom. The **essential** tier is zero-downside and does not break 
     -f approval_policy=first_time_contributors_new_to_github
   ```
 
-  Three values, loosest to strictest: `first_time_contributors_new_to_github`, `first_time_contributors`, `all_external_contributors`. **This repository runs the loosest**, chosen against a measured blast radius rather than by default (#689): the token is read-only, no secrets are exposed to fork runs, and every workflow here is a validator. A repo whose workflows touch secrets or deploy should not copy that choice.
+  Three values, loosest to strictest: `first_time_contributors_new_to_github`, `first_time_contributors`, `all_external_contributors`. **This repository runs the loosest**, chosen against a measured blast radius rather than by default (#689).
+
+  **The predicate is fork-REACHABILITY, not "does this repo have secrets".** Getting that wrong in either direction is the usual mistake, so measure it:
+
+  ```bash
+  # workflows a fork PR can trigger at all
+  for f in .github/workflows/*.yml; do rg -q '^\s*pull_request' "$f" && basename "$f"; done
+  # workflows that carry secrets, and what triggers them
+  rg -l 'secrets\.' .github/workflows/*.yml
+  ```
+
+  Here that returns twelve `pull_request`-triggered workflows, every one a read-only validator, and two secret-bearing ones (`release.yml`, `update-readmes.yml`) plus the Pages deploy — **none of which carries a `pull_request` trigger at all**. So this repo does touch secrets and does deploy; a fork PR simply cannot reach any of it.
+
+  Which is why "we have no secrets" is the wrong test, in both directions. A repo whose deploy runs only on push-to-main is not endangered by loosening this, because a fork PR cannot trigger it and the platform withholds secrets from fork runs regardless. A repo whose `pull_request` validators run on **self-hosted runners** should keep the gate strict even with no secret anywhere — arbitrary code execution on your own hardware, resource abuse and cache-poisoning are what the approval gate is actually for, and none of them is "touches secrets".
 - **Enable Dependabot alerts + security updates + a `.github/dependabot.yml`.** Alerts and fixes are *separate* toggles — enable both, or you detect vulnerabilities and fix nothing. Include a `github-actions` ecosystem block to keep action SHAs fresh.
   ```bash
   gh api -X PUT repos/OWNER/REPO/vulnerability-alerts      # alerts + dependency graph
@@ -151,7 +164,7 @@ Apply top to bottom. The **essential** tier is zero-downside and does not break 
 - **Provision a GitHub App bypass for the bot** (Contents: read/write) via `actions/create-github-app-token`, pass the token to checkout + `git-auto-commit-action`, and add the App as an `Integration` bypass actor with `bypass_mode: always`. This is the correct realization of "let the bot through" once required checks/PR are on.
 - **Enable CodeQL "default setup"** (server-managed) rather than advanced setup, so no extra workflow YAML is committed into a repo that auto-commits. Two consequences to accept with it, both learned the expensive way (#643):
 
-  - **Its runs cannot be retried.** Default setup produces `event: dynamic` runs, and `gh run rerun` refuses them — both bare and `--failed`. A transient GitHub-side failure (a 503 while determining feature enablement) therefore pins a red check that no re-run can clear. The only ways forward are a new commit or a PR close/reopen. A committed `codeql.yml` produces retriable runs and would remove this entirely; that is the trade.
+  - **Its runs cannot be retried.** Default setup produces `event: dynamic` runs, and `gh run rerun` refuses them — both bare and `--failed`. A transient GitHub-side failure (#640 recorded a 503) therefore pins a red check that no re-run can clear. The only ways forward are a new commit or, *reportedly*, a PR close/reopen — the new-commit path is measured (#640's merge commit healed on `main`); the close/reopen path is not, and whether a `reopened` event re-fires a dynamic analysis on an unchanged head SHA is unrecorded. Try it, but do not plan around it. A committed `codeql.yml` produces retriable runs and would remove this entirely; that is the trade.
   - **`CodeQL: neutral` is not evidence that code scanning passed.** The aggregate check named `CodeQL` comes from the `github-advanced-security` app and reports `neutral` even while the per-language `Analyze (…)` runs — from the `github-actions` app — report `failure`. Anything asserting code-scanning health, human or automated, must read the `Analyze (…)` runs:
 
     ```bash

--- a/guides/protecting-github-repositories.md
+++ b/guides/protecting-github-repositories.md
@@ -121,7 +121,17 @@ Apply top to bottom. The **essential** tier is zero-downside and does not break 
   ```yaml
   - uses: stefanzweifel/git-auto-commit-action@<40-char-sha>  # v6.x.x
   ```
-- **Leave fork-PR approval at the public-repo default** ("Require approval for first-time contributors"). Fork `pull_request` runs already get a read-only token and no secrets.
+- **Decide fork-PR approval deliberately; the default has a cost this guide used to omit.** The public-repo default is "Require approval for first-time contributors", and fork `pull_request` runs already get a read-only token and no secrets — so the default is safe. What it also does is run **nothing at all** on a first-time contributor's PR until a maintainer clicks approve, and if nobody notices, the contributor sees a PR with no checks and no signal. Measured on this repo's first external PR: 0 workflow runs, 0 check-runs, 0 check-suites.
+
+  The setting is readable *and writable* over the API — it is not web-UI-only, an error worth naming because it sends people designing around a constraint that does not exist:
+
+  ```bash
+  gh api repos/OWNER/REPO/actions/permissions/fork-pr-contributor-approval
+  gh api -X PUT repos/OWNER/REPO/actions/permissions/fork-pr-contributor-approval \
+    -f approval_policy=first_time_contributors_new_to_github
+  ```
+
+  Three values, loosest to strictest: `first_time_contributors_new_to_github`, `first_time_contributors`, `all_external_contributors`. **This repository runs the loosest**, chosen against a measured blast radius rather than by default (#689): the token is read-only, no secrets are exposed to fork runs, and every workflow here is a validator. A repo whose workflows touch secrets or deploy should not copy that choice.
 - **Enable Dependabot alerts + security updates + a `.github/dependabot.yml`.** Alerts and fixes are *separate* toggles — enable both, or you detect vulnerabilities and fix nothing. Include a `github-actions` ecosystem block to keep action SHAs fresh.
   ```bash
   gh api -X PUT repos/OWNER/REPO/vulnerability-alerts      # alerts + dependency graph
@@ -139,7 +149,17 @@ Apply top to bottom. The **essential** tier is zero-downside and does not break 
 - **Add `required_status_checks`** to the ruleset with `do_not_enforce_on_create=true` and `strict_required_status_checks_policy=true`. **Critical:** this blocks the bot's direct push unless you provision a bypass (next item), *and* the checks must run on `push`, not only `pull_request`, or they never report and the push is permanently blocked.
 - **Add a `pull_request` rule** if you want a review surface. On a solo repo keep `required_approving_review_count: 0` — you cannot approve your own PR, and `>= 1` is an unsatisfiable self-lockout.
 - **Provision a GitHub App bypass for the bot** (Contents: read/write) via `actions/create-github-app-token`, pass the token to checkout + `git-auto-commit-action`, and add the App as an `Integration` bypass actor with `bypass_mode: always`. This is the correct realization of "let the bot through" once required checks/PR are on.
-- **Enable CodeQL "default setup"** (server-managed) rather than advanced setup, so no extra workflow YAML is committed into a repo that auto-commits.
+- **Enable CodeQL "default setup"** (server-managed) rather than advanced setup, so no extra workflow YAML is committed into a repo that auto-commits. Two consequences to accept with it, both learned the expensive way (#643):
+
+  - **Its runs cannot be retried.** Default setup produces `event: dynamic` runs, and `gh run rerun` refuses them — both bare and `--failed`. A transient GitHub-side failure (a 503 while determining feature enablement) therefore pins a red check that no re-run can clear. The only ways forward are a new commit or a PR close/reopen. A committed `codeql.yml` produces retriable runs and would remove this entirely; that is the trade.
+  - **`CodeQL: neutral` is not evidence that code scanning passed.** The aggregate check named `CodeQL` comes from the `github-advanced-security` app and reports `neutral` even while the per-language `Analyze (…)` runs — from the `github-actions` app — report `failure`. Anything asserting code-scanning health, human or automated, must read the `Analyze (…)` runs:
+
+    ```bash
+    gh api repos/OWNER/REPO/commits/SHA/check-runs \
+      --jq '.check_runs[] | select(.name|test("Analyze")) | "\(.name)\t\(.conclusion)"'
+    ```
+
+  Neither is a reason against default setup. They are the reasons to know which one you chose.
 - **Set merge-method toggles to match policy** (e.g. merge-commits-only: `allow_squash_merge=false`, `allow_rebase_merge=false`) and auto-delete head branches on merge.
 - **Restrict the allowed-actions policy** to GitHub-owned + an explicit allow-list that *includes* `stefanzweifel/git-auto-commit-action` (it is not GitHub-owned; omitting it silently fails the workflow).
 
@@ -258,6 +278,7 @@ These are the beliefs that feel like security but are not.
 - **"Convert the bot from push to a PR to satisfy the rules."** A PR opened by the default `GITHUB_TOKEN` does **not** trigger `pull_request`/`push` workflows, so required checks never run and the PR sits on "expected/pending" forever. The PR must be created with an App token or PAT.
 - **"Required status checks mean nothing unreviewed lands."** Without a *required-PR* rule, anyone with write can still push directly if a check reports on push; and in classic BP admins bypass by default unless `enforce_admins=true`. Rulesets differ — they do not auto-exempt admins — so porting the classic mental model silently changes who is gated.
 - **"Branch protection protects the repo from a malicious collaborator."** It protects one ref. A write collaborator can push to unprotected branches, add a malicious workflow, or move tags. Scope, allowed-actions policy, and fork approval matter as much.
+- **"Fork-PR approval is a Settings-only toggle."** It is at `/repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval`, readable and writable, with three values. Designing a manual procedure around the belief that it is web-UI-only is wasted work — verify the premise before designing around it.
 - **"Public-repo secret scanning stops leaks."** Alerts fire *after* the commit; push protection blocks at push time but the auto-commit bot cannot click the interactive web bypass, so a CI-committed secret just fails the job — treat it as a real finding, not a flake. The free tier also covers provider patterns only, not every generic secret.
 - **"Require signed commits is free hardening."** It blocks the bot, which pushes unsigned via git CLI. Keeping both requires an API-based commit action.
 - **"Swap `GITHUB_TOKEN` for a broad PAT to get past protection."** A PAT is long-lived and account-wide — a strict privilege escalation over the ephemeral repo-scoped token. Prefer an App or deploy key.

--- a/guides/protecting-github-repositories.md
+++ b/guides/protecting-github-repositories.md
@@ -136,13 +136,30 @@ Apply top to bottom. The **essential** tier is zero-downside and does not break 
   **The predicate is fork-REACHABILITY, not "does this repo have secrets".** Getting that wrong in either direction is the usual mistake, so measure it:
 
   ```bash
-  # workflows a fork PR can trigger at all
-  for f in .github/workflows/*.yml; do rg -q '^\s*pull_request' "$f" && basename "$f"; done
-  # workflows that carry secrets, and what triggers them
-  rg -l 'secrets\.' .github/workflows/*.yml
+  # 1. workflows a fork PR can trigger. ANCHORED, and both extensions — see the trap below
+  rg -l '^\s*pull_request:|^\s*on:.*\bpull_request\b' .github/workflows/*.yml .github/workflows/*.yaml
+  # 2. the two triggers that BREAK the predicate — any hit here and step 1 is not the answer
+  rg -n 'pull_request_target|workflow_run' .github/workflows/
+  # 3. workflows that carry secrets, including inherited ones
+  rg -l 'secrets\.|secrets:\s*inherit' .github/workflows/*.yml .github/workflows/*.yaml
   ```
 
-  Here that returns twelve `pull_request`-triggered workflows, every one a read-only validator, and two secret-bearing ones (`release.yml`, `update-readmes.yml`) plus the Pages deploy — **none of which carries a `pull_request` trigger at all**. So this repo does touch secrets and does deploy; a fork PR simply cannot reach any of it.
+  **Check the ruler before believing it.** The obvious first command, `rg '^\s*pull_request'`,
+  is wrong in both directions and both are false-SAFE. It matches `pull_request_target:` —
+  the one trigger that runs in the **base-repo context with secrets and a write token**, which
+  this guide names two sections up as the documented privilege-escalation pattern — so an
+  unanchored scan files your most dangerous workflow among the read-only validators. And it
+  misses `on: [push, pull_request]` and `on: pull_request` entirely, because neither puts the
+  word at the start of a line. Globbing `*.yml` alone misses `.yaml`, which Actions accepts.
+
+  Command 2 is not optional. A `pull_request_target` workflow is privileged regardless of the
+  approval policy, and a `workflow_run` workflow chained off a PR-triggered one extends
+  reachability *with* secrets — the pwn-request escalation. Either one and the reachability
+  argument below does not apply to your repo.
+
+  Here that returns twelve `pull_request`-triggered workflows, every one a read-only validator; **zero** `pull_request_target` or `workflow_run` workflows; and two secret-bearing ones (`release.yml`, `update-readmes.yml`) plus the Pages deploy — **none of which carries a `pull_request` trigger at all**. So this repo does touch secrets and does deploy; a fork PR simply cannot reach any of it.
+
+  One caveat that only matters once command 2 is clean: a composite action or reusable workflow reaching for a secret is not a hole in a fork `pull_request` run, because on a public repo secrets are not provisioned to it at all — there is nothing to reach. Inside a `pull_request_target` workflow it is a hole, which is why that command comes first.
 
   Which is why "we have no secrets" is the wrong test, in both directions. A repo whose deploy runs only on push-to-main is not endangered by loosening this, because a fork PR cannot trigger it and the platform withholds secrets from fork runs regardless. A repo whose `pull_request` validators run on **self-hosted runners** should keep the gate strict even with no secret anywhere — arbitrary code execution on your own hardware, resource abuse and cache-poisoning are what the approval gate is actually for, and none of them is "touches secrets".
 - **Enable Dependabot alerts + security updates + a `.github/dependabot.yml`.** Alerts and fixes are *separate* toggles — enable both, or you detect vulnerabilities and fix nothing. Include a `github-actions` ecosystem block to keep action SHAs fresh.
@@ -168,7 +185,7 @@ Apply top to bottom. The **essential** tier is zero-downside and does not break 
   - **`CodeQL: neutral` is not evidence that code scanning passed.** The aggregate check named `CodeQL` comes from the `github-advanced-security` app and reports `neutral` even while the per-language `Analyze (…)` runs — from the `github-actions` app — report `failure`. Anything asserting code-scanning health, human or automated, must read the `Analyze (…)` runs:
 
     ```bash
-    gh api repos/OWNER/REPO/commits/SHA/check-runs \
+    gh api --paginate repos/OWNER/REPO/commits/SHA/check-runs \
       --jq '.check_runs[] | select(.name|test("Analyze")) | "\(.name)\t\(.conclusion)"'
     ```
 


### PR DESCRIPTION
## Summary

Two documentation defects of the same shape, neither findable by any gate, because no gate reads prose against reality. This repo calls that class a P1.

**Neither issue is closed by this PR** — see the bottom.

## The guide recommended the setting the operator deliberately rejected

`guides/protecting-github-repositories.md:124` said:

> **Leave fork-PR approval at the public-repo default** ("Require approval for first-time contributors").

#689 measured what that default costs on this repository's first external PR — **0 workflow runs, 0 check-runs, 0 check-suites**, because nothing runs at all until a maintainer clicks approve — and set the policy to the loosest value instead, against a measured blast radius:

```console
$ gh api repos/pjt222/agent-almanac/actions/permissions/fork-pr-contributor-approval
{"approval_policy":"first_time_contributors_new_to_github"}
```

That decision lived in an issue comment while the guide went on recommending its opposite. A reader following this repo's own guide would have undone it.

The guide now states the **trade** rather than a default, records which value this repo runs and why, and says plainly that a repo whose workflows touch secrets or deploy should not copy the choice.

It also carried the premise a prior session had to correct the expensive way — that the setting is Settings-only. It is readable *and writable* at `/repos/{owner}/{repo}/actions/permissions/fork-pr-contributor-approval`, with three values. Added to Misconceptions with the general lesson: verify a premise before designing a manual procedure around it.

## The CodeQL guidance omitted the two things that bite

`:142` recommended default setup for a good reason — no workflow YAML committed into a repo that auto-commits — and named neither consequence #643 paid for:

- **Its runs cannot be retried.** `event: dynamic`, and `gh run rerun` refuses them bare *and* `--failed`. A GitHub-side 503 pins a red check no re-run can clear; only a new commit or a PR close/reopen moves it.
- **`CodeQL: neutral` is not evidence that code scanning passed.** That aggregate comes from the `github-advanced-security` app and reads `neutral` while the per-language `Analyze (…)` runs — a *different app*, `github-actions` — read `failure`. A reader checking "is CodeQL green" sees the wrong one.

Both re-verified live rather than quoted from the issue:

```console
$ gh api repos/pjt222/agent-almanac/code-scanning/default-setup --jq '{state,languages,schedule}'
{"languages":["actions","javascript","javascript-typescript","python","typescript"],"schedule":"weekly","state":"configured"}

$ rg -l codeql .github/workflows/      # 15 files, no match
$ gh api .../check-runs --jq '... | "\(.name)\t\(.app.slug)"'
Analyze (actions)                github-actions
Analyze (javascript-typescript)  github-actions
```

## And the merge rule that was never written

#640 was merged at `UNSTABLE` on four judgements made in the moment, none recorded where a later session would find them. `CLAUDE.md` gains **§ Merging With a Red Check**, ordered so someone who was not there can apply it:

1. **Is it one of the five required contexts?** Then it is not a judgement call at all.
2. **Did the tool fail, or did it find something?** Read the log, not the conclusion — only the first is ever a merge-anyway case.
3. **If the tool failed: can it be re-run?** Prefer re-running to reasoning. Everything in `.github/workflows/` is retriable; CodeQL default setup is the named exception.
4. **If it cannot be re-run: record four facts on the PR before merging** — which log line shows the failure is the tool's, that the check is not required, that every repo-owned workflow is green on the same SHA, and how the check gets re-exercised afterwards.

## What this does NOT close

**#689** — its open AC asks for verification **by measurement** on the next external PR, that fork PRs now report contexts. #589 is closed and remains the only fork PR in this repository's history, so there is nothing to measure until one arrives. Reading the setting back is not that measurement, and the issue says so. This is the spin-off its triage flagged.

**#643** — its first AC asks whether CodeQL default setup stays at all. A committed `codeql.yml` produces retriable runs and removes step 3's exception; default setup is lower maintenance and commits no YAML into a repo that auto-commits. That is a maintainer trade, and the rule above holds under either answer — only the exception changes.

Refs #689, #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmu8MKEFniwX7WrjV1iXr