### PR TITLE
fix(guard): a dropped word left the rebaseline message ungrammatical (#688)

### DIFF
--- a/scripts/repo-guard.js
+++ b/scripts/repo-guard.js
@@ -550,8 +550,9 @@ if (command === 'rebaseline') {
     console.error('control against ACCIDENT, not against intent: anyone who wants to can substitute');
     console.error('`$(git rev-parse HEAD)`. What it buys is that no red `guard:verify` ever prints a');
     console.error('paste-ready override in its own output. Read the authors above — they may be');
-    console.error('to yours, because a subagent commits through this repository\'s own git config.');
-    console.error('That is what happened in #493. The content is the test; the author is a hint.');
+    console.error('IDENTICAL to yours, because a subagent commits through this repository\'s own');
+    console.error('git config. That is what happened in #493. The content is the test; the author');
+    console.error('is a hint.');
     process.exit(2);
   }
 

--- a/scripts/test/repo-guard.test.js
+++ b/scripts/test/repo-guard.test.js
@@ -667,6 +667,27 @@ test('REFUSES without --accept: the delta must be read before it is accepted', a
   assert.match(r.stderr, /commits added:/, 'it must print what it is asking about');
   assert.ok(r.stderr.includes(head), 'and the exact sha to paste back');
   assert.ok(existsSync(snapshotPath(dir)), 'the original baseline survives a refusal');
+
+  // The rationale, asserted across the line wrap. #699 rewrote this paragraph and dropped the
+  // word "IDENTICAL", leaving `...they may be / to yours, because...` -- and all 51 tests
+  // stayed green, because every assertion here is a substring and none of them spanned the
+  // break. Collapsing whitespace first is what makes the sentence visible: it is invariant
+  // under REFLOW (re-wrap the same words at any width and this still passes) while a dropped,
+  // duplicated or reordered word fails. That is the property the PR body claimed was
+  // unavailable -- it argued the choice was between break-blind substrings and pinning whole
+  // rendered messages, and this is neither.
+  //
+  // Pinning it deliberately: this sentence IS the correction #699 existed to install. The
+  // author line is only a HINT because a subagent commits through this repository's own git
+  // config, which is what happened in #493. A silent change to that reasoning should fail a
+  // test, and the five other lines of the paragraph remain free to reword.
+  const flat = r.stderr.replace(/\s+/g, ' ');
+  assert.match(
+    flat,
+    /they may be IDENTICAL to yours, because a subagent commits through this repository's own git config\./,
+    'the acknowledgement rationale must survive a reflow intact',
+  );
+  assert.match(flat, /The content is the test; the author is a hint\./);
 });
 
 test('REFUSES a sha that is not the current HEAD', async (t) => {


### PR DESCRIPTION
## Summary

`npm run guard:rebaseline` printed:

```
Read the authors above — they may be
to yours, because a subagent commits through this repository's own git config.
```

"identical" went missing when that message was rewritten in #699 to correct the author-as-discriminator overclaim. **Every test passed** — the suite asserts on substrings, and none of them spans the break.

## How it was found

By *running* the command on this session's own moved HEAD, which is exactly the case #699 built it for. That is the note worth keeping: use a tool you shipped on the first occasion that calls for it. The sentence is load-bearing — it is the one explaining why the author line is only a hint, and the reason (`#493`'s subagent committed through this repo's own git config) is the whole correction #699 made.

Reflowed rather than patched in place, so clause boundaries fall where sentences do and the next edit has less chance of splitting one.

`node --test scripts/test/repo-guard.test.js`: 51 passing.

## Coverage — corrected, and now added

**The paragraph that stood here was wrong and is retracted.** It read:

> The suite cannot catch this class — a substring assertion cannot see a sentence broken across two `console.error` calls. Pinning full rendered messages would be brittle in the other direction. Left as-is deliberately; noted rather than papered over.

That is a false dichotomy, found in adversarial review. There is a third formulation: **collapse whitespace, then substring-assert the sentence.**

```js
const flat = r.stderr.replace(/\s+/g, ' ');
assert.match(flat, /they may be IDENTICAL to yours, because a subagent commits through this repository's own git config\./);
assert.match(flat, /The content is the test; the author is a hint\./);
```

Invariant under reflow — re-wrap the same words at any width and it passes — while a dropped, duplicated or reordered word fails. It pins neither line boundaries nor the whole message; the paragraph's other five lines stay free to reword. "Brittle" was an unmeasured claim used to justify no coverage, which is the shape this repo treats as an untested docstring guarantee at its worst.

It also isn't a departure from the suite's philosophy: A27 pins a refusal's advisory wording for exactly this reason, and says so in its own comment.

**Measured both directions against `npm run test:scripts`:**

```
before  MUTANT SURVIVED  delete-matching 'IDENTICAL to yours' -> exit 0, 0 failing (633 green)
after   MUTANT KILLED    same mutation                        -> exit 1, 1 failing
```

The mutant parses and runs to completion in both runs, so the kill is coverage rather than a crash signature, and **1** is the honest count — the single test written for it.

Without this the one-word fix ships with nothing preventing its immediate regression, which is how the word went missing in the first place.

Refs #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FBmu8MKEFniwX7WrjV1iXr