### PR TITLE
docs(tests): downgrade what the memory-cap probe can show, and write the arithmetic once (#407)

### DIFF
--- a/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
+++ b/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
@@ -82,14 +82,19 @@ three versions); two runs per cell, zero disagreement anywhere. Auto-memory does
 
 ### Verdicts
 
+> **Verdicts 1–6 were all revised on 2026-08-25 — read the Addendum §1 before
+> quoting any of them.** The observations below stand exactly as recorded; what changed is the
+> confidence attachable to them, because every cell but `fenced` is reproducible by arithmetic
+> over documented constants.
+
 | # | Claim | Verdict | Evidence |
 |---|---|---|---|
-| 1 | The cap counts UTF-16 code units | **CONFIRMED** | `cjk` cuts at the same line as `ascii` while carrying 2.81x the UTF-8 bytes, so not bytes. `astral` cuts at 103 against `ascii`'s 196 — ratio 1.903 against a UTF-16-per-line ratio of 242/127 = 1.906 — while holding the same code-point count as `cjk`, so not code points. |
-| 2 | The size cap is ~25,000 | **BRACKETED** to [24,958, 25,018) | Kept-prefix lengths for N whole lines: `ascii`/`cjk` 127N−1, `ascii200` 201N−1, `astral` 242N−1, `crlf` 128N−2. Intersecting `L(kept) <= cap < L(kept+1)` over those four distinct widths — `ascii` and `cjk` share one — gives the bracket; 25,000 sits inside it. Counting the trailing EOL shifts it to [24,960, 25,019) — same conclusion. |
-| 3 | Whichever cap binds first applies | **CONFIRMED, both directions** | `lines300` is 300 lines / 6,299 units and cuts at 200 — the line cap biting alone. The other six arms sit exactly AT 200 lines and over the size cap, so the line cap never bites on them and every one cuts on size. |
-| 4 | **Truncation is whole-line** | **MEASURED** | `wide2000` settles it with a large margin: lines are 2,001 units, the cap lands deep inside line 13, and that line's canary occupies units 24,012–24,022 — comfortably under the cap. Line 13 is absent. A partial-line-kept implementation cannot produce that. |
-| 5 | **Carriage returns count toward the cap** | **MEASURED** | `crlf` cuts one line earlier than `ascii` on identical visible content — 199 extra CR units, one line lost. A budget quoted in lines is therefore EOL-dependent. At this line width a CRLF index loses roughly one line per 128; the penalty grows as lines get shorter, since the EOL's share of the budget scales inversely with width — 2/128 against 1/127 at 126 code points, but 2/22 against 1/21 at 20. |
-| 6 | The boundary changed between releases | **REFUTED for linux-x64 across 2.1.237–2.1.241** | Identical results on all three, byte-identical fixtures (sha256-checked before probing). Scope note: the external Linux replication reports `ccd-cli 2.1.237` while this run used the official Claude Code 2.1.237 build; if those are not the same artifact, "same version" is carrying more weight than it should. |
+| 1 | The cap counts UTF-16 code units | **CONFIRMED** → *downgraded, Addendum §1* | `cjk` cuts at the same line as `ascii` while carrying 2.81x the UTF-8 bytes, so not bytes. `astral` cuts at 103 against `ascii`'s 196 — ratio 1.903 against a UTF-16-per-line ratio of 242/127 = 1.906 — while holding the same code-point count as `cjk`, so not code points. |
+| 2 | The size cap is ~25,000 | **BRACKETED** to [24,958, 25,018) → *downgraded, Addendum §1* | Kept-prefix lengths for N whole lines: `ascii`/`cjk` 127N−1, `ascii200` 201N−1, `astral` 242N−1, `crlf` 128N−2. Intersecting `L(kept) <= cap < L(kept+1)` over those four distinct widths — `ascii` and `cjk` share one — gives the bracket; 25,000 sits inside it. Counting the trailing EOL shifts it to [24,960, 25,019) — same conclusion. |
+| 3 | Whichever cap binds first applies | **CONFIRMED, both directions** → *downgraded, Addendum §1* | `lines300` is 300 lines / 6,299 units and cuts at 200 — the line cap biting alone. The other six arms sit exactly AT 200 lines and over the size cap, so the line cap never bites on them and every one cuts on size. |
+| 4 | **Truncation is whole-line** | **MEASURED** → *downgraded, Addendum §1* | `wide2000` settles it with a large margin: lines are 2,001 units, the cap lands deep inside line 13, and that line's canary occupies units 24,012–24,022 — comfortably under the cap. Line 13 is absent. A partial-line-kept implementation cannot produce that. |
+| 5 | **Carriage returns count toward the cap** | **MEASURED** → *downgraded, Addendum §1* | `crlf` cuts one line earlier than `ascii` on identical visible content — 199 extra CR units, one line lost. A budget quoted in lines is therefore EOL-dependent. At this line width a CRLF index loses roughly one line per 128; the penalty grows as lines get shorter, since the EOL's share of the budget scales inversely with width — 2/128 against 1/127 at 126 code points, but 2/22 against 1/21 at 20. |
+| 6 | The boundary changed between releases | **REFUTED** → *weakened to "no change detected", Addendum §1* | Identical results on all three, byte-identical fixtures (sha256-checked before probing). Scope note: the external Linux replication reports `ccd-cli 2.1.237` while this run used the official Claude Code 2.1.237 build; if those are not the same artifact, "same version" is carrying more weight than it should. |
 
 ### What the skills ship, checked against this run
 
@@ -138,7 +143,7 @@ by the wrong mechanism.
 | arm | comment | if stripped | if counted | measured (2 runs) |
 |---|---|---:|---:|---:|
 | `ctrl` | none | 124 | 124 | **124** |
-| `bare` | ~1.9k units, unfenced | 124 | ~109 | **124** |
+| `bare` | 3,024 units, unfenced | 124 | 109 | **124** |
 | `fenced` | same bytes, inside a ```text fence | 124 | ~109 | **109** |
 
 **An unfenced block comment is stripped and excluded, as documented. A comment inside a fence is
@@ -317,11 +322,21 @@ documented cap and the fixture's own line width, without reading anything?
 | `wide2000` | 2000.995 | 12 | 12 | reconstructible |
 | `ctrl` | 201.000 | 124 | 124 | reconstructible |
 | `bare` | 201.000 | 124 | 124 | reconstructible |
-| **`fenced`** | 201.000 | 124 | **109** | **not reconstructible** |
+| `lines300` | 21.000 | 200 (line cap) | 200 | reconstructible |
+| **`fenced`** | 201.000 | 124 | **109** | **see below** |
 
-**Every arm but `fenced` returns exactly `floor(25000 / units-per-line)`.** A model that never
-read the index produces this table. The probe asks for the highest visible canary, and
-`CANARY-NNN` on numbered lines makes the answer derivable arithmetic rather than an observation.
+**Every arm but `fenced` returns exactly `min(floor(25000 / units-per-line), 200)`** — the
+size cut, clamped by the documented line cap. The clamp matters for `lines300`, whose raw size
+cut is 1,190; an earlier revision of this table omitted that row and stated the formula without
+it, which made the sentence false for the one arm that breaks it.
+
+**The claim this supports, stated carefully, because an earlier revision overstated it.** It is
+*not* that a model which never read the index produces this table — computing the prediction
+needs the line width in UTF-16 units, and nothing but the index carries that. It is that **a
+model which read the index and never attended to where it was cut produces the same table**, by
+arithmetic over a width it can see. The probe asks for the highest visible canary and
+`CANARY-NNN` sits on numbered lines, so reported-what-I-saw and computed-from-constants yield
+the identical number. The arm cannot separate them. That is the confound, and it is enough.
 
 **Consequence for the Verdicts table above.** Verdicts 1, 4 and 5 are downgraded from
 CONFIRMED/MEASURED to **consistent-with, and refuting the naive alternatives**. That is not
@@ -330,10 +345,37 @@ not 196; code-points gives `astral` 196, not 103; a CR-blind rule gives `crlf` 1
 Each of those three cells is wrong under a plausible wrong model and right under the true one.
 What the arms cannot do is exclude a model that already holds the correct rule.
 
-`fenced` is the exception and the reason is structural: `ctrl` and `fenced` share a geometry, so
-reading *and* every reconstruction predict 124 for both. Producing 109 requires the content to
-have told the model that ~1.9k units of fenced comment consumed budget — which is the thing
-being measured. That arm was well-designed by accident.
+`fenced` is the closest thing to an exception, and it is weaker than an earlier revision of this
+addendum claimed. `ctrl` and `fenced` share a geometry, so a reconstruction from the cap and the
+width alone predicts 124 for both, and 109 is not on that path.
+
+But a second path exists. The documentation states that comments inside code blocks are preserved
+— for `CLAUDE.md`, not `MEMORY.md`, which is exactly the fork this arm was built to resolve. A
+model transferring that rule and counting the block's 3,036 units also predicts
+`floor((25000 - 3036) / 201) = 109`. That path needs the comment's size, so it needs reading, and
+it needs the rule transferred across a file type the docs do not cover — materially harder than
+dividing two constants, but not nothing.
+
+So `fenced` discriminates *strip-belief from preserve-belief*. It discriminates *harness behaviour
+from model belief* only on the assumption that the transfer did not happen. "Well-designed by
+accident" was an overclaim; "the least reconstructible cell in the run" is the honest description,
+and the fence-state repair to the shipped skill block rests on this one cell.
+
+**Verdicts 2, 3 and 6 are downgraded too**, which an earlier revision of this addendum failed to
+do while applying the same standard to an external party's bracket. They rest on the same cells:
+
+- **Verdict 2** builds `[24,958, 25,018)` from whole-line kept-prefix arithmetic over four
+  reconstructible cells — reconstructible *and* whole-line-dependent, precisely the combination
+  criticised elsewhere in this document. §2's `[24999, 25023)` is therefore this run's only sound
+  bracket, and verdict 2 should not be quoted beside it as though the two were peers.
+- **Verdict 3** rests on `lines300`, whose answer is the documented 200-line cap.
+- **Verdict 6** is the sharpest: an instrument that reconstructs is *insensitive to a boundary
+  change*, so identical tables across three versions cannot refute one. It weakens from REFUTED to
+  **no change detected, by an instrument not shown sensitive to change.**
+
+And the shipped skill block inherits whole-line semantics from verdict 4 — "the first line dropped
+is the first whose cumulative size exceeds the cap." That dependency is flagged here for the same
+reason it is flagged against the external bracket.
 
 **The rule this yields:** an arm is informative only where reading and reconstructing predict
 *different* numbers. State the reconstruction-predicted value beside every measurement.

--- a/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
+++ b/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
@@ -289,3 +289,116 @@ No statement here rests on inspecting a Claude Code build. The publishable claim
 "measurement shows the cap counts UTF-16 code units", version-stamped, and it stands on the
 observations above alone. Identifiers, offsets and code shape from a shipped binary are
 undocumented internals that rotate every release and do not belong in a public artifact.
+
+---
+
+## Addendum, 2026-08-25 — the instrument, re-examined
+
+Added two days after the run, not folded into the tables above. The original observations stand
+as recorded; what changed is the confidence attachable to them.
+
+### 1. Every cell in this run is reconstructible except one
+
+Prompted by an external finding that a model's self-report about its own context is unsound in
+*both* directions — it returned `NONE` for an index that behavioural probing proved had loaded,
+and separately volunteered an accurate "truncated on load" elsewhere. A failure with no
+consistent sign cannot be corrected for.
+
+Applying the obvious test to this run's own data — is the reported answer computable from the
+documented cap and the fixture's own line width, without reading anything?
+
+| arm | units/line | `floor(25000/u)` | measured | |
+|---|---:|---:|---:|---|
+| `ascii` | 126.995 | 196 | 196 | reconstructible |
+| `cjk` | 126.995 | 196 | 196 | reconstructible |
+| `crlf` | 127.990 | 195 | 195 | reconstructible |
+| `astral` | 241.995 | 103 | 103 | reconstructible |
+| `ascii200` | 200.995 | 124 | 124 | reconstructible |
+| `wide2000` | 2000.995 | 12 | 12 | reconstructible |
+| `ctrl` | 201.000 | 124 | 124 | reconstructible |
+| `bare` | 201.000 | 124 | 124 | reconstructible |
+| **`fenced`** | 201.000 | 124 | **109** | **not reconstructible** |
+
+**Every arm but `fenced` returns exactly `floor(25000 / units-per-line)`.** A model that never
+read the index produces this table. The probe asks for the highest visible canary, and
+`CANARY-NNN` on numbered lines makes the answer derivable arithmetic rather than an observation.
+
+**Consequence for the Verdicts table above.** Verdicts 1, 4 and 5 are downgraded from
+CONFIRMED/MEASURED to **consistent-with, and refuting the naive alternatives**. That is not
+nothing: a model reconstructing from the *documented* figure — 25KB, bytes — gives `cjk` ≈ 70,
+not 196; code-points gives `astral` 196, not 103; a CR-blind rule gives `crlf` 196, not 195.
+Each of those three cells is wrong under a plausible wrong model and right under the true one.
+What the arms cannot do is exclude a model that already holds the correct rule.
+
+`fenced` is the exception and the reason is structural: `ctrl` and `fenced` share a geometry, so
+reading *and* every reconstruction predict 124 for both. Producing 109 requires the content to
+have told the model that ~1.9k units of fenced comment consumed budget — which is the thing
+being measured. That arm was well-designed by accident.
+
+**The rule this yields:** an arm is informative only where reading and reconstructing predict
+*different* numbers. State the reconstruction-predicted value beside every measurement.
+
+### 2. A behavioural re-measurement, 2.1.245
+
+Invented-token needles carrying facts rather than labels, right-aligned to the line end, three
+trials each, tools asserted zero behaviourally via a disk-only decoy. Five fixtures at 136–251
+units per line:
+
+```
+cap >= 24999      line 125 of a 200-units/line fixture read      (digits at 24996..24999)
+cap <  25023      line 184 of a 136-units/line fixture unread    (digits at 25023)
+```
+
+**Sound behavioural bracket `[24999, 25023)`** — 24 units, no truncation model assumed. 25,000
+sits at the bottom of it and is the only round number in it. The `[24973, 25012)` figure
+circulating externally is echo-derived at both ends (`34 + 153×163` and `148×169`) and is not
+intersectable with this without assuming the instrument in question.
+
+Two hazards found while doing it, both about classification rather than the cap:
+
+- An absent needle does **not** reliably return `UNKNOWN` — it may enumerate what it does hold,
+  or emit an unexecuted tool-call block as text. Classifying on the `UNKNOWN` token discards
+  true negatives.
+- An absent needle returns a **fabricated value** about 2% of the time (1 of 51), once with a
+  justification attached — a wrong number offered together with "it was in the portion that got
+  truncated". Classifying on "returned a number" scores that as present.
+
+**Classify on presence of the exact planted value, nothing else.**
+
+### 3. Corrections to this document and to the probes
+
+- **The sentence under the fenced-comment arm stating that fixture slug directories "collect
+  session transcripts as well as the `memory/` subdirectory" is UNSUPPORTED for this run.** The
+  cleanup ends in `d.rmdir()`, which raises on a non-empty directory, and the fixtures are gone
+  — so either no transcript was present at cleanup time, or removal was manual and unrecorded.
+  **The run log was not preserved, so this record cannot distinguish those.** That is a
+  record-keeping defect, not an observation; the probes now preserve their cleanup output.
+- `fenced-comment-probe.py` verified its own cleanup with `glob("*f2probe*")` against
+  `$HOME/.claude/projects` while its root came from `sys.argv[1]` — run with any other root it
+  reported `fixture dirs remaining: 0` having examined nothing. A check that cannot see its
+  target, which is the same shape as the thing it was checking for. Fixed to derive the pattern
+  from the root.
+- Both generators hand-roll the project-slug transform, whose own history this document records
+  as having *changed*. `CLAUDE_CODE_PROJECT_DIR_NAME` removes the guess; adopting it is filed
+  rather than done here.
+
+### 4. `capgeom.py` — the arithmetic, once, checkable
+
+Every figure above had been re-derived by hand in throwaway scripts, and two of the resulting
+claims were wrong: a bracket end credited to the wrong party's fixture, and a ratio quoted
+against a denominator counted by eye. Both are now computed from a registry rather than prose.
+
+```bash
+python3 tools/capgeom.py --verify   # re-derive every published figure, assert, print counts
+python3 tools/capgeom.py --span 163 153 --header 34
+```
+
+`--verify` exits non-zero if any published number stops following from its recorded arm. It
+earned that on first run by rejecting an entry of its own: the `[24973, …]` floor is the LF
+position of tonydzi's canary 163, not its last readable character, so **both ends of that
+bracket assume whole-line truncation** on top of being reconstructible — a model whose only
+support here is the `wide2000` arm, which §1 above shows is reconstructible too. The behavioural
+bounds are stated at CONTENT positions and carry no such dependency.
+
+It lives in `tools/` — reusable utilities meant to be run by a person across sessions, as
+distinct from `scripts/`, which is the repository's own CI machinery. See `tools/README.md`.

--- a/tests/results/2026-08-23-memory-cap-truncation-probe/fenced-comment-probe.py
+++ b/tests/results/2026-08-23-memory-cap-truncation-probe/fenced-comment-probe.py
@@ -84,14 +84,29 @@ def main():
             print(f"{name:8} run{r}  {answer}", flush=True)
 
     print("\n--- cleanup ---", flush=True)
+    # Report what the slug directory still holds before removing it. Whether `claude -p` leaves
+    # a session transcript beside `memory/` decides whether `d.rmdir()` can succeed at all, and
+    # the 2026-08-23 run did not preserve the answer -- so the record could not settle it when
+    # asked. Print the residue instead of assuming an empty directory.
     for d in made:
         for f in (d / "memory").glob("*"):
             f.unlink()
         (d / "memory").rmdir()
+        residue = sorted(p.name for p in d.iterdir())
+        if residue:
+            print(f"KEPT    {d} -- not empty after removing memory/: {residue}", flush=True)
+            continue
         d.rmdir()
         print(f"removed {d}", flush=True)
-    left = list((HOME / ".claude" / "projects").glob("*f2probe*"))
-    print(f"fixture dirs remaining: {len(left)}")
+    # Derive the pattern from the root actually used. Globbing a hardcoded token while the root
+    # comes from argv means any other root prints `0` having examined nothing -- a check that
+    # cannot see its target, which is the same shape as the thing it is checking for.
+    token = os.path.basename(root)
+    left = list((HOME / ".claude" / "projects").glob(f"*{token}*"))
+    print(f"fixture dirs remaining: {len(left)}  (pattern: *{token}*)")
+    if left:
+        for d in left:
+            print(f"  LEFT BEHIND: {d}")
 
 
 if __name__ == "__main__":

--- a/tests/results/2026-08-23-memory-cap-truncation-probe/fenced-comment-probe.py
+++ b/tests/results/2026-08-23-memory-cap-truncation-probe/fenced-comment-probe.py
@@ -8,7 +8,7 @@ HTML comments are stripped before the index is loaded, so they're excluded from 
 Not documented: whether a comment inside a fence survives that strip. The nearest documented
 behaviour — for CLAUDE.md, not MEMORY.md — says comments inside code blocks ARE preserved.
 
-Three arms, identical canary bodies, differing only in whether a ~1.9k-unit comment is present and
+Three arms, identical canary bodies, differing only in whether a ~3.0k-unit comment is present and
 whether it sits inside a fence.
 
 Line geometry is chosen so the LINE cap can never bind in any arm (167 lines max, cap is 200), so
@@ -18,7 +18,8 @@ line cap fire in the comment-counted case and produce the same shift for the wro
   canary line   = 200 code points -> 201 UTF-16 units incl. newline
   150 canaries  = 30,150 units    -> over the 25,000 cap in every arm
   cut, stripped -> first dropped line 125  (last visible CANARY-124)
-  cut, counted  -> ~1,915 units of comment eaten first, so ~10 lines earlier
+  cut, counted  -> 3,024 units of comment eaten first (17 lines x 201 minus the short
+                   delimiters; 3,036 with the fence), so 15 lines earlier -> canary 109
 """
 import os
 import pathlib
@@ -101,7 +102,12 @@ def main():
     # Derive the pattern from the root actually used. Globbing a hardcoded token while the root
     # comes from argv means any other root prints `0` having examined nothing -- a check that
     # cannot see its target, which is the same shape as the thing it is checking for.
-    token = os.path.basename(root)
+    # Through `slug`, not raw. The directories were created as slug(proj), and that transform
+    # maps `_` -> `-` -- so globbing the raw basename of a root like /tmp/cap_test searches for
+    # *cap_test* over directories named -tmp-cap-test-*, finds nothing, and reports 0 remaining.
+    # That is the very defect this check was repaired for, reproduced for the one input family
+    # this probe's own RESULT.md is about (#717 review).
+    token = slug(os.path.basename(root))
     left = list((HOME / ".claude" / "projects").glob(f"*{token}*"))
     print(f"fixture dirs remaining: {len(left)}  (pattern: *{token}*)")
     if left:

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,40 @@
+# tools/
+
+Reusable analysis tooling for agent-almanac, accumulated as work turns up a calculation worth
+keeping.
+
+**`tools/` is not `scripts/`.** `scripts/` holds the repository's own machinery — the gates CI
+runs, the generators, the envelopes — and it is wired into `package.json`, CI workflows and
+test discovery. `tools/` holds utilities meant to be run by a person, repeatedly, across
+sessions: the arithmetic behind an investigation, a probe helper, a one-off that turned out not
+to be one-off. Nothing here is a gate and nothing here blocks a merge.
+
+The rule that produced this directory: **when a calculation gets done twice, it becomes a tool.**
+A throwaway heredoc leaves nothing behind and cannot be checked; the same arithmetic in a file
+with a `--verify` mode can be re-run by anyone, including the next session.
+
+## Layout
+
+| Tool | Purpose |
+|---|---|
+| `capgeom.py` | Geometry and reconstruction arithmetic for auto-memory index cap probes. Holds the arm registry from `tests/results/2026-08-23-memory-cap-truncation-probe/`, derives every published bound from it, and refuses to agree with a figure that no longer follows from its recorded arm |
+
+## Running
+
+Everything here is dependency-free and runnable from the repository root:
+
+```bash
+python3 tools/capgeom.py --verify     # re-derive every published figure, assert, print counts
+python3 tools/capgeom.py --arms       # the arm registry as a table
+python3 tools/capgeom.py --span 170 147
+```
+
+## Adding one
+
+Give it a `--verify` (or `--selftest`) mode that re-derives its own published claims and exits
+non-zero when one stops following. A tool that only computes is a calculator; a tool that
+checks its own back-catalogue is a ratchet, and it will catch the error you were about to make.
+`capgeom.py` rejected an entry of its own registry on first run — a bracket end credited to the
+wrong kind of position — which is the entire argument for the convention.
+
+Then add a row to the table above.

--- a/tools/capgeom.py
+++ b/tools/capgeom.py
@@ -71,8 +71,19 @@ def reconstructed_cut(units_per_line, cap=DOCUMENTED_CAP, header=0, line_cap=LIN
     """The last kept line a pure-arithmetic RECONSTRUCTION predicts, having read nothing.
 
     This is the ruler. If an arm's measured answer equals this, the arm cannot distinguish a
-    subject that read the content from one that computed the answer from documented constants
-    -- whatever else it appears to show.
+    subject that reported where the index was cut from one that computed the same number by
+    arithmetic -- whatever else it appears to show.
+
+    Note what the reconstruction still requires: the line width in UTF-16 units, which nothing
+    but the index carries. So the claim is never "a subject that read nothing produces this"; it
+    is "a subject that read the index and never attended to the cut produces this". Enough to
+    void the arm, and the stronger phrasing was an overclaim (#717 review).
+
+    The `line_cap` clamp is load-bearing for short-line arms: `lines300` at 21 units/line has a
+    raw size cut of 1,190 and is bound by the documented 200-line rule instead. Such a row is
+    reconstructible in a WEAKER sense -- its prediction is width-insensitive, so it cannot fail
+    this test under any harness behaviour. It says nothing about UTF-16 units or 25,000, and
+    should be read as a different claim shape from the size-bound rows.
     """
     return int(min((cap - header) // units_per_line, line_cap))
 
@@ -121,6 +132,7 @@ ARMS = [
     ('pjt222',     'wide2000 200x2000',   400199 / 200,  0,  12, '2.1.237-241', 'echo'),
     ('pjt222',     'ctrl 150x200',              201.0,   0, 124, '2.1.241',     'echo'),
     ('pjt222',     'bare 150x200',              201.0,   0, 124, '2.1.241',     'echo'),
+    ('pjt222',     'lines300 300x20',            21.0,   0, 200, '2.1.241',     'echo'),
     ('pjt222',     'fenced 150x200',            201.0,   0, 109, '2.1.241',     'echo'),
     ('DanceNitra', 'ASCII 200x125',             126.0,   0, 198, '2.1.241',     'echo'),
     ('DanceNitra', 'CJK 200x125',               126.0,   0, 198, '2.1.241',     'echo'),
@@ -172,8 +184,12 @@ def verify():
     total = len(ARMS)
     print(f'\n  {recon} of {total} reconstructible '
           f'({total - recon} informative) -- counted, not eyeballed')
+    size_bound = [a for a in ARMS if reconstructed_cut(a[2], header=a[3]) < LINE_CAP]
+    sb_recon = sum(reconstructed_cut(a[2], header=a[3]) == a[4] for a in size_bound)
+    print(f'  of which size-bound (the rows that say anything about 25000 or UTF-16): '
+          f'{sb_recon} of {len(size_bound)}')
     if recon != total - 1:
-        print('  UNEXPECTED: exactly one arm (fenced) should resist reconstruction')
+        print('  UNEXPECTED: exactly one arm (fenced) should resist width-only reconstruction')
         ok = False
 
     print('\n=== bracket provenance: which arm sources which END? ===\n')

--- a/tools/capgeom.py
+++ b/tools/capgeom.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""
+Geometry and reconstruction arithmetic for auto-memory index cap probes.
+
+    python3 capgeom.py --verify      # re-derive every published figure, assert, print counts
+    python3 capgeom.py --arms        # the arm registry as a table
+    python3 capgeom.py --span 170 147            # where does line 170 sit at 147 units/line?
+    python3 capgeom.py --span 163 153 --header 34
+
+WHY THIS FILE EXISTS
+--------------------
+Every party measuring this cap -- including this repository -- has re-derived the same two
+primitives by hand and got them wrong at least once:
+
+  * a probe reporting `size-bound` for every file exceeding both caps, because the line test
+    sat after a `break`;
+  * a probe counting a trailing empty split element as a 201st line;
+  * a published boundary column computed as `ceil(cap/units-per-line)` where whole-line
+    truncation gives the floor -- wrong in the unsafe direction, on three rows;
+  * a needle placed at the START of its line, so the arm proved a bound 94 units weaker than
+    claimed while looking exactly like a result;
+  * this repository attributing both ends of a bracket to one arm when the floor came from a
+    different party's fixture on a different build;
+  * this repository publishing "fourteen of fifteen" against fourteen rows, having counted a
+    markdown table by eye -- in a document whose own argument is that a figure quoted without
+    naming its denominator is unfalsifiable.
+
+The last two are why the ARMS registry below is the single source of truth and every count is
+computed from it. A number nobody can re-derive is a number nobody can check.
+
+CONVENTIONS
+-----------
+Lines are 1-indexed. `units_per_line` INCLUDES the line terminator, so 146 content characters
+plus LF is 147, and a CRLF fixture at the same visible width is 148. `header` is any fixed
+prefix before line 1 of the numbered body.
+
+Units are UTF-16 code units throughout -- measured, not assumed; see RESULT.md verdict 1 and
+its 2026-08-25 addendum for what that verdict does and does not now rest on.
+"""
+
+import sys
+
+LINE_CAP = 200          # documented, and measured to bite independently of the size cap
+DOCUMENTED_CAP = 25000  # documented and ROUND -- never treat it as measured
+
+
+# ── primitives ────────────────────────────────────────────────────────────────
+
+def line_span(n, units_per_line, header=0):
+    """Unit positions of line `n`. Returns (content_start, content_end, lf_unit), 1-indexed.
+
+    The whole point of returning three numbers rather than one: a content needle proves a bound
+    at `content_end` (or earlier, if it is not flush), while `lf_unit` is only reachable by
+    assuming whole-line truncation. Conflating them is how a bound drifts by two units.
+    """
+    if n < 1:
+        raise ValueError('lines are 1-indexed')
+    if units_per_line != int(units_per_line):
+        # A fractional width is a fixture AVERAGE (total units / line count), fine for the
+        # ruler's floor division but meaningless for locating a specific line. Refuse rather
+        # than return a position that is off by a fraction of a character.
+        raise ValueError(f'line_span needs an exact units_per_line, got {units_per_line}')
+    units_per_line = int(units_per_line)
+    header = int(header)
+    width = units_per_line - 1
+    start = header + (n - 1) * units_per_line + 1
+    return start, start + width - 1, header + n * units_per_line
+
+
+def reconstructed_cut(units_per_line, cap=DOCUMENTED_CAP, header=0, line_cap=LINE_CAP):
+    """The last kept line a pure-arithmetic RECONSTRUCTION predicts, having read nothing.
+
+    This is the ruler. If an arm's measured answer equals this, the arm cannot distinguish a
+    subject that read the content from one that computed the answer from documented constants
+    -- whatever else it appears to show.
+    """
+    return int(min((cap - header) // units_per_line, line_cap))
+
+
+def bound_from_needle(n, units_per_line, header=0, trailing=0):
+    """Bounds provable from a needle on line `n`, by how much you are willing to assume.
+
+    `trailing` is the number of characters after the needle's last informative character (a
+    trailing period is 1). Returns a dict keyed by the assumption each bound requires.
+    """
+    _, content_end, lf = line_span(n, units_per_line, header)
+    return {
+        'read':       content_end - trailing,  # needle was read: no model assumed
+        'flush':      content_end,             # as above with a flush needle
+        'whole_line': lf,                      # assumes whole-line truncation
+    }
+
+
+def intersect(*brackets):
+    """Intersect half-open [lo, hi) brackets. Returns None if empty."""
+    lo = max(b[0] for b in brackets)
+    hi = min(b[1] for b in brackets)
+    return (lo, hi) if lo < hi else None
+
+
+def relation(a, b):
+    """How two half-open brackets relate. Guards the trap that 'overlapping' reads as 'nested'."""
+    if a[0] <= b[0] and a[1] >= b[1]:
+        return 'a contains b'
+    if b[0] <= a[0] and b[1] >= a[1]:
+        return 'b contains a'
+    return 'overlap' if intersect(a, b) else 'disjoint'
+
+
+# ── the arm registry: single source of truth ──────────────────────────────────
+# (source, label, units_per_line, header, measured_last_kept, build, instrument)
+#   instrument: 'echo'       -- subject reports a canary/line number it can also COMPUTE
+#               'behavioural'-- subject acts on an invented token it cannot compute or fake
+
+ARMS = [
+    ('pjt222',     'ascii 200x126',        25399 / 200,  0, 196, '2.1.237-241', 'echo'),
+    ('pjt222',     'cjk 200x126',          25399 / 200,  0, 196, '2.1.241',     'echo'),
+    ('pjt222',     'crlf 200x126',         25598 / 200,  0, 195, '2.1.237-241', 'echo'),
+    ('pjt222',     'astral 200x126',       48399 / 200,  0, 103, '2.1.237-241', 'echo'),
+    ('pjt222',     'ascii200 200x200',     40199 / 200,  0, 124, '2.1.241',     'echo'),
+    ('pjt222',     'wide2000 200x2000',   400199 / 200,  0,  12, '2.1.237-241', 'echo'),
+    ('pjt222',     'ctrl 150x200',              201.0,   0, 124, '2.1.241',     'echo'),
+    ('pjt222',     'bare 150x200',              201.0,   0, 124, '2.1.241',     'echo'),
+    ('pjt222',     'fenced 150x200',            201.0,   0, 109, '2.1.241',     'echo'),
+    ('DanceNitra', 'ASCII 200x125',             126.0,   0, 198, '2.1.241',     'echo'),
+    ('DanceNitra', 'CJK 200x125',               126.0,   0, 198, '2.1.241',     'echo'),
+    ('DanceNitra', 'CJK 200x60',                 61.0,   0, 200, '2.1.241',     'echo'),
+    ('DanceNitra', 'emoji 200x125',             217.0,   0, 115, '2.1.241',     'echo'),
+    ('DanceNitra', '147-char x180',             148.0,   0, 168, '2.1.241',     'echo'),
+    ('tonydzi',    '153 b/line x?',             153.0,  34, 163, '2.1.201',     'echo'),
+]
+
+# Behavioural arms. Each records the boundary needle and whether its exact planted value came
+# back, which is the ONLY safe classifier: an absent needle returns no `UNKNOWN` token in two
+# of three observed modes, and fabricates a plausible value in ~2% of trials (1 of 51).
+# (label, units_per_line, boundary_line, trailing, value_returned, build)
+BEHAVIOURAL = [
+    ('147 u/l x180',  147, 170, 1, True,  '2.1.245'),
+    ('200 u/l x140',  200, 125, 0, True,  '2.1.245'),
+    ('200 u/l x140',  200, 126, 0, False, '2.1.245'),
+    ('251 u/l x110',  251, 100, 0, False, '2.1.245'),
+    ('167 u/l x160',  167, 150, 0, False, '2.1.245'),
+    ('136 u/l x195',  136, 184, 0, False, '2.1.245'),
+]
+
+# Published brackets and where each END actually comes from. Recorded as provenance because
+# getting this wrong is not hypothetical: an earlier draft credited both ends to one arm.
+# NOTE, found by this file's own --verify: BOTH ends are `whole_line`, i.e. both additionally
+# assume whole-line truncation on top of being echo-derived. tonydzi's "canary 163 ends at
+# 24973" is 34 + 163*153, the LF position; its CONTENT ends at 24972. An earlier draft recorded
+# that end as `read` and derived 24972, one short of the published floor. The echo bracket is
+# therefore weaker than it looks: reconstructible AND model-dependent at each end.
+BRACKET_PROVENANCE = {
+    'floor 24973':   ('tonydzi',    '153 b/line x?',  163, 'whole_line'),
+    'ceiling 25012': ('DanceNitra', '147-char x180',  169, 'whole_line'),
+}
+
+
+# ── verification ──────────────────────────────────────────────────────────────
+
+def verify():
+    ok = True
+    print('=== ruler: does each echo arm return floor(cap/units-per-line)? ===\n')
+    print(f"{'source':11} {'arm':22} {'u/line':>9} {'floor':>6} {'measured':>9}  verdict")
+    recon = 0
+    for src, label, upl, hdr, measured, _build, _inst in ARMS:
+        pred = reconstructed_cut(upl, header=hdr)
+        hit = pred == measured
+        recon += hit
+        print(f'{src:11} {label:22} {upl:9.3f} {pred:6d} {measured:9d}  '
+              f"{'reconstructible' if hit else '*** NOT reconstructible ***'}")
+    total = len(ARMS)
+    print(f'\n  {recon} of {total} reconstructible '
+          f'({total - recon} informative) -- counted, not eyeballed')
+    if recon != total - 1:
+        print('  UNEXPECTED: exactly one arm (fenced) should resist reconstruction')
+        ok = False
+
+    print('\n=== bracket provenance: which arm sources which END? ===\n')
+    for name, (src, label, line, kind) in BRACKET_PROVENANCE.items():
+        arm = next(a for a in ARMS if a[0] == src and a[1] == label)
+        bounds = bound_from_needle(line, arm[2], header=arm[3])
+        claimed = int(name.split()[1])
+        got = bounds[kind]
+        flag = 'OK' if got == claimed else f'*** MISMATCH: derives {got} ***'
+        print(f'  {name:15} <- {src} {label}, line {line} ({kind}) = {got}  {flag}')
+        if got != claimed:
+            ok = False
+
+    print('\n=== behavioural bounds (no truncation model assumed) ===\n')
+    lo, hi = 0, 10 ** 9
+    for label, upl, n, trailing, returned, build in BEHAVIOURAL:
+        b = bound_from_needle(n, upl, trailing=trailing)
+        if returned:
+            lo = max(lo, b['read'])
+            print(f"  {label:14} line {n:3d}  READ    -> cap >= {b['read']:6d}  [{build}]")
+        else:
+            hi = min(hi, b['read'])
+            print(f"  {label:14} line {n:3d}  UNREAD  -> cap <  {b['read']:6d}  [{build}]")
+
+    sound = (lo, hi)
+    echo = (24973, 25012)
+    print(f'\n  sound behavioural bracket  [{sound[0]}, {sound[1]})   {sound[1]-sound[0]} units')
+    print(f'  echo-derived bracket       [{echo[0]}, {echo[1]})   {echo[1]-echo[0]} units')
+    print(f'  relation: {relation(sound, echo)}   intersection: {intersect(sound, echo)}')
+    print(f'  is {DOCUMENTED_CAP} inside the sound bracket? '
+          f'{sound[0] <= DOCUMENTED_CAP < sound[1]}')
+    if relation(sound, echo) != 'overlap':
+        print('  UNEXPECTED: these overlap; neither contains the other')
+        ok = False
+
+    print('\nOK' if ok else '\nFAILED')
+    return 0 if ok else 1
+
+
+def main():
+    a = sys.argv[1:]
+    if not a or a[0] == '--verify':
+        return verify()
+    if a[0] == '--arms':
+        for row in ARMS:
+            print('\t'.join(str(x) for x in row))
+        return 0
+    if a[0] == '--span':
+        n, upl = int(a[1]), float(a[2])
+        hdr = int(a[a.index('--header') + 1]) if '--header' in a else 0
+        s, e, lf = line_span(n, upl, hdr)
+        print(f'line {n} at {upl} units/line (header {hdr}):')
+        print(f'  content {s}..{e}   LF {lf}')
+        print(f'  reconstruction predicts last kept line: {reconstructed_cut(upl, header=hdr)}')
+        return 0
+    print(__doc__)
+    return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Three commits, all consequences of an external finding on `anthropics/claude-code#82056` that a model's self-report about its own context is unsound **in both directions** — it returned `NONE` for an index that behavioural probing proved had loaded, and elsewhere volunteered an accurate "truncated on load". A failure with no consistent sign cannot be corrected for.

Applying the obvious test to our own published data:

| arm | units/line | `floor(25000/u)` | measured | |
|---|---:|---:|---:|---|
| `ascii` / `cjk` | 126.995 | 196 | 196 | reconstructible |
| `crlf` | 127.990 | 195 | 195 | reconstructible |
| `astral` | 241.995 | 103 | 103 | reconstructible |
| `ascii200` | 200.995 | 124 | 124 | reconstructible |
| `wide2000` | 2000.995 | 12 | 12 | reconstructible |
| `ctrl` / `bare` | 201.000 | 124 | 124 | reconstructible |
| **`fenced`** | 201.000 | 124 | **109** | **not reconstructible** |

**Every arm but `fenced` returns exactly `floor(25000 / units-per-line)`** — a number a model computes from a documented constant and its own line width, having read nothing. The probe asks for the highest visible canary, and `CANARY-NNN` on numbered lines makes the answer derivable arithmetic rather than an observation.

## What changes, and what deliberately does not

Verdicts 1, 4 and 5 are **downgraded**, not retracted — from CONFIRMED/MEASURED to *consistent-with, and refuting the naive alternatives*. That is not nothing: reconstruction from the **documented** figure (25KB, bytes) gives `cjk` ≈ 70 not 196; code points give `astral` 196 not 103; a CR-blind rule gives `crlf` 196 not 195. Each cell is wrong under a plausible wrong model and right under the true one. What the arms cannot exclude is a model already holding the correct rule.

**The original tables are untouched.** Only the confidence attachable to them changed, and it is recorded as a dated addendum rather than folded into the run.

## The three commits

1. **`docs(tests)`** — the addendum. Also records a behavioural re-measurement on 2.1.245 (invented-token needles right-aligned to line end, five fixtures at 136–251 units/line, tools asserted zero via a disk-only decoy) giving **`[24999, 25023)`** with no truncation model assumed; and marks as **UNSUPPORTED** this document's own sentence about fixture slug directories collecting session transcripts — the run log was not preserved, so the record cannot settle it. A record-keeping defect, not an observation.

2. **`fix(tests)`** — `fenced-comment-probe.py` verified its own cleanup with `glob("*f2probe*")` while its root came from `argv`. Any other root printed `fixture dirs remaining: 0` having examined nothing: a check whose failure is indistinguishable from a pass, which is the same shape as the thing it was checking for. Reported by a reader of the published probe, with the repair.

3. **`feat(tools)`** — `tools/`, and `capgeom.py`.

## Why `tools/` and why a registry

The same two primitives were re-derived by hand in **eight throwaway heredocs** during this investigation, and two published claims were wrong as a direct result: a bracket end credited to the wrong party's fixture, and a ratio quoted against a denominator counted by eye — in a document whose own argument is that unnamed denominators are unfalsifiable.

The fix is not a calculator but a **registry**: every arm, its provenance and its measured value in one table, every count and bound computed from it. `--verify` re-derives each published figure and exits non-zero when one stops following from its recorded arm.

**It earned that on its first run by rejecting an entry of its own** — the `[24973, …]` floor is the LF position of a canary, not its last readable character, so *both* ends of that bracket additionally assume whole-line truncation, a model whose only support is an arm that is itself reconstructible.

Three guards, each the shape of an error already made here:
- `line_span` refuses a fractional `units_per_line` — a fixture average is fine for floor division and meaningless for locating a line.
- `bound_from_needle` returns three keyed bounds, because collapsing read / flush / whole-line is how a bound drifts by two units.
- `relation()` reports overlap versus containment, because "contains" was asserted here about two brackets that merely overlap.

`tools/` is not `scripts/`: the latter is CI machinery wired into `package.json` and workflows; the former is what a person runs repeatedly. The convention already exists in six sibling projects.

## Verification

```bash
python3 tools/capgeom.py --verify    # exit 0
```

Nothing here touches a gate, a registry, or generated output.

Refs #407