### PR TITLE
docs(tests): name the issue the probe's deferred work was filed as

### DIFF
--- a/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
+++ b/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
@@ -421,8 +421,8 @@ Two hazards found while doing it, both about classification rather than the cap:
   target, which is the same shape as the thing it was checking for. Fixed to derive the pattern
   from the root.
 - Both generators hand-roll the project-slug transform, whose own history this document records
-  as having *changed*. `CLAUDE_CODE_PROJECT_DIR_NAME` removes the guess; adopting it is filed
-  rather than done here.
+  as having *changed*. `CLAUDE_CODE_PROJECT_DIR_NAME` removes the guess; adopting it is filed as
+  #720, together with the cleanup's non-fail-closed `KEPT` path.
 
 ### 4. `capgeom.py` — the arithmetic, once, checkable
 


### PR DESCRIPTION
One line. `RESULT.md` claimed the slug-transform adoption was "filed rather than done here" without naming where, which a reader cannot verify — an unverifiable "this is tracked" reads as a commitment and carries none. Now cites #720.

Refs #407, #720