### PR TITLE
fix(ci): the skills registry was gated by a count, which a rename leaves untouched (#700)

### DIFF
--- a/scripts/envelopes/a15-skill-registry-entry-set.mjs
+++ b/scripts/envelopes/a15-skill-registry-entry-set.mjs
@@ -1,0 +1,99 @@
+/**
+ * Envelope for integrity check A15 — skill registry entry set vs disk (#700).
+ *
+ *   node scripts/gate-envelope.js --spec scripts/envelopes/a15-skill-registry-entry-set.mjs
+ *
+ * A15 is the skills-shaped sibling of A4/A5, and it exists because the only thing guarding
+ * `skills/_registry.yml` was a COUNT, in `validate-skills.yml`. A count cannot see a set
+ * difference, and the realistic path leaves it untouched: rename `skills/<old>/` to
+ * `skills/<new>/` without editing the registry and the number is identical while the registry
+ * names a directory that does not exist.
+ *
+ * ## Why the mutations are renames and an indent shift, never an added or deleted entry
+ *
+ * Same constraint as `a4-a5-registry-entry-sets.mjs`: the harness mutates file CONTENT, it
+ * cannot add or remove a file. That is not a limitation here, it is the right instrument —
+ * renaming one `- id:` leaves the entry COUNT untouched, so `total_skills` stays green and only
+ * the set logic can fire. A case that changed the count would be killed by the count check and
+ * prove nothing about A15.
+ *
+ * ## Case 5 is why this file exists at all
+ *
+ * Cases 1-4 mirror shapes already proven for A4/A5. Case 5 does not: it covers the
+ * `total_skills` cross-check, which was ADDED during #708 to close a hole found in review — a
+ * PARTIAL extraction slipping past a zero-guard that fires only on TOTAL failure, then
+ * reporting every unextracted skill as "only on disk". That fix is new load-bearing logic in a
+ * MERGE-BLOCKING context (`integrity` is a required status check), and the PR transcript does
+ * not record its branch ever having fired. A fix for a false-positive hole, itself uncovered,
+ * is exactly the shape this repo's envelopes exist to refuse.
+ *
+ * The mutation is a one-space indent shift rather than an edited count, for two reasons: it
+ * reproduces the real partial-extraction scenario instead of a stale number, and it does not
+ * hardcode `total_skills`, which changes every time a skill is added.
+ *
+ * ## Every `expect` must sit on a single FAIL line
+ *
+ * `gate-envelope.js` kills a case only when ONE line contains both `FAIL` and the expected
+ * substring. A4/A5 learned this the expensive way — a header FAIL plus indented per-id detail
+ * reported [WRONG-RED] against a check that was naming ids correctly. Case 5's substring is the
+ * two-cause clause, which is both on the FAIL line and independent of any count.
+ */
+
+export const gate = { command: ['bash', 'scripts/validate-integrity.sh'] };
+
+export const cases = [
+  {
+    // The #700 scenario proper: the directory still exists under its old name, the registry
+    // now names one that does not. `total_skills` is untouched, so nothing else can fire.
+    label: 'A15: a skill id is renamed — the orphaned ENTRY is named, with the SKILL.md path shape',
+    file: 'skills/_registry.yml',
+    find: '      - id: create-r-package\n',
+    replace: '      - id: create-r-package-typo\n',
+    // Also pins `${shape//<id>/$id}`: A15 must say `skills/<id>/SKILL.md`, not A4's `<tree>/<id>.md`.
+    expect: 'only in registry (no file): create-r-package-typo -- expected skills/create-r-package-typo/SKILL.md',
+  },
+  {
+    // Same mutation, other half. Two claims, not one: a check printing only `only in registry`
+    // would satisfy case 1 while leaving the now-unreferenced directory unnamed.
+    label: 'A15: a skill id is renamed — the unreferenced DIRECTORY is named',
+    file: 'skills/_registry.yml',
+    find: '      - id: create-r-package\n',
+    replace: '      - id: create-r-package-typo\n',
+    expect: 'skills: only on disk (no registry entry): create-r-package',
+  },
+  {
+    // A duplicate must be caught BEFORE `sort -u` collapses it, or two entries pointing at one
+    // directory are forgiven by the very check meant to pair them one-to-one.
+    label: 'A15: two entries sharing one id are caught before sort -u collapses them',
+    file: 'skills/_registry.yml',
+    find: '      - id: create-skill\n',
+    replace: '      - id: create-r-package\n',
+    expect: 'has two entries sharing one id: create-r-package',
+  },
+  {
+    // FAIL-CLOSED. Breaking the `domains:` anchor makes the sed range match nothing, so the
+    // extraction returns empty. Comparing an empty set against disk would report all 370
+    // directories as unregistered — loud, and the next reader "repairs" a clean registry.
+    label: 'A15: a drifted section key reports pattern drift, not 370 unregistered skills',
+    file: 'skills/_registry.yml',
+    find: '\ndomains:\n',
+    replace: '\ndomainz:\n',
+    expect: "extracted 0 '- id:' values from skills/_registry.yml under 'domains:' -- pattern drift",
+  },
+  {
+    // THE CASE WITH NO PRIOR EVIDENCE. One id shifted by a single space no longer matches the
+    // six-space `- id:` pattern, so the extraction silently SHRINKS. The zero-guard above does
+    // not fire — it only sees TOTAL failure — and without this cross-check the run would report
+    // the unextracted skill as "only on disk (no registry entry)": a false positive, in a
+    // required context, naming the wrong cause and sending the reader to edit a clean registry.
+    //
+    // Asserting the two-cause clause rather than the numbers: the message must NOT claim the
+    // extraction drifted, because a stale `total_skills` produces this same branch and is the
+    // likelier trigger in practice (it needs only a skipped step 3 of "Adding a New Skill").
+    label: 'A15: a PARTIAL extraction is caught by the total_skills cross-check, naming both causes',
+    file: 'skills/_registry.yml',
+    find: '      - id: create-skill\n',
+    replace: '       - id: create-skill\n',
+    expect: 'either the extraction pattern drifted or total_skills is stale',
+  },
+];

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -260,13 +260,24 @@ registry_entry_set() { # <tree> <registry> <section key>
   # substring. With the detail indented under a header, an envelope asserting "the orphaned
   # entry is named" reported [WRONG-RED] against a check that was naming it correctly -- the
   # harness could not see it, so the case proved nothing either way.
-  local only_reg only_disk
+  compare_id_sets "$registry" "$tree" "$reg_ids" "$disk_ids" "$tree/<id>.md" || rc=1
+  return "$rc"
+}
+
+# Both directions of a registry-vs-disk comparison, extracted so the SKILLS shape below can
+# reuse it (#700). It differs from A4/A5 only in how the two sets are gathered -- skills live
+# at `skills/<id>/SKILL.md` rather than `<tree>/<id>.md`, and their ids sit six spaces deep
+# under `domains.<domain>.skills` rather than two -- so duplicating the reporting half would
+# add a fifth hand-rolled comparison to the pile #672 is about.
+compare_id_sets() { # <registry> <tree> <reg ids> <disk ids> <expected path shape>
+  local registry="$1" tree="$2" reg_ids="$3" disk_ids="$4" shape="$5"
+  local only_reg only_disk id rc=0
   only_reg=$(comm -23 <(printf '%s\n' "$reg_ids") <(printf '%s\n' "$disk_ids") || true)
   only_disk=$(comm -13 <(printf '%s\n' "$reg_ids") <(printf '%s\n' "$disk_ids") || true)
   if [ -n "$only_reg" ]; then
     while IFS= read -r id; do
       [ -z "$id" ] && continue
-      echo "FAIL: $registry: only in registry (no file): $id -- expected $tree/$id.md"
+      echo "FAIL: $registry: only in registry (no file): $id -- expected ${shape//<id>/$id}"
       rc=1
     done <<< "$only_reg"
   fi
@@ -306,6 +317,50 @@ if [ "$disk_count" != "$reg_count" ]; then
 fi
 registry_entry_set teams teams/_registry.yml teams || { failed=1; a5_fail=1; }
 [ "$a5_fail" -eq 0 ] && echo "OK: $disk_count teams on disk match total_teams and the registry entry set"
+
+# A15: Skill registry entry set (#700)
+#
+# The count check lives in `validate-skills.yml` and compares `total_skills:` against a disk
+# count. A count cannot see a SET difference, and the realistic path leaves it untouched:
+# rename `skills/<old>/` to `skills/<new>/` without editing the registry and the number is
+# identical while the registry now names a directory that does not exist.
+#
+# Nothing else caught it. B1 walks `skills/*/` on disk to check symlinks -- the disk-to-symlink
+# direction, which never reads the registry. B8 compares registry ids against glyph keys and is
+# warn-only. B12 compares against `~/.claude/skills`, is warn-only, and prints SKIP in CI.
+#
+# The consequence is not tidiness: `skillsDeclaringBash` in the README generator enumerates the
+# registry and, until #701, counted a registry-listed-but-missing skill as NON-declaring --
+# quietly deflating a figure published in SECURITY.md, in the direction that UNDER-reports how
+# much of the corpus instructs an agent to run shell commands. That branch now throws; this is
+# the upstream repair, so the throw is unreachable on a green main rather than load-bearing.
+echo "--- A15: Skill registry entry set ---"
+a15_fail=0
+# Six spaces, not two: skills nest under `domains.<domain>.skills`. Scoped to `^domains:` for
+# the same reason A4/A5 scope to their section -- a future top-level key with its own `- id:`
+# list would silently widen the set.
+a15_reg_all=$(sed -n '/^domains:/,/^[a-z_][a-z_0-9]*:/ { /^      - id: /p }' skills/_registry.yml   | tr -d '\r' | sed -E 's/^      - id: *//' | sed -E 's/^"(.*)"$/\1/' | sort || true)
+a15_dupes=$(printf '%s\n' "$a15_reg_all" | uniq -d || true)
+if [ -n "$a15_dupes" ]; then
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    echo "FAIL: skills/_registry.yml has two entries sharing one id: $id"
+    failed=1; a15_fail=1
+  done <<< "$a15_dupes"
+fi
+a15_reg=$(printf '%s\n' "$a15_reg_all" | sed '/^$/d' | sort -u || true)
+# Directories carrying a SKILL.md, which is what the generator and the CLI both consume. A bare
+# directory with no SKILL.md is not a skill and must not count as one on either side.
+a15_disk=$(find skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' -not -path 'skills/_template/*'   -printf '%h\n' 2>/dev/null | sed 's|^skills/||' | sort || true) # abort-ok: see A4
+if [ -z "$a15_reg" ]; then
+  echo "FAIL: extracted 0 '- id:' values from skills/_registry.yml under 'domains:' -- pattern drift, not a clean tree"
+  failed=1; a15_fail=1
+else
+  compare_id_sets skills/_registry.yml skills "$a15_reg" "$a15_disk" "skills/<id>/SKILL.md" \
+    || { failed=1; a15_fail=1; }
+fi
+a15_count=$(printf '%s\n' "$a15_reg" | sed '/^$/d' | wc -l)
+[ "$a15_fail" -eq 0 ] && echo "OK: $a15_count skills in the registry match the directories on disk"
 
 # A6: Agent intent contract (#285)
 echo "--- A6: Agent intent contract ---"

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -359,7 +359,7 @@ else
   compare_id_sets skills/_registry.yml skills "$a15_reg" "$a15_disk" "skills/<id>/SKILL.md" \
     || { failed=1; a15_fail=1; }
 fi
-a15_count=$(printf '%s\n' "$a15_reg" | sed '/^$/d' | wc -l)
+a15_count=$(printf '%s\n' "$a15_reg" | sed '/^$/d' | wc -l || true)
 [ "$a15_fail" -eq 0 ] && echo "OK: $a15_count skills in the registry match the directories on disk"
 
 # A6: Agent intent contract (#285)

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -351,8 +351,8 @@ fi
 a15_reg=$(printf '%s\n' "$a15_reg_all" | sed '/^$/d' | sort -u || true)
 # Directories carrying a SKILL.md, which is what the generator and the CLI both consume. A bare
 # directory with no SKILL.md is not a skill and must not count as one on either side.
-a15_disk=$(find skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' -not -path 'skills/_template/*'   -printf '%h\n' 2>/dev/null | sed 's|^skills/||' | sort || true) # abort-ok: see A4
-a15_declared=$(grep 'total_skills:' skills/_registry.yml | tr -d '\r' | awk '{print $2}' || true)
+a15_disk=$(find skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' -not -path 'skills/_template/*' -printf '%h\n' | sed 's|^skills/||' | sort) # abort-ok: find over a directory whose absence is not drift but a broken checkout
+a15_declared=$(grep -m1 '^total_skills:' skills/_registry.yml | tr -d '\r' | awk '{print $2}' || true)
 a15_extracted=$(printf '%s\n' "$a15_reg" | sed '/^$/d' | wc -l || true)
 if [ -z "$a15_reg" ]; then
   echo "FAIL: extracted 0 '- id:' values from skills/_registry.yml under 'domains:' -- pattern drift, not a clean tree"
@@ -367,8 +367,7 @@ elif [ "$a15_extracted" != "$a15_declared" ]; then
   # turns that storm into one accurate line. It is not a substitute for the count check in
   # validate-skills.yml, which compares the declared number against DISK; this compares it
   # against what the EXTRACTION found, and the two catch different things.
-  echo "FAIL: extracted $a15_extracted '- id:' values from skills/_registry.yml but total_skills says $a15_declared"
-  echo "      -- pattern drift in the extraction, not a registry/disk mismatch. Check indentation."
+  echo "FAIL: skills/_registry.yml: extracted $a15_extracted '- id:' values but total_skills says $a15_declared -- either the extraction pattern drifted or total_skills is stale; the count-vs-disk check in validate-skills.yml discriminates"
   failed=1; a15_fail=1
 else
   compare_id_sets skills/_registry.yml skills "$a15_reg" "$a15_disk" "skills/<id>/SKILL.md" \

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -352,15 +352,29 @@ a15_reg=$(printf '%s\n' "$a15_reg_all" | sed '/^$/d' | sort -u || true)
 # Directories carrying a SKILL.md, which is what the generator and the CLI both consume. A bare
 # directory with no SKILL.md is not a skill and must not count as one on either side.
 a15_disk=$(find skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' -not -path 'skills/_template/*'   -printf '%h\n' 2>/dev/null | sed 's|^skills/||' | sort || true) # abort-ok: see A4
+a15_declared=$(grep 'total_skills:' skills/_registry.yml | tr -d '\r' | awk '{print $2}' || true)
+a15_extracted=$(printf '%s\n' "$a15_reg" | sed '/^$/d' | wc -l || true)
 if [ -z "$a15_reg" ]; then
   echo "FAIL: extracted 0 '- id:' values from skills/_registry.yml under 'domains:' -- pattern drift, not a clean tree"
+  failed=1; a15_fail=1
+elif [ "$a15_extracted" != "$a15_declared" ]; then
+  # The zero-guard only fires on a TOTAL extraction failure. A PARTIAL one -- one id at a
+  # different indent, say -- sails past it, shrinks the registry set, and then reports every
+  # unextracted skill as "only on disk (no registry entry)": loud, but a false positive, in a
+  # REQUIRED context, with a message pointing at the wrong cause.
+  #
+  # `total_skills:` is an independent statement of the same number, so comparing against it
+  # turns that storm into one accurate line. It is not a substitute for the count check in
+  # validate-skills.yml, which compares the declared number against DISK; this compares it
+  # against what the EXTRACTION found, and the two catch different things.
+  echo "FAIL: extracted $a15_extracted '- id:' values from skills/_registry.yml but total_skills says $a15_declared"
+  echo "      -- pattern drift in the extraction, not a registry/disk mismatch. Check indentation."
   failed=1; a15_fail=1
 else
   compare_id_sets skills/_registry.yml skills "$a15_reg" "$a15_disk" "skills/<id>/SKILL.md" \
     || { failed=1; a15_fail=1; }
 fi
-a15_count=$(printf '%s\n' "$a15_reg" | sed '/^$/d' | wc -l || true)
-[ "$a15_fail" -eq 0 ] && echo "OK: $a15_count skills in the registry match the directories on disk"
+[ "$a15_fail" -eq 0 ] && echo "OK: $a15_extracted skills in the registry match the directories on disk"
 
 # A6: Agent intent contract (#285)
 echo "--- A6: Agent intent contract ---"


### PR DESCRIPTION
## Summary

Three of the four content registries have a set-level integrity check. Skills had a **number**.

| registry | check | kind |
|---|---|---|
| `agents/_registry.yml` | A4 — `registry_entry_set` | set, blocking |
| `teams/_registry.yml` | A5 — `registry_entry_set` | set, blocking |
| `guides/_registry.yml` | A12 (#626) | set |
| `skills/_registry.yml` | `validate-skills.yml` | **count** |

A count cannot see a *set* difference, and the realistic path leaves it untouched: rename `skills/<old>/` to `skills/<new>/` without editing the registry and the number is identical while the registry names a directory that does not exist.

## Measured, both halves on the same tree state

```console
$ mv skills/gold-washing skills/gold-panning
$ bash scripts/validate-integrity.sh
--- A15: Skill registry entry set ---
FAIL: skills/_registry.yml: only in registry (no file): gold-washing -- expected skills/gold-washing/SKILL.md
FAIL: skills: only on disk (no registry entry): gold-panning -- it renders in no generated index

$ disk=370  registry_total=370   →  the count check PASSES on that same state
```

Nothing else caught it either. **B1** walks `skills/*/` on disk to check symlinks — the disk→symlink direction, which never reads the registry. **B8** compares registry ids against glyph keys and is warn-only. **B12** compares against `~/.claude/skills`, is warn-only, and prints `SKIP` in CI. So no check that reads registry ids could fail a build.

## Why it is not tidiness

`skillsDeclaringBash` enumerates the registry and — until #701 — counted a registry-listed-but-missing skill as **non-declaring**, quietly deflating a figure published in `SECURITY.md`. The direction matters: it *under*-reports how much of the corpus instructs an agent to run shell commands, which is the dangerous way for a security document to be wrong.

That branch now throws. This is the **upstream** repair, so the throw becomes unreachable on a green main rather than load-bearing.

## Shape, and why it is not a fifth hand-rolled comparison

`registry_entry_set` assumes `<tree>/<id>.md` and two-space indentation. Skills are `skills/<id>/SKILL.md` and sit six spaces deep under `domains.<domain>.skills`, so the *gathering* genuinely differs. The **reporting** does not, and duplicating it would add another member to the pile #672 is about — so the comparison half is extracted as `compare_id_sets` and both callers use it. A4 and A5 are unchanged in behaviour, verified by running them (`OK: 75 agents…`, `OK: 22 teams…`).

Disk enumeration is directories carrying a `SKILL.md`, which is what the generator and the CLI both consume. A bare directory without one is not a skill and must not count as one on either side.

**The count check stays.** A count and a set catch different mistakes, and #680 is this repo's lesson about removing a redundant gate because a better one exists.

## Acceptance criteria

- [x] `skills/_registry.yml` gets a blocking entry-set check, in the same shape as A4/A5
- [x] Both directions reported, `_template` excluded through the same rule the disk walk uses
- [x] Verified by breaking it, not by reading: the rename above goes red, and the count check demonstrably does not
- [x] The `total_skills` count check stays
- [x] All changes pass existing tests (`validate-integrity.sh`: 0 FAIL; `test:scripts`: 633 passing)

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmu8MKEFniwX7WrjV1iXr