### PR TITLE
test(memory-cap): the harness states the cap in the prompt (#722)

### DIFF
--- a/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
+++ b/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
@@ -354,15 +354,36 @@ outside the model's own arithmetic: the line width, which only the index carries
 other input, the cap itself, reaches the model from documentation outside the run. A wire capture
 of the request body — not a question put to the model — shows that it does not:
 
+**Scope, before the strings: this was captured on 2.1.245, and the arms below ran on 2.1.237,
+2.1.238, 2.1.241 and (tonydzi) 2.1.201.** Whether those builds injected the notice at all, let
+alone with the `limit:` figure the answer-key arithmetic needs, was **not measured**. A
+third-party report of the `Only part of it was loaded` string at `tools_offered: 0` supports its
+*existence* on an earlier build but does not carry the limit figure, and its build is unstated.
+So the strengthening below is an INFERENCE across builds, not a measurement of this run. If the
+notice turns out to be absent on 2.1.237–241, the #717 downgrades stand unchanged on their
+original argument and only this strengthening lapses — the error direction is safe either way.
+
 ```
 > WARNING: MEMORY.md is 29.4KB (limit: 24.4KB) — index entries are too long. Only part of it was loaded. …
 > WARNING: MEMORY.md is 300 lines (limit: 200). Only part of it was loaded. …
 ```
 
 The harness appends one of these **inside the same `<system-reminder>` as the index**, at read time,
-in a session with no file tools. So every over-cap arm in this run carried its own answer key:
-the cap stated in the notice, the width visible in the index, and `floor(24.4 × 1024 / 201) = 124`
-— the measured cut, exactly. `lines300` is the starkest case; its notice reads `is 300 lines
+in a session with no file tools. If it did so on the builds above, then every over-cap arm here
+carried its own answer key: the cap stated in the notice, the width visible in the index, and
+`floor(24.4 × 1024 / 201) = 124` — which is the cut measured for the 201-unit arms `ctrl`, `bare`
+and `ascii200`. **Not `fenced`**, whose measured 109 is the one cell this arithmetic does not
+reach, and which is why it remains the least reconstructible in the run.
+
+Two caveats on "the width visible in the index", both of which narrow the claim rather than
+overturn it. For the ASCII arms the width is directly countable. For `cjk`, `astral`, `crlf` and
+`emoji` it must be counted in **UTF-16 units** — a third input, and one this corpus discovered
+rather than read anywhere, so those arms are not reconstructible from the prompt alone by a model
+without that rule. (The notice's own total is self-calibrating enough to recover it in principle —
+a bytes reading implies fewer lines than are visibly present — but nothing here measures whether
+that happens.)
+
+`lines300` is the starkest case and needs none of that: its notice reads `is 300 lines
 (limit: 200)`, so the answer `200` was a literal in its own prompt.
 
 This makes reconstruction **cheaper** than this section claims, so it strengthens every downgrade
@@ -415,7 +436,10 @@ reason it is flagged against the external bracket.
 ### 2. A behavioural re-measurement, 2.1.245
 
 Invented-token needles carrying facts rather than labels, right-aligned to the line end, three
-trials each, tools asserted zero behaviourally via a disk-only decoy. Five fixtures at 136–251
+trials each, tools asserted zero behaviourally via a disk-only decoy — read that as "no
+file-reading tool was offered", not literally zero: these arms ran on 2.1.245 on this machine,
+the exact configuration where a wire capture later showed one server-side `advisor` tool still
+present (see the Method correction above, #722). Five fixtures at 136–251
 units per line:
 
 ```

--- a/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
+++ b/tests/results/2026-08-23-memory-cap-truncation-probe/RESULT.md
@@ -52,6 +52,16 @@ a clean, internally consistent, completely wrong table showing that truncation d
 `--tools` is also variadic and eats a positional prompt (`Error: Input must be provided either
 through stdin or as a prompt argument when using --print`), so the prompt goes on stdin.
 
+**`--tools ""` is not tool-zero, and this section overstated it (corrected 2026-08-25, #722).** A
+wire capture of the same invocation on 2.1.245 shows one tool still offered — `advisor`, type
+`advisor_20260301` — because `--tools` filters *client* tools while `advisor` is server-side,
+enabled by `advisorModel` in `~/.claude/settings.json`. `--strict-mcp-config` does not remove it
+either. The claim is therefore machine-dependent: true only for an operator who has not set that
+key. It does not affect this run's arms, since `advisor` cannot read a file off disk and the
+disk-read failure above is the one the flag exists to prevent — but "tools asserted zero" should be
+read as "no file-reading tool was offered", and the honest way to assert it is to read the `tools`
+array out of the request rather than to infer it from a decoy.
+
 ### Fixtures
 
 | arm | filler | width (code points) | lines | EOL | UTF-8 bytes | UTF-16 units | code points | astral | what it discriminates |
@@ -338,6 +348,27 @@ arithmetic over a width it can see. The probe asks for the highest visible canar
 `CANARY-NNN` sits on numbered lines, so reported-what-I-saw and computed-from-constants yield
 the identical number. The arm cannot separate them. That is the confound, and it is enough.
 
+**Superseded in the operator's favour on 2026-08-25 — the cap did not have to come from
+documentation either.** The paragraph above concedes that reconstruction needs *one* input from
+outside the model's own arithmetic: the line width, which only the index carries. It assumed the
+other input, the cap itself, reaches the model from documentation outside the run. A wire capture
+of the request body — not a question put to the model — shows that it does not:
+
+```
+> WARNING: MEMORY.md is 29.4KB (limit: 24.4KB) — index entries are too long. Only part of it was loaded. …
+> WARNING: MEMORY.md is 300 lines (limit: 200). Only part of it was loaded. …
+```
+
+The harness appends one of these **inside the same `<system-reminder>` as the index**, at read time,
+in a session with no file tools. So every over-cap arm in this run carried its own answer key:
+the cap stated in the notice, the width visible in the index, and `floor(24.4 × 1024 / 201) = 124`
+— the measured cut, exactly. `lines300` is the starkest case; its notice reads `is 300 lines
+(limit: 200)`, so the answer `200` was a literal in its own prompt.
+
+This makes reconstruction **cheaper** than this section claims, so it strengthens every downgrade
+below rather than softening one. Full method, both verbatim strings, the delivery path and the
+limits of the finding: [`2026-08-25-truncation-notice-probe/RESULT.md`](../2026-08-25-truncation-notice-probe/RESULT.md) (#722).
+
 **Consequence for the Verdicts table above.** Verdicts 1, 4 and 5 are downgraded from
 CONFIRMED/MEASURED to **consistent-with, and refuting the naive alternatives**. That is not
 nothing: a model reconstructing from the *documented* figure — 25KB, bytes — gives `cjk` ≈ 70,
@@ -368,7 +399,8 @@ do while applying the same standard to an external party's bracket. They rest on
   reconstructible cells — reconstructible *and* whole-line-dependent, precisely the combination
   criticised elsewhere in this document. §2's `[24999, 25023)` is therefore this run's only sound
   bracket, and verdict 2 should not be quoted beside it as though the two were peers.
-- **Verdict 3** rests on `lines300`, whose answer is the documented 200-line cap.
+- **Verdict 3** rests on `lines300`, whose answer is the documented 200-line cap — and which #722
+  showed was additionally handed that number verbatim, as `(limit: 200)` in its own prompt.
 - **Verdict 6** is the sharpest: an instrument that reconstructs is *insensitive to a boundary
   change*, so identical tables across three versions cannot refute one. It weakens from REFUTED to
   **no change detected, by an instrument not shown sensitive to change.**

--- a/tests/results/2026-08-25-truncation-notice-probe/RESULT.md
+++ b/tests/results/2026-08-25-truncation-notice-probe/RESULT.md
@@ -1,0 +1,261 @@
+## Run: 2026-08-25-truncation-notice-probe
+
+**Observer**: Claude (Opus 5, one Claude Code session on one machine) | **Issue**: #722 | **Relates**: #407, #717, #720, `anthropics/claude-code#82056`
+
+### Objective
+
+#717 downgraded every verdict in the [2026-08-23 memory-cap run](../2026-08-23-memory-cap-truncation-probe/RESULT.md)
+on one argument: the reported answer in almost every arm equals `min(floor(25000 / units-per-line), 200)`,
+so the probe cannot separate *reported where the index was cut* from *computed the same number by
+arithmetic*.
+
+That argument carried an untested premise. It assumed the model must **derive** the boundary — that
+the cap constant reaches it from documentation, outside the measurement. If the harness instead
+injects a truncation notice naming the cut, the line count or the byte total, then the boundary is
+simply *told*, reconstruction costs nothing, and the confound is worse than the addendum states.
+
+This run settles it. **A notice exists, in two variants, and it names the limit.**
+
+### The read-out is the wire, not the model
+
+#717 established that a session's self-report about its own context is unsound in **both**
+directions — `NONE` for an index that behavioural probing proved had loaded, and elsewhere an
+accurate unprompted "truncated on load". A failure with no consistent sign cannot be corrected for,
+so no question of the form "did you see a notice?" can answer this.
+
+So nothing here asks the model anything. The outbound request body is captured with
+[`tools/wirecap.py`](../../../tools/wirecap.py) — `ANTHROPIC_BASE_URL` points at a local server that
+records the POST body and answers with a canned, well-formed SSE reply. The captured body is the
+entire context the client assembled. **The model's answer is not an input to any conclusion below**,
+and the reconstruction ruler therefore does not apply to this instrument at all: reading bytes that
+were sent cannot be confused with computing them.
+
+Nothing is forwarded anywhere — the request is answered locally. Credential headers are redacted at
+capture time and never written to disk (`wirecap.py --verify` asserts this, including that a planted
+secret does not reach the file).
+
+### Environment
+
+| Field | Value |
+|---|---|
+| Binary | Claude Code **2.1.245** via the `claude` launcher (`/home/phtho/.local/bin/claude`) |
+| Platform | Ubuntu 24.04.4 LTS on WSL2, kernel 6.18.33.2-microsoft-standard-WSL2, x86_64 |
+| Session type | `claude -p` (print mode), `--tools "" --strict-mcp-config`, prompt on stdin |
+| Model named in request | `claude-opus-5` |
+| Fixture filesystem | ext4 under `$HOME` — not the `/mnt/d` NTFS mount |
+| Date | 2026-08-25 |
+
+**One build, one platform, one OS.** A Windows or macOS notice string cannot be confirmed or refuted
+from here, and neither can a different build's.
+
+### Method
+
+Three fixtures, each 200-char or 20-char ASCII lines carrying a unique `CANARY-NNN` token, written as
+bytes. Generator: [`notice-probe.py`](notice-probe.py) in this directory.
+
+| arm | lines | chars/line | UTF-16 units | over which cap |
+|---|---:|---:|---:|---|
+| `under` | 100 | 200 | 20,099 | neither — the control |
+| `over` | 150 | 200 | 30,149 | size |
+| `lines` | 300 | 20 | 6,299 | line count only |
+
+`under` is a strict **line-prefix** of `over` — the line text depends only on the line's own index —
+so every line of `under` also occurs in `over`. Differencing the two captures therefore yields
+exactly: the canary lines `under` lacks, plus anything the harness added *because the index was cut*.
+The canary lines are trivially recognisable, so whatever else is in that set is the notice.
+
+**This needs no advance guess at the wording**, which is the reason for differencing rather than
+grepping for a string someone reported elsewhere.
+
+Prompts were deliberately unrelated to memory (`Reply with the single word OK.`, `What is 2+2?`).
+
+#### The store path is discovered, never computed
+
+Both generators in the 2026-08-23 run hand-roll the project-slug transform, whose history that
+document records as having *changed* (#720). This one does not guess it: it runs a throwaway session
+in the arm directory, observes which `~/.claude/projects/` entry appears, and fails closed if none
+does.
+
+**That was not caution for its own sake — a computed slug would have been wrong.** The observed
+directory was `-home-phtho--claude-jobs-…`: the `.` of `.claude` maps to `-`, giving a doubled dash.
+`memcap-fixture.py`'s hand-rolled `slug()` implements `/`→`-` and `_`→`-` and **not** `.`→`-`, so it
+would have written all three fixtures to paths nothing reads, and all three arms would have reported
+no memory index at all. Concrete support for #720, found by following it.
+
+### Observations
+
+#### 1. The cut, measured on the wire
+
+Highest `CANARY-NNN` present in the captured request body:
+
+| arm | fixture lines | on the wire | predicted | |
+|---|---:|---:|---:|---|
+| `under` | 100 | 100 | — | complete, no cut |
+| `over` | 150 | **124** | `floor(25000/201) = 124` | cut |
+| `lines` | 300 | **200** | `min(300, 200) = 200` | cut |
+
+Whole lines throughout — no partial line appears in any capture.
+
+This is the first cut measurement in this corpus taken from bytes rather than from an answer. It
+agrees with the behavioural arms exactly, which is a point in the earlier run's favour: the
+instrument was confounded, not wrong.
+
+#### 2. A notice exists. Two variants, verbatim
+
+Present in the `over` capture and **absent from the `under` capture**:
+
+```
+> WARNING: MEMORY.md is 29.4KB (limit: 24.4KB) — index entries are too long. Only part of it was loaded. Keep index entries to one line under ~200 chars; move detail into topic files.
+```
+
+Present in the `lines` capture:
+
+```
+> WARNING: MEMORY.md is 300 lines (limit: 200). Only part of it was loaded. Keep index entries to one line under ~200 chars; move detail into topic files.
+```
+
+183 and 154 characters respectively. The size variant carries an em-dash and the clause `index
+entries are too long`; the line variant has neither. Both share the tail from `Only part of it was
+loaded.` onward.
+
+The `over` arm was run twice, with different prompts, and reproduced the string and the cut exactly.
+
+#### 3. Delivery mechanism
+
+Not a hook, and not a separate content block. The notice is **inline text inside the first user
+message** — `body.messages[0].content[0].text` — within the `<system-reminder>` block that carries
+the memory index, appended immediately after the (already truncated) index and before the
+`# userEmail` section:
+
+```
+Contents of <store>/memory/MEMORY.md (user's auto-memory, persists across conversations):
+
+<... index, truncated ...>
+
+> WARNING: MEMORY.md is 29.4KB (limit: 24.4KB) — …
+# userEmail
+…
+      IMPORTANT: this context may or may not be relevant to your tasks. …
+</system-reminder>
+```
+
+This confirms the third-party report of an `Only part of it was loaded` string at `tools_offered: 0`
+referenced in #722, and supplies the full string and the delivery path it lacked. It is a **read**-time
+injection: the session ran no `Edit` — it had no file tools at all — so it is a different family from
+the `approaching the N-line read limit` advisories, which fire on `PostToolUse:Edit` and arrive as
+`hook_additional_context`.
+
+#### 4. The notice reports the WHOLE file, not the loaded part
+
+`29.4KB` is the full 30,149-unit fixture (`30149/1024 = 29.44`). The loaded 124 lines are 24,923
+units = 24.3KB. So the notice tells the reader both what was offered and what the ceiling is — and
+by subtraction, roughly how much went missing.
+
+The displayed unit is **UTF-16 units / 1024**, not bytes: `30149/1000` would display `30.1KB`. That
+the divisor is 1024 and the numerator is UTF-16 units is consistent with, and independent of, the
+2026-08-23 finding that the cap counts UTF-16 units.
+
+### Verdicts
+
+| # | Claim | Status |
+|---|---|---|
+| 1 | An over-cap auto-memory index produces an in-context notice at read time, in a session that ran no `Edit` | **MEASURED** — present in `over` and `lines`, absent in `under`, reproduced |
+| 2 | The notice names the limit | **MEASURED** — `limit: 24.4KB` and `limit: 200` |
+| 3 | The notice is precise enough to reconstruct the boundary from | **MEASURED for the line cap; MEASURED-with-rounding for the size cap** — see below |
+| 4 | The notice is delivered as inline text in `messages[0]`, inside the memory `<system-reminder>` | **MEASURED** |
+| 5 | The cut is whole-line, at `floor(cap/units-per-line)` clamped by a 200-line cap | **MEASURED on the wire**, first non-behavioural confirmation in this corpus |
+
+#### On verdict 3, stated carefully
+
+For the **line** cap there is nothing to reconstruct: the notice names `300` and `200` outright.
+
+For the **size** cap the figure is rounded to one decimal. `24.4KB` brackets the cap to
+`[24934.4, 25036.8)` — a 102.4-unit window. That is 4x wider than the behavioural bracket
+`[24999, 25023)` from the 2026-08-23 addendum §2, so **it does not improve the cap estimate** and is
+not intersectable with it as an independent measurement: it is the harness describing its own
+constant, which is a documentation channel, not an observation of behaviour. It is worth recording
+only that the two are consistent and that 25,000 lies in both.
+
+But *bracketing the cap* is not what matters here. What matters is that a model holding
+`limit: 24.4KB` and seeing 201-unit lines computes `floor(24.4 x 1024 / 201) = 124` — **the measured
+cut, exactly**. The rounding is far too coarse to pin the cap and far too fine to prevent the
+division from landing on the right integer.
+
+### What this means for the 2026-08-23 corpus
+
+The #717 addendum argued that reconstruction requires the line width, "and nothing but the index
+carries that" — true, and it is why a model that never read the index cannot produce the table. The
+addendum then assumed the *other* input, the cap, arrives from documentation outside the run.
+
+**It does not. It is injected into the very context being probed, in every over-cap arm.** So:
+
+- Every over-cap arm carried its own answer key. Both constants needed for
+  `floor(cap / units-per-line)` were in the prompt: the cap stated in the notice, the width visible
+  in the index. No external documentation, no prior knowledge of Claude Code, nothing but arithmetic
+  over the text in front of it.
+- The `lines300` arm is worse than "its answer is the documented 200-line cap" (addendum §1). Its
+  notice states `is 300 lines (limit: 200)`. **The answer 200 was handed to it verbatim**, as a
+  literal in its own context.
+- This strengthens the downgrade of verdicts 1–6 rather than qualifying it. Nothing in the addendum
+  needs walking back; §1's characterisation of what reconstruction *costs* was too generous.
+
+The one cell it does not touch is `fenced` (109 where geometry predicts 124), which is
+reconstructible only by a longer path that requires reading the block and transferring a
+`CLAUDE.md` documentation rule to `MEMORY.md`. That cell's standing is unchanged.
+
+### Side finding: `--tools ""` did not produce tool-zero
+
+The captured request carries **one** tool in every arm:
+
+```json
+{"name": "advisor", "type": "advisor_20260301", "model": "…"}
+```
+
+`--tools ""` filters *client* tools; `advisor` is server-side, enabled by `advisorModel` in
+`~/.claude/settings.json`, and neither `--tools ""` nor `--strict-mcp-config` removes it.
+
+**Benign for this run** — the read-out is the wire, so tool availability cannot affect any conclusion
+above, and `advisor` cannot read a file off disk in any case, which is the specific failure the
+`--tools ""` convention exists to prevent.
+
+**Not benign as a convention.** The 2026-08-23 method section and #722's own acceptance criteria both
+say "tools asserted zero", and on this machine that assertion is false. It is machine-dependent: it
+holds only for an operator with no `advisorModel` set. The cheap fix is to assert tool-zero from the
+captured request's `tools` array — a direct reading — rather than behaviourally via a disk-only
+decoy, which can only ever show that *the tools present did not read the decoy*.
+
+### What this run does NOT claim
+
+- **Nothing about whether the model attends to the notice.** Presence in context is not use. This run
+  measures what is *sent*; it says nothing about what is read, and the inconsistent self-report the
+  earlier work recorded is entirely compatible with a notice that is always present and sometimes
+  ignored. That remains open and is not answerable by asking.
+- **Nothing about other platforms or builds.** 2.1.245, linux-x64, WSL2, one machine.
+- **No improvement to the cap bracket.** `[24999, 25023)` from the 2026-08-23 addendum §2 stands as
+  the sound bracket; the notice's `24.4KB` is coarser and is not an independent behavioural
+  measurement.
+- **Nothing about how the harness computes the displayed KB internally.** `units/1024` is consistent
+  with both observations and refutes `/1000`; it is not proof of the implementation.
+- **Nothing about a store whose index is over cap for both reasons at once.** No arm combined a
+  >200-line and >25,000-unit fixture, so which variant wins, or whether both print, is unmeasured.
+
+### Reproduction
+
+```bash
+python3 tools/wirecap.py --verify                      # self-test the instrument first
+python3 tools/wirecap.py --port 8788 --out over.jsonl & # one per arm
+python3 tests/results/2026-08-25-truncation-notice-probe/notice-probe.py \
+  --build /tmp/t722 --port 8788
+
+cd /tmp/t722/over && printf '%s' 'Reply with the single word OK.' \
+  | ANTHROPIC_BASE_URL=http://127.0.0.1:8788 claude -p --tools "" --strict-mcp-config
+
+python3 tools/wirecap.py --diff over.jsonl under.jsonl
+python3 tests/results/2026-08-25-truncation-notice-probe/notice-probe.py --cleanup /tmp/t722
+```
+
+**The raw captures are not committed.** They contain `device_id`, `account_uuid`, `session_id` and
+the operator's email — the request body is the whole assembled context, which is exactly what makes
+the instrument useful and exactly what makes it unpublishable. Only the notice strings and the canary
+counts appear above. Cleanup was verified independently of the script:
+`find ~/.claude/projects -maxdepth 1 -name '*t722*'` returned 0.

--- a/tests/results/2026-08-25-truncation-notice-probe/RESULT.md
+++ b/tests/results/2026-08-25-truncation-notice-probe/RESULT.md
@@ -60,12 +60,29 @@ bytes. Generator: [`notice-probe.py`](notice-probe.py) in this directory.
 | `lines` | 300 | 20 | 6,299 | line count only |
 
 `under` is a strict **line-prefix** of `over` — the line text depends only on the line's own index —
-so every line of `under` also occurs in `over`. Differencing the two captures therefore yields
-exactly: the canary lines `under` lacks, plus anything the harness added *because the index was cut*.
-The canary lines are trivially recognisable, so whatever else is in that set is the notice.
+so every line of `under` also occurs in `over`.
 
-**This needs no advance guess at the wording**, which is the reason for differencing rather than
-grepping for a string someone reported elsewhere.
+**The residual set is not purely canaries-plus-notice, and the first draft of this section said it
+was.** The two arms ran in different directories, so the only-in-A set also contains per-session
+and per-store noise. Measured, it was 29 lines, of which four are that noise:
+
+| only in A | what it is |
+|---|---|
+| 24 × `CANARY-101…124` | the lines `under` does not have |
+| ` - Primary working directory: …/over` | differs by arm |
+| `Contents of …-t722-over/memory/MEMORY.md …` | differs by arm |
+| `You have a persistent file-based memory at …` | embeds the store path |
+| `{"device_id":…,"session_id":…}` | differs per session |
+| **the WARNING line** | **the finding** |
+
+So the identification is: strip the canaries, strip the four lines that name a path or a session,
+and one line remains. That is a judgement over a small residual, not the logical guarantee
+"whatever else is in that set is the notice" claimed. It still needs **no advance guess at the
+wording**, which is the point of differencing rather than grepping for a string someone reported
+elsewhere — but the honest version is "a five-line residual a human reads", not "exactly one line".
+
+Running both arms sequentially in the SAME directory, varying only `MEMORY.md`, would make the
+exact-set claim nearly true by construction. Worth doing if this is repeated.
 
 Prompts were deliberately unrelated to memory (`Reply with the single word OK.`, `What is 2+2?`).
 
@@ -151,9 +168,16 @@ the `approaching the N-line read limit` advisories, which fire on `PostToolUse:E
 units = 24.3KB. So the notice tells the reader both what was offered and what the ceiling is — and
 by subtraction, roughly how much went missing.
 
-The displayed unit is **UTF-16 units / 1024**, not bytes: `30149/1000` would display `30.1KB`. That
-the divisor is 1024 and the numerator is UTF-16 units is consistent with, and independent of, the
-2026-08-23 finding that the cap counts UTF-16 units.
+The **divisor is 1024, not 1000**: `30149/1000` would display `30.1KB`.
+
+**The numerator is not measured here, and an earlier draft of this line claimed it was.** The
+fixture is all-ASCII, so UTF-8 bytes, UTF-16 units and code points are the same 30,149 number, and
+`bytes/1024` predicts the identical 29.4. This arm discriminates the divisor and nothing else.
+
+That gap matters downstream rather than here: if the harness computed the KB figure from *bytes*,
+then a model doing the answer-key arithmetic on `cjk` would derive ≈65 rather than the measured
+196, and the "every over-cap arm carried its own answer key" claim would hold only for the ASCII
+arms. **A single CJK-line fixture separates it cheaply and was not run.**
 
 ### Verdicts
 
@@ -163,7 +187,8 @@ the divisor is 1024 and the numerator is UTF-16 units is consistent with, and in
 | 2 | The notice names the limit | **MEASURED** — `limit: 24.4KB` and `limit: 200` |
 | 3 | The notice is precise enough to reconstruct the boundary from | **MEASURED for the line cap; MEASURED-with-rounding for the size cap** — see below |
 | 4 | The notice is delivered as inline text in `messages[0]`, inside the memory `<system-reminder>` | **MEASURED** |
-| 5 | The cut is whole-line, at `floor(cap/units-per-line)` clamped by a 200-line cap | **MEASURED on the wire**, first non-behavioural confirmation in this corpus |
+| 5 | The cut is whole-line | **MEASURED on the wire** — no partial line in any capture; first non-behavioural confirmation in this corpus |
+| 5b | …at `floor(cap/units-per-line)`, clamped by a 200-line cap | **consistent at two widths** (201 and 21), not measured in generality — two points do not establish a formula |
 
 #### On verdict 3, stated carefully
 
@@ -214,9 +239,19 @@ The captured request carries **one** tool in every arm:
 `--tools ""` filters *client* tools; `advisor` is server-side, enabled by `advisorModel` in
 `~/.claude/settings.json`, and neither `--tools ""` nor `--strict-mcp-config` removes it.
 
-**Benign for this run** — the read-out is the wire, so tool availability cannot affect any conclusion
-above, and `advisor` cannot read a file off disk in any case, which is the specific failure the
-`--tools ""` convention exists to prevent.
+**Benign for this run, and the airtight reason is not the one I reached for first.** The first draft
+argued that `advisor` "cannot read a file off disk" — an untested assertion about a server-side tool,
+which is precisely the docstring-guarantee-nobody-ran shape this repo bans. The sound argument needs
+no claim about what `advisor` can do:
+
+**the canned SSE reply never emits a `tool_use` block, so no tool — client or server — executed in
+any session in this run.** That is a property of the instrument, checkable in `wirecap.py`'s
+`SSE_EVENTS`, not a belief about a tool.
+
+One narrower caveat survives it. Tool availability *does* change the assembled request — the `tools`
+array is part of it, and plausibly some system-prompt text. It cannot affect the **differential**
+conclusions, since both arms share the configuration. The single-capture observations, such as where
+in the block the notice sits, are therefore conditioned on a machine with `advisorModel` set.
 
 **Not benign as a convention.** The 2026-08-23 method section and #722's own acceptance criteria both
 say "tools asserted zero", and on this machine that assertion is false. It is machine-dependent: it
@@ -230,7 +265,16 @@ decoy, which can only ever show that *the tools present did not read the decoy*.
   measures what is *sent*; it says nothing about what is read, and the inconsistent self-report the
   earlier work recorded is entirely compatible with a notice that is always present and sometimes
   ignored. That remains open and is not answerable by asking.
-- **Nothing about other platforms or builds.** 2.1.245, linux-x64, WSL2, one machine.
+- **Nothing about other platforms or builds.** 2.1.245, linux-x64, WSL2, one machine. This bites
+  harder than it looks: the corpus this run re-reads ran on **2.1.237, 2.1.238, 2.1.241** and
+  (tonydzi) **2.1.201**. Whether those builds injected the notice, or injected it with a `limit:`
+  figure, is unmeasured. The "carried its own answer key" consequence is therefore an INFERENCE
+  across builds. Its failure is safe — the #717 downgrades stand on their original argument and
+  only the strengthening lapses.
+- **The KB numerator is unmeasured.** The fixtures are all-ASCII, where bytes, UTF-16 units and
+  code points coincide, so `bytes/1024` and `units/1024` are indistinguishable here. One CJK
+  fixture would settle it, and it decides whether the answer-key arithmetic reaches the non-ASCII
+  arms at all.
 - **No improvement to the cap bracket.** `[24999, 25023)` from the 2026-08-23 addendum §2 stands as
   the sound bracket; the notice's `24.4KB` is coarser and is not an independent behavioural
   measurement.
@@ -241,18 +285,36 @@ decoy, which can only ever show that *the tools present did not read the decoy*.
 
 ### Reproduction
 
-```bash
-python3 tools/wirecap.py --verify                      # self-test the instrument first
-python3 tools/wirecap.py --port 8788 --out over.jsonl & # one per arm
-python3 tests/results/2026-08-25-truncation-notice-probe/notice-probe.py \
-  --build /tmp/t722 --port 8788
+An earlier version of this block did not reproduce the run: it pointed one capture file at both the
+build phase and the measurement, so the three arms' **discovery** sessions landed in the file the
+diff then read. Build and measure must use different capture files.
 
+```bash
+P=tests/results/2026-08-25-truncation-notice-probe/notice-probe.py
+
+python3 tools/wirecap.py --verify                              # self-test the instrument first
+
+# 1. Build. Discovery traffic goes to its own file and is never diffed.
+python3 tools/wirecap.py --port 8787 --out discovery.jsonl &
+python3 $P --build /tmp/t722 --port 8787
+#   NOTICE_PROBE_ONLY=lines python3 $P --build /tmp/t722 --port 8787   # one arm only
+
+# 2. Measure. One server and one capture file PER ARM.
+python3 tools/wirecap.py --port 8788 --out over.jsonl &
 cd /tmp/t722/over && printf '%s' 'Reply with the single word OK.' \
   | ANTHROPIC_BASE_URL=http://127.0.0.1:8788 claude -p --tools "" --strict-mcp-config
+#   repeat on 8789 -> under.jsonl, 8790 -> lines.jsonl
 
 python3 tools/wirecap.py --diff over.jsonl under.jsonl
-python3 tests/results/2026-08-25-truncation-notice-probe/notice-probe.py --cleanup /tmp/t722
+python3 $P --cleanup /tmp/t722
 ```
+
+Two properties of `notice-probe.py` worth knowing before trusting a rerun. `discover_store` takes
+`sorted(new)[0]` of whatever `~/.claude/projects` entries appear, so a **concurrent peer session**
+creating a store during the build can be selected instead — fail-open to the wrong store. And the
+cleanup cross-check below globs `*t722*`, which only matches because the disposable root was named
+`…/t722`; point it at a differently-named root and the pattern sees nothing, which is the
+cannot-see-its-target shape §3 of the 2026-08-23 record already documents for the other probe.
 
 **The raw captures are not committed.** They contain `device_id`, `account_uuid`, `session_id` and
 the operator's email — the request body is the whole assembled context, which is exactly what makes

--- a/tests/results/2026-08-25-truncation-notice-probe/RESULT.md
+++ b/tests/results/2026-08-25-truncation-notice-probe/RESULT.md
@@ -70,7 +70,7 @@ and per-store noise. Measured, it was 29 lines, of which four are that noise:
 |---|---|
 | 24 × `CANARY-101…124` | the lines `under` does not have |
 | ` - Primary working directory: …/over` | differs by arm |
-| `Contents of …-t722-over/memory/MEMORY.md …` | differs by arm |
+| `Contents of <store-slug>/memory/MEMORY.md …` | differs by arm |
 | `You have a persistent file-based memory at …` | embeds the store path |
 | `{"device_id":…,"session_id":…}` | differs per session |
 | **the WARNING line** | **the finding** |
@@ -94,7 +94,7 @@ in the arm directory, observes which `~/.claude/projects/` entry appears, and fa
 does.
 
 **That was not caution for its own sake — a computed slug would have been wrong.** The observed
-directory was `-home-phtho--claude-jobs-…`: the `.` of `.claude` maps to `-`, giving a doubled dash.
+directory was `-home-<user>--claude-jobs-…`: the `.` of `.claude` maps to `-`, giving a doubled dash.
 `memcap-fixture.py`'s hand-rolled `slug()` implements `/`→`-` and `_`→`-` and **not** `.`→`-`, so it
 would have written all three fixtures to paths nothing reads, and all three arms would have reported
 no memory index at all. Concrete support for #720, found by following it.

--- a/tests/results/2026-08-25-truncation-notice-probe/UPSTREAM-DRAFT.md
+++ b/tests/results/2026-08-25-truncation-notice-probe/UPSTREAM-DRAFT.md
@@ -1,0 +1,83 @@
+# Draft comment for `anthropics/claude-code#82056`
+
+**Status: NOT POSTED.** Drafted 2026-08-25 alongside the probe. Posting is an outward-facing
+action and needs the operator's go-ahead. When posted, record the comment id here and in
+`RESULT.md`, the way the two 2026-08-25 comments are recorded in the 2026-08-23 run.
+
+---
+
+The premise under every bracket in this thread — mine, and I think all three of the others — is
+that a session has to *derive* where its index was cut. It doesn't. **The harness states the cap
+in the prompt.**
+
+I stopped asking the model anything and captured the request body instead: `ANTHROPIC_BASE_URL`
+pointed at a local server that records the POST and answers with a canned SSE reply. Three
+fixtures on 2.1.245, linux-x64, `claude -p`, no file tools, no `Edit` anywhere in the session.
+
+## The two strings
+
+Present in an over-cap capture, absent from an under-cap one, appended **inside the same
+`<system-reminder>` as the index itself**, immediately after the already-truncated content:
+
+```
+> WARNING: MEMORY.md is 29.4KB (limit: 24.4KB) — index entries are too long. Only part of it was loaded. Keep index entries to one line under ~200 chars; move detail into topic files.
+```
+
+```
+> WARNING: MEMORY.md is 300 lines (limit: 200). Only part of it was loaded. Keep index entries to one line under ~200 chars; move detail into topic files.
+```
+
+Inline text in `messages[0].content[0].text` — not a hook attachment, not a separate block. This
+is the read-time sibling of the `approaching the N-line read limit` advisories, which fire on
+`PostToolUse:Edit`; it needs no tool call and no edit. It also confirms the `Only part of it was
+loaded` string reported here at `tools_offered: 0`, and supplies the rest of it.
+
+## Why this matters more than it looks
+
+My earlier comment argued that a canary-echo arm can't separate *read* from *computed*, but
+conceded that computing needs one input from outside — the line width, which only the index
+carries — and assumed the cap arrived from documentation.
+
+It doesn't. It's in the prompt. So an over-cap arm hands the model **both** constants:
+
+```
+told:  limit: 24.4KB
+seen:  201-unit lines
+       floor(24.4 × 1024 / 201) = 124
+```
+
+124 is exactly what the wire shows was kept (lines 1–124 of a 150-line fixture). No
+documentation, no prior knowledge of Claude Code, nothing but arithmetic over text in front of
+it.
+
+The line-cap arm is starker still. Its notice reads `is 300 lines (limit: 200)`, and the answer
+is `200`. There is nothing to reconstruct — the number is a literal in its own prompt.
+
+## What it does not change
+
+- **The behavioural bracket stands.** `24.4KB` rounds, so it brackets the cap only to
+  `[24934.4, 25036.8)` — 102 units, four times *wider* than the `[24999, 25023)` I posted from
+  invented-token fixtures. It names the cap without measuring it, so please don't intersect it
+  with anything; it's the harness describing its own constant, which is a documentation channel.
+  Worth noting only that 25,000 sits inside both.
+- **It says nothing about whether the model reads the notice.** Presence in context is not use,
+  and I think this is the clean explanation for why self-report here has had no consistent sign:
+  the information is always there, and attending to it is optional. That still can't be settled
+  by asking.
+- **One build, one platform.** 2.1.245 on WSL2/Ubuntu. I can't speak for Windows or macOS, and
+  the notice text is exactly the kind of thing that gets reworded.
+
+## The methodological bit
+
+Reading the wire isn't subject to the reconstruction ruler at all — bytes that were *sent* can't
+be confused with bytes that were *computed* — so it's a strictly stronger instrument than
+anything I've posted here before, and it's cheap. If anyone wants to check the strings on another
+platform, the capture tool and the fixture generator are both in the writeup and are
+dependency-free Python.
+
+One correction to my own method while I'm here: `--tools ""` is **not** tool-zero. The capture
+shows one tool still offered — a server-side `advisor` tool enabled by `advisorModel` in
+`settings.json`. `--tools` filters client tools only, and `--strict-mcp-config` doesn't touch it.
+It can't read a file off disk so it doesn't affect the disk-read failure that flag exists to
+prevent, but "tools asserted zero" was machine-dependent and I'd stated it flatly. Reading the
+`tools` array out of the captured request is the honest assertion.

--- a/tests/results/2026-08-25-truncation-notice-probe/UPSTREAM-DRAFT.md
+++ b/tests/results/2026-08-25-truncation-notice-probe/UPSTREAM-DRAFT.md
@@ -1,10 +1,28 @@
-# Draft comment for `anthropics/claude-code#82056`
+# Comment for `anthropics/claude-code#82056`
 
-**Status: NOT POSTED.** Drafted 2026-08-25 alongside the probe. Posting is an outward-facing
-action and needs the operator's go-ahead. When posted, record the comment id here and in
-`RESULT.md`, the way the two 2026-08-25 comments are recorded in the 2026-08-23 run.
+**Status: POSTED 2026-08-25 as
+[comment 5412833938](https://github.com/anthropics/claude-code/issues/82056#issuecomment-5412833938).**
+
+The posted text differs from the draft below: it was rewritten after
+[DanceNitra's reply](https://github.com/anthropics/claude-code/issues/82056#issuecomment-5411236356),
+which retracted four echo-derived cells and the `[24955, 25012)` ceiling to the reconstruction
+ruler, kept `198` on a shuffled-label arm, and **replicated this run's floor on Windows**
+(`cap >= 24,999`, a third platform). The posted version adds the point that the shuffled-label arm
+is immune to the notice finding — the cap gives you a line NUMBER, and that arm's answer is a
+label only reading yields — which the draft below does not make.
+
+**Two scoping corrections are owed on the posted text**, both raised by an adversarial review
+after it went out, and both narrowing rather than retracting:
+
+1. The capture is 2.1.245. The thread's brackets rest on arms from 2.1.201–2.1.241, where the
+   notice's presence and wording are unmeasured.
+2. The fixtures are all-ASCII, so the KB figure's NUMERATOR is unmeasured — `bytes/1024` and
+   `units/1024` are indistinguishable on them. That decides whether the answer-key arithmetic
+   reaches `cjk`, `astral` and `emoji`, which are precisely the thread's non-ASCII arms.
 
 ---
+
+## Draft as first written, before the reply (kept for the record)
 
 The premise under every bracket in this thread — mine, and I think all three of the others — is
 that a session has to *derive* where its index was cut. It doesn't. **The harness states the cap

--- a/tests/results/2026-08-25-truncation-notice-probe/notice-probe.py
+++ b/tests/results/2026-08-25-truncation-notice-probe/notice-probe.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+agent-almanac #722 -- does the harness inject a truncation notice when the auto-memory index
+is over cap, at READ time, in a session that ran no Edit?
+
+THE READ-OUT IS THE WIRE, NOT THE MODEL
+---------------------------------------
+#717 established that a session's self-report about its own context is unsound in BOTH
+directions, so "ask the model whether it saw a notice" cannot answer this. Instead the
+outbound request body is captured with `tools/wirecap.py` and two arms are DIFFERENCED:
+
+    over   150 lines x 200 chars = 30,150 UTF-16 units  -> over the ~25,000 cap
+    under  100 lines x 200 chars = 20,100 UTF-16 units  -> under it
+
+`under` is a strict line-prefix of `over`, so every line of `under` also occurs in `over`.
+Lines appearing only in the `over` capture are therefore exactly: the canary lines that
+`under` does not have, plus anything the harness added because the index was cut. The
+canary lines are trivially recognisable, so whatever else is in that set IS the notice --
+and no advance guess at its wording is needed, which is the whole point of differencing
+rather than grepping.
+
+STORE PATH IS DISCOVERED, NOT COMPUTED
+--------------------------------------
+Both existing generators hand-roll the project-slug transform, whose history this repo
+records as having CHANGED (#720). This script does not guess it: it runs a throwaway session
+in the arm directory first and observes which `~/.claude/projects/` entry appears. If none
+appears, it fails closed rather than writing a fixture somewhere nothing will read it.
+
+USAGE
+-----
+    python3 notice-probe.py --build   ROOT --port PORT
+    python3 notice-probe.py --cleanup ROOT
+"""
+import argparse
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import time
+
+CANARY_WIDTH = 11           # len("CANARY-000 ")
+
+# arm      -> (lines, chars per line)
+#   over   over the SIZE cap    (30,149 units)  -- and a strict line-superset of `under`
+#   under  under both caps      (20,099 units)  -- the control
+#   lines  over the LINE cap only (6,299 units, 300 lines) -- does that path announce itself?
+ARMS = {
+    "over":  (150, 200),
+    "under": (100, 200),
+    "lines": (300,  20),
+}
+
+
+def build_index(nlines, line_chars):
+    """`nlines` lines of exactly `line_chars` code points, no trailing newline.
+
+    `under` must be a strict line-prefix of `over`, so the line text may depend only on the
+    line's own index and the width -- never on nlines."""
+    return "\n".join(
+        f"CANARY-{i:03d} " + "x" * (line_chars - CANARY_WIDTH)
+        for i in range(1, nlines + 1)
+    )
+
+
+def utf16_units(text):
+    return len(text.encode("utf-16-le")) // 2
+
+
+def projects_dir():
+    return pathlib.Path.home() / ".claude" / "projects"
+
+
+def snapshot_projects():
+    root = projects_dir()
+    return {p.name for p in root.iterdir()} if root.exists() else set()
+
+
+def discover_store(arm_dir, port, timeout=180):
+    """Run a throwaway session inside `arm_dir` and observe which projects entry appears.
+
+    Returns the discovered directory name, or None. Never computes a slug."""
+    before = snapshot_projects()
+    env = dict(os.environ)
+    env["ANTHROPIC_BASE_URL"] = f"http://127.0.0.1:{port}"
+    try:
+        subprocess.run(
+            ["claude", "-p", "--tools", "", "--strict-mcp-config"],
+            cwd=str(arm_dir), input="hi", text=True, env=env,
+            capture_output=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        pass
+    for _ in range(20):
+        new = snapshot_projects() - before
+        if new:
+            return sorted(new)[0]
+        time.sleep(0.25)
+    return None
+
+
+def build(root, port):
+    root = pathlib.Path(root).resolve()
+    manifest = {}
+    only = os.environ.get("NOTICE_PROBE_ONLY")
+    print(f"{'arm':6} {'lines':>6} {'u16':>8} {'store':>6}  path")
+    for name, (nlines, line_chars) in ARMS.items():
+        if only and name != only:
+            continue
+        arm_dir = root / name
+        arm_dir.mkdir(parents=True, exist_ok=True)
+
+        store = discover_store(arm_dir, port)
+        if store is None:
+            print(f"FAIL: no ~/.claude/projects entry appeared for {arm_dir}.", file=sys.stderr)
+            print("      Refusing to guess the slug transform (#720).", file=sys.stderr)
+            return 1
+
+        text = build_index(nlines, line_chars)
+        memdir = projects_dir() / store / "memory"
+        memdir.mkdir(parents=True, exist_ok=True)
+        target = memdir / "MEMORY.md"
+        with open(target, "wb") as fh:            # bytes: never let text mode touch line endings
+            fh.write(text.encode("utf-8"))
+
+        manifest[name] = {
+            "arm_dir": str(arm_dir), "store": store, "memory": str(target),
+            "lines": nlines, "utf16_units": utf16_units(text),
+        }
+        print(f"{name:6} {nlines:6} {utf16_units(text):8} {'ok':>6}  {target}")
+
+    # MERGE, never overwrite: a single-arm run must not drop the other arms' stores from the
+    # manifest, because cleanup refuses to delete what the manifest does not name.
+    manifest_path = root / "manifest.json"
+    if manifest_path.exists():
+        existing = json.loads(manifest_path.read_text())
+        existing.update(manifest)
+        manifest = existing
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    print(f"\nmanifest: {manifest_path} ({len(manifest)} arm(s))")
+    return 0
+
+
+def cleanup(root):
+    """Remove arm dirs and their discovered stores. FAIL-CLOSED: anything that could not be
+    removed is reported and the exit code is non-zero, because a probe fixture is
+    indistinguishable from a real memory store to anything that walks that directory."""
+    root = pathlib.Path(root).resolve()
+    manifest_path = root / "manifest.json"
+    if not manifest_path.exists():
+        print(f"FAIL: no manifest at {manifest_path}; refusing to guess what to delete.",
+              file=sys.stderr)
+        return 1
+
+    manifest = json.loads(manifest_path.read_text())
+    kept = []
+    for name, info in manifest.items():
+        store_dir = projects_dir() / info["store"]
+        for path in (store_dir, pathlib.Path(info["arm_dir"])):
+            if not path.exists():
+                print(f"  {name}: already gone: {path}")
+                continue
+            try:
+                shutil.rmtree(path)
+                print(f"  {name}: removed {path}")
+            except OSError as exc:
+                kept.append(f"{path}: {exc}")
+
+    if root.exists():
+        try:
+            shutil.rmtree(root)
+            print(f"  removed root {root}")
+        except OSError as exc:
+            kept.append(f"{root}: {exc}")
+
+    leftovers = [p.name for p in projects_dir().iterdir()
+                 if any(info["store"] == p.name for info in manifest.values())]
+    if leftovers:
+        kept.extend(f"store still present: {n}" for n in leftovers)
+
+    if kept:
+        print("\nKEPT (cleanup incomplete):", file=sys.stderr)
+        for item in kept:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+    print("\ncleanup: complete, nothing kept")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build", metavar="ROOT")
+    parser.add_argument("--cleanup", metavar="ROOT")
+    parser.add_argument("--port", type=int, default=8787)
+    args = parser.parse_args()
+
+    if args.build:
+        return build(args.build, args.port)
+    if args.cleanup:
+        return cleanup(args.cleanup)
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/results/2026-08-25-truncation-notice-probe/notice-probe.py
+++ b/tests/results/2026-08-25-truncation-notice-probe/notice-probe.py
@@ -9,8 +9,12 @@ THE READ-OUT IS THE WIRE, NOT THE MODEL
 directions, so "ask the model whether it saw a notice" cannot answer this. Instead the
 outbound request body is captured with `tools/wirecap.py` and two arms are DIFFERENCED:
 
-    over   150 lines x 200 chars = 30,150 UTF-16 units  -> over the ~25,000 cap
-    under  100 lines x 200 chars = 20,100 UTF-16 units  -> under it
+    over   150 lines x 200 chars = 30,149 UTF-16 units  -> over the ~25,000 cap
+    under  100 lines x 200 chars = 20,099 UTF-16 units  -> under it
+
+(N*201 - 1, not N*201: the generator joins with "\n" and writes NO trailing newline. An earlier
+draft of this docstring counted one that is never written, disagreeing with the registry 30 lines
+below -- the doc-vs-code drift this corpus exists to police.)
 
 `under` is a strict line-prefix of `over`, so every line of `under` also occurs in `over`.
 Lines appearing only in the `over` capture are therefore exactly: the canary lines that

--- a/tools/README.md
+++ b/tools/README.md
@@ -26,8 +26,8 @@ Everything here is dependency-free and runnable from the repository root:
 
 ```bash
 python3 tools/capgeom.py --verify             # re-derive every published figure, assert, print counts
-python3 tools/capgeom.py --selftest-negative  # mutate each recorded figure, assert --verify goes red
-python3 tools/capgeom.py --arms               # the echo/behavioural arm registry as a table
+python3 tools/capgeom.py --selftest-negative  # mutate recorded figures, assert --verify goes red
+python3 tools/capgeom.py --arms               # the ARMS registry (echo instrument) as a table
 python3 tools/capgeom.py --wire               # the wire-measured arms (#722)
 python3 tools/capgeom.py --span 170 147
 
@@ -37,10 +37,16 @@ python3 tools/wirecap.py --diff over.jsonl under.jsonl
 ```
 
 **A `--verify` nobody has watched fail is a green light of unknown wiring.** `capgeom.py
---selftest-negative` is the answer to that for this directory: it mutates each recorded figure in
+--selftest-negative` is the answer to that for this directory: it mutates a recorded figure in
 memory — never the file on disk, so there is no mutant to strand — and asserts `--verify` exits
-non-zero for every one, plus that the unmutated baseline is still green. A survivor means that
-figure is published but unchecked.
+non-zero for each, plus that the unmutated baseline is still green. A survivor means that figure
+is published but unchecked.
+
+**It covers the named mutation set, not literally every figure**, and the difference is not
+academic: three line-arm figures were published-but-unchecked until a review looked for them, and
+their mutations would have survived silently. The pre-existing `ARMS` and `BEHAVIOURAL` registries
+are outside the set too — nudging an `ARMS` width survives, since only `measured` feeds the
+reconstruction count. Add a mutation when you add a figure.
 
 ## Adding one
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -18,16 +18,29 @@ with a `--verify` mode can be re-run by anyone, including the next session.
 | Tool | Purpose |
 |---|---|
 | `capgeom.py` | Geometry and reconstruction arithmetic for auto-memory index cap probes. Holds the arm registry from `tests/results/2026-08-23-memory-cap-truncation-probe/`, derives every published bound from it, and refuses to agree with a figure that no longer follows from its recorded arm |
+| `wirecap.py` | Captures the request body a Claude Code session actually sends, by standing in as `ANTHROPIC_BASE_URL`. Answers locally — nothing is forwarded — and redacts credential headers before anything reaches disk. Use it when the question is "what is in the context?", which a session cannot be asked, because its self-report on that is unsound in both directions |
 
 ## Running
 
 Everything here is dependency-free and runnable from the repository root:
 
 ```bash
-python3 tools/capgeom.py --verify     # re-derive every published figure, assert, print counts
-python3 tools/capgeom.py --arms       # the arm registry as a table
+python3 tools/capgeom.py --verify             # re-derive every published figure, assert, print counts
+python3 tools/capgeom.py --selftest-negative  # mutate each recorded figure, assert --verify goes red
+python3 tools/capgeom.py --arms               # the echo/behavioural arm registry as a table
+python3 tools/capgeom.py --wire               # the wire-measured arms (#722)
 python3 tools/capgeom.py --span 170 147
+
+python3 tools/wirecap.py --verify                       # self-test: capture verbatim, redact secrets
+python3 tools/wirecap.py --port 8788 --out over.jsonl   # then point ANTHROPIC_BASE_URL at it
+python3 tools/wirecap.py --diff over.jsonl under.jsonl
 ```
+
+**A `--verify` nobody has watched fail is a green light of unknown wiring.** `capgeom.py
+--selftest-negative` is the answer to that for this directory: it mutates each recorded figure in
+memory — never the file on disk, so there is no mutant to strand — and asserts `--verify` exits
+non-zero for every one, plus that the unmutated baseline is still green. A survivor means that
+figure is published but unchecked.
 
 ## Adding one
 

--- a/tools/capgeom.py
+++ b/tools/capgeom.py
@@ -195,10 +195,16 @@ def notice_kb(units):
 
 
 def kb_bracket(displayed):
-    """The unit range consistent with a one-decimal KB figure.
+    """The unit range consistent with a one-decimal KB figure, ASSUMING round-half.
 
-    This is what the notice's rounding permits, and the reason the notice CANNOT sharpen the
-    cap estimate even though it names it."""
+    This is what the notice's rounding permits, and the reason the notice CANNOT sharpen the cap
+    estimate even though it names it.
+
+    The mode is ASSUMED, not measured. If the harness TRUNCATES to one decimal the range is
+    [24985.6, 25088) instead, and the single calibration point available (29.4423 -> 29.4) reads
+    the same under both. No conclusion moves: both variants contain 25,000, and both sit inside
+    [24924, 25125), the preimage of 124 under floor(./201) -- which is the only property the
+    reconstruction argument needs."""
     return ((displayed - 0.05) * 1024, (displayed + 0.05) * 1024)
 
 
@@ -320,7 +326,8 @@ def verify():
         ok = False
 
     arm_l, shown_lines, limit_lines = NOTICE_LINES
-    on_wire_l = next(w[3] for w in WIRE if w[0] == arm_l)
+    wire_l = next(w for w in WIRE if w[0] == arm_l)
+    on_wire_l = wire_l[3]
     print(f'\n  line variant states "is {shown_lines} lines (limit: {limit_lines})"; '
           f'wire cut = {on_wire_l}')
     if limit_lines != on_wire_l or limit_lines != LINE_CAP:
@@ -329,6 +336,23 @@ def verify():
     else:
         print(f'  the answer {limit_lines} was a LITERAL in that arm\'s own prompt '
               '-- nothing to reconstruct')
+
+    # Three figures on the line arm were PRINTED and never asserted, so mutating them survived
+    # (#724 review). A published-but-unchecked figure is the thing this file exists to prevent.
+    #
+    #   - the notice's stated line count must equal the fixture's line count;
+    #   - the fixture must be UNDER the size cap, or the arm does not isolate the line cap and
+    #     its registry comment ("over the LINE cap only") is false;
+    #   - and its width must therefore be small enough for the clamp to bind.
+    if shown_lines != wire_l[2]:
+        print(f'  *** notice says {shown_lines} lines, fixture has {wire_l[2]} ***')
+        ok = False
+    size_of_line_arm = int(wire_l[2] * wire_l[1]) - 1
+    print(f'  fixture size {size_of_line_arm} units vs cap {DOCUMENTED_CAP}: '
+          f'{"under -- line cap isolated" if size_of_line_arm < DOCUMENTED_CAP else "OVER"}')
+    if size_of_line_arm >= DOCUMENTED_CAP:
+        print('  *** the line arm must be UNDER the size cap, or it isolates nothing ***')
+        ok = False
 
     print('\nOK' if ok else '\nFAILED')
     return 0 if ok else 1
@@ -350,11 +374,26 @@ MUTATIONS = [
     ('notice size 29.4->29.5',        'NOTICE_SIZE',  lambda: ('over 150x200', 29.5, 24.4)),
     ('notice limit 24.4->24.5',       'NOTICE_SIZE',  lambda: ('over 150x200', 29.4, 24.5)),
     ('notice line limit 200->150',    'NOTICE_LINES', lambda: ('lines 300x20', 300, 150)),
+    # The three that SURVIVED before the #724 review, now covered.
+    ('notice shown lines 300->301',   'NOTICE_LINES', lambda: ('lines 300x20', 301, 200)),
+    ('WIRE lines fixture 300->301',   'WIRE',         lambda: _swap_wire_field('lines 300x20', 2, 301)),
+    ('WIRE lines u/l 21->200 (over)', 'WIRE',         lambda: _swap_wire_field('lines 300x20', 1, 200.0)),
 ]
 
 
 def _swap_wire(label, on_wire):
-    return [(w[0], w[1], w[2], on_wire if w[0] == label else w[3], w[4]) for w in WIRE]
+    return _swap_wire_field(label, 3, on_wire)
+
+
+def _swap_wire_field(label, index, value):
+    """Replace one field of one WIRE row. `index` is a position in
+    (label, units_per_line, fixture_lines, on_wire, build)."""
+    out = []
+    for row in WIRE:
+        if row[0] == label:
+            row = tuple(value if i == index else v for i, v in enumerate(row))
+        out.append(row)
+    return out
 
 
 def selftest_negative():

--- a/tools/capgeom.py
+++ b/tools/capgeom.py
@@ -168,6 +168,45 @@ BRACKET_PROVENANCE = {
 }
 
 
+# ── #722: the harness states the cap in the prompt ────────────────────────────
+# A third instrument, added 2026-08-25. `echo` and `behavioural` both read the MODEL; `wire`
+# reads the request body the client actually sent, captured with tools/wirecap.py. The
+# reconstruction ruler does not apply to it -- bytes that were sent cannot be confused with
+# bytes that were computed -- so these arms need no `informative` accounting.
+#
+# (label, units_per_line, fixture_lines, highest_line_on_the_wire, build)
+WIRE = [
+    ('under 100x200', 201.0, 100, 100, '2.1.245'),   # complete: no cut, no notice
+    ('over 150x200',  201.0, 150, 124, '2.1.245'),   # size cut  + size notice
+    ('lines 300x20',   21.0, 300, 200, '2.1.245'),   # line cut  + line notice
+]
+
+# The notice the harness appends inside the memory <system-reminder> when it truncates. Recorded
+# because its NUMBERS are the finding: it states the cap, so a model never needs documentation.
+NOTICE_SIZE = ('over 150x200', 29.4, 24.4)   # (arm, "MEMORY.md is X KB", "(limit: Y KB)")
+NOTICE_LINES = ('lines 300x20', 300, 200)    # (arm, "MEMORY.md is N lines", "(limit: M)")
+
+
+def notice_kb(units):
+    """The KB figure the notice displays for an index of `units` UTF-16 units.
+
+    Divisor is 1024, not 1000: the 30,149-unit fixture displayed 29.4, and 30149/1000 = 30.1."""
+    return round(units / 1024, 1)
+
+
+def kb_bracket(displayed):
+    """The unit range consistent with a one-decimal KB figure.
+
+    This is what the notice's rounding permits, and the reason the notice CANNOT sharpen the
+    cap estimate even though it names it."""
+    return ((displayed - 0.05) * 1024, (displayed + 0.05) * 1024)
+
+
+def cut_from_notice(displayed_limit_kb, units_per_line):
+    """What a model computes from the notice alone: it is TOLD the cap and can SEE the width."""
+    return int(displayed_limit_kb * 1024 // units_per_line)
+
+
 # ── verification ──────────────────────────────────────────────────────────────
 
 def verify():
@@ -225,16 +264,148 @@ def verify():
         print('  UNEXPECTED: these overlap; neither contains the other')
         ok = False
 
+    print('\n=== wire arms: the cut read from the request body, not from an answer ===\n')
+    for label, upl, fixture_lines, on_wire, build in WIRE:
+        pred = reconstructed_cut(upl)
+        cut = on_wire < fixture_lines
+        expected = pred if cut else fixture_lines
+        flag = 'OK' if on_wire == expected else f'*** MISMATCH: expected {expected} ***'
+        print(f"  {label:16} {fixture_lines:3d} lines -> {on_wire:3d} on the wire  "
+              f"({'cut' if cut else 'complete'})  {flag}  [{build}]")
+        if on_wire != expected:
+            ok = False
+
+    print('\n=== the notice states the cap, so reconstruction needs no documentation ===\n')
+    arm, shown_kb, limit_kb = NOTICE_SIZE
+    upl = next(w[1] for w in WIRE if w[0] == arm)
+    fixture_units = int(next(w[2] for w in WIRE if w[0] == arm) * upl) - 1
+    measured_cut = next(w[3] for w in WIRE if w[0] == arm)
+
+    if notice_kb(fixture_units) != shown_kb:
+        print(f'  *** notice_kb({fixture_units}) = {notice_kb(fixture_units)}, '
+              f'notice showed {shown_kb} ***')
+        ok = False
+    else:
+        print(f'  notice_kb({fixture_units} units) = {shown_kb}  '
+              f'-- matches the captured string, so the divisor is 1024')
+
+    if notice_kb(DOCUMENTED_CAP) != limit_kb:
+        print(f'  *** notice_kb({DOCUMENTED_CAP}) = {notice_kb(DOCUMENTED_CAP)}, '
+              f'notice showed limit {limit_kb} ***')
+        ok = False
+    else:
+        print(f'  notice_kb({DOCUMENTED_CAP}) = {limit_kb}  '
+              f'-- the stated limit is consistent with the documented cap')
+
+    told = cut_from_notice(limit_kb, upl)
+    flag = 'OK' if told == measured_cut else f'*** derives {told}, measured {measured_cut} ***'
+    print(f'  a model TOLD "limit: {limit_kb}KB" and SEEING {upl:.0f}-unit lines computes '
+          f'floor({limit_kb}*1024/{upl:.0f}) = {told}   {flag}')
+    if told != measured_cut:
+        ok = False
+
+    nb = kb_bracket(limit_kb)
+    print(f'\n  the notice brackets the cap to [{nb[0]:.1f}, {nb[1]:.1f})  '
+          f'{nb[1]-nb[0]:.1f} units wide')
+    print(f'  sound behavioural bracket      [{sound[0]}, {sound[1]})  '
+          f'{sound[1]-sound[0]} units wide')
+    print(f'  contains {DOCUMENTED_CAP}? {nb[0] <= DOCUMENTED_CAP < nb[1]}   '
+          f'contains the behavioural bracket? {nb[0] <= sound[0] and sound[1] <= nb[1]}')
+    # The notice names the cap but rounds it, so it must NOT be quoted as sharpening the
+    # estimate. Pin that as an assertion, because "the harness told us the cap" is exactly the
+    # sentence that invites treating it as a measurement.
+    if (nb[1] - nb[0]) <= (sound[1] - sound[0]):
+        print('  UNEXPECTED: the notice bracket should be WIDER -- it names the cap but '
+              'rounds it, and is not an independent behavioural measurement')
+        ok = False
+
+    arm_l, shown_lines, limit_lines = NOTICE_LINES
+    on_wire_l = next(w[3] for w in WIRE if w[0] == arm_l)
+    print(f'\n  line variant states "is {shown_lines} lines (limit: {limit_lines})"; '
+          f'wire cut = {on_wire_l}')
+    if limit_lines != on_wire_l or limit_lines != LINE_CAP:
+        print('  *** the line notice should state the line cap verbatim ***')
+        ok = False
+    else:
+        print(f'  the answer {limit_lines} was a LITERAL in that arm\'s own prompt '
+              '-- nothing to reconstruct')
+
     print('\nOK' if ok else '\nFAILED')
     return 0 if ok else 1
+
+
+# ── negative evidence ─────────────────────────────────────────────────────────
+# A --verify that has never been seen to FAIL is a green light of unknown wiring. This repo's
+# standing rule (CLAUDE.md, "Proving a Gate Can Fail") is to break the subject and watch the
+# check go red before trusting it. These mutations are applied to the module's own registries
+# in memory -- the file on disk is never touched, so there is no mutant to strand and no backup
+# to lose.
+#
+# Each entry names a recorded figure and a wrong value for it. Every one MUST make verify()
+# exit non-zero; a survivor means that figure is published but unchecked.
+MUTATIONS = [
+    ('WIRE over cut 124->125',        'WIRE',         lambda: _swap_wire('over 150x200', 125)),
+    ('WIRE lines cut 200->199',       'WIRE',         lambda: _swap_wire('lines 300x20', 199)),
+    ('WIRE under 100->99 (a cut)',    'WIRE',         lambda: _swap_wire('under 100x200', 99)),
+    ('notice size 29.4->29.5',        'NOTICE_SIZE',  lambda: ('over 150x200', 29.5, 24.4)),
+    ('notice limit 24.4->24.5',       'NOTICE_SIZE',  lambda: ('over 150x200', 29.4, 24.5)),
+    ('notice line limit 200->150',    'NOTICE_LINES', lambda: ('lines 300x20', 300, 150)),
+]
+
+
+def _swap_wire(label, on_wire):
+    return [(w[0], w[1], w[2], on_wire if w[0] == label else w[3], w[4]) for w in WIRE]
+
+
+def selftest_negative():
+    """Mutate each recorded figure and assert verify() goes red."""
+    import contextlib
+    import io
+
+    globals_ = globals()
+    survivors = []
+    print('=== negative evidence: each recorded figure, mutated ===\n')
+    for name, target, make in MUTATIONS:
+        original = globals_[target]
+        globals_[target] = make()
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                code = verify()
+        finally:
+            globals_[target] = original
+        killed = code != 0
+        print(f"  {name:32} -> {'KILLED (verify went red)' if killed else '*** SURVIVED ***'}")
+        if not killed:
+            survivors.append(name)
+
+    # And the baseline must still be green, or every kill above is meaningless.
+    with contextlib.redirect_stdout(io.StringIO()):
+        baseline = verify()
+    print(f"\n  baseline (unmutated) -> {'green' if baseline == 0 else '*** RED ***'}")
+    if baseline != 0:
+        survivors.append('baseline is not green -- kills above prove nothing')
+
+    if survivors:
+        print(f'\nFAILED: {len(survivors)} unchecked figure(s)')
+        for item in survivors:
+            print(f'  {item}')
+        return 1
+    print(f'\nOK -- {len(MUTATIONS)} of {len(MUTATIONS)} mutations killed')
+    return 0
 
 
 def main():
     a = sys.argv[1:]
     if not a or a[0] == '--verify':
         return verify()
+    if a[0] == '--selftest-negative':
+        return selftest_negative()
     if a[0] == '--arms':
         for row in ARMS:
+            print('\t'.join(str(x) for x in row))
+        return 0
+    if a[0] == '--wire':
+        for row in WIRE:
             print('\t'.join(str(x) for x in row))
         return 0
     if a[0] == '--span':

--- a/tools/wirecap.py
+++ b/tools/wirecap.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+Capture the request body a Claude Code session actually sends, without asking the model
+anything about itself.
+
+WHY THIS EXISTS
+---------------
+The auto-memory cap work (agent-almanac #407, #717, #722) established that a session's
+self-report about its own context is unsound in BOTH directions -- it returned `NONE` for an
+index that behavioural probing proved had loaded, and elsewhere volunteered an accurate
+"truncated on load". A failure with no consistent sign cannot be corrected for, so any
+question of the form "is X present in the context?" must be answered by reading the wire,
+never by asking the model.
+
+This is the cheapest channel from `skills/conduct-empirical-wire-capture` Step 1 that
+captures a request body: point `ANTHROPIC_BASE_URL` at this server, and it records the
+whole POST body to a JSONL file and answers with a canned, well-formed SSE reply so the
+client exits cleanly instead of retrying.
+
+The captured body is the ENTIRE context the client assembled -- system prompt, injected
+memory index, hook attachments, the lot. Differencing two captures that vary in exactly one
+input is therefore a controlled read-out that needs no advance guess at what string to grep
+for.
+
+SCOPE AND ETHICS
+----------------
+Per `skills/conduct-empirical-wire-capture`: this captures YOUR OWN requests, from YOUR OWN
+machine, against YOUR OWN account. Credential headers are redacted AT CAPTURE TIME -- they
+are never written to disk, not even once. The request is answered locally and is NOT
+forwarded anywhere, so nothing leaves the machine at all.
+
+USAGE
+-----
+    python3 tools/wirecap.py --port 8787 --out capture.jsonl     # run the server
+    python3 tools/wirecap.py --verify                            # self-test, exit non-zero on failure
+
+    # in another shell
+    ANTHROPIC_BASE_URL=http://127.0.0.1:8787 \
+      printf '%s' 'hello' | claude -p --tools "" --strict-mcp-config
+
+Then difference two captures:
+
+    python3 tools/wirecap.py --diff over.jsonl under.jsonl
+"""
+import argparse
+import http.server
+import json
+import os
+import socket
+import sys
+import threading
+import time
+import urllib.request
+
+# Headers whose values are secrets. Redacted before anything is written to disk.
+SECRET_HEADERS = {
+    "authorization",
+    "x-api-key",
+    "anthropic-auth-token",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+}
+REDACTED = "<redacted-at-capture-time>"
+
+# A minimal well-formed streaming reply. The client only has to be able to parse this and
+# exit; the content is irrelevant to the measurement.
+SSE_EVENTS = [
+    ("message_start", {
+        "type": "message_start",
+        "message": {
+            "id": "msg_wirecap", "type": "message", "role": "assistant",
+            "model": "claude-wirecap", "content": [],
+            "stop_reason": None, "stop_sequence": None,
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        },
+    }),
+    ("content_block_start", {
+        "type": "content_block_start", "index": 0,
+        "content_block": {"type": "text", "text": ""},
+    }),
+    ("content_block_delta", {
+        "type": "content_block_delta", "index": 0,
+        "delta": {"type": "text_delta", "text": "WIRECAP"},
+    }),
+    ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+    ("message_delta", {
+        "type": "message_delta",
+        "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+        "usage": {"output_tokens": 1},
+    }),
+    ("message_stop", {"type": "message_stop"}),
+]
+
+
+def redact_headers(raw_items):
+    """Drop secret header VALUES before they can reach disk. Names are kept -- knowing that
+    an `authorization` header was present is useful and is not itself a secret."""
+    out = {}
+    for name, value in raw_items:
+        out[name.lower()] = REDACTED if name.lower() in SECRET_HEADERS else value
+    return out
+
+
+def make_handler(out_path, counter):
+    class Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, *_args):
+            pass  # the JSONL file is the log
+
+        def _record(self, body_bytes):
+            counter["n"] += 1
+            try:
+                body = json.loads(body_bytes.decode("utf-8"))
+                parsed = True
+            except Exception:
+                body = body_bytes.decode("utf-8", "replace")
+                parsed = False
+            record = {
+                "seq": counter["n"],
+                "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "method": self.command,
+                "path": self.path,
+                "headers": redact_headers(self.headers.items()),
+                "body_bytes": len(body_bytes),
+                "body_parsed": parsed,
+                "body": body,
+            }
+            with open(out_path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+        def _read_body(self):
+            length = int(self.headers.get("content-length") or 0)
+            return self.rfile.read(length) if length else b""
+
+        def do_POST(self):
+            body_bytes = self._read_body()
+            self._record(body_bytes)
+
+            if self.path.rstrip("/").endswith("count_tokens"):
+                payload = json.dumps({"input_tokens": 1}).encode()
+                self.send_response(200)
+                self.send_header("content-type", "application/json")
+                self.send_header("content-length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+                return
+
+            chunks = []
+            for name, data in SSE_EVENTS:
+                chunks.append(
+                    f"event: {name}\ndata: {json.dumps(data)}\n\n".encode("utf-8")
+                )
+            payload = b"".join(chunks)
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("cache-control", "no-cache")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self):
+            self._record(b"")
+            payload = b"{}"
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    return Handler
+
+
+def serve(port, out_path, ready=None):
+    counter = {"n": 0}
+    server = http.server.ThreadingHTTPServer(
+        ("127.0.0.1", port), make_handler(out_path, counter)
+    )
+    if ready is not None:
+        ready(server)
+    server.serve_forever()
+
+
+def free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def load(path):
+    with open(path, encoding="utf-8") as fh:
+        return [json.loads(line) for line in fh if line.strip()]
+
+
+def texts_of(record):
+    """Every string the client put in this request, flattened, with a path label.
+
+    A truncation notice could arrive as a system block, a user block, a hook attachment or a
+    bare string, and the point of a differential capture is not to know in advance. So walk
+    the whole body rather than the fields we happen to expect."""
+    found = []
+
+    def walk(node, path):
+        if isinstance(node, str):
+            found.append((path, node))
+        elif isinstance(node, dict):
+            for key, value in node.items():
+                walk(value, f"{path}.{key}")
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                walk(value, f"{path}[{index}]")
+
+    walk(record.get("body"), "body")
+    return found
+
+
+def diff(path_a, path_b):
+    """Strings present in A and absent from B, and vice versa.
+
+    Compared as whole strings AND as lines, because a notice injected into an existing block
+    changes that block's text wholesale while adding only one line."""
+    recs_a, recs_b = load(path_a), load(path_b)
+
+    def lines_of(recs):
+        out = set()
+        for rec in recs:
+            for _path, text in texts_of(rec):
+                for line in text.splitlines():
+                    if line.strip():
+                        out.add(line.rstrip())
+        return out
+
+    lines_a, lines_b = lines_of(recs_a), lines_of(recs_b)
+    only_a = sorted(lines_a - lines_b)
+    only_b = sorted(lines_b - lines_a)
+
+    print(f"A = {path_a}  ({len(recs_a)} request(s), {len(lines_a)} distinct lines)")
+    print(f"B = {path_b}  ({len(recs_b)} request(s), {len(lines_b)} distinct lines)")
+    print(f"\n--- lines only in A ({len(only_a)}) ---")
+    for line in only_a:
+        print(f"  A| {line[:400]}")
+    print(f"\n--- lines only in B ({len(only_b)}) ---")
+    for line in only_b:
+        print(f"  B| {line[:400]}")
+    return only_a, only_b
+
+
+def verify():
+    """Self-test: does this tool capture a body verbatim, and does it refuse to write a
+    credential to disk? Both are properties the measurement depends on."""
+    failures = []
+    port = free_port()
+    out_path = os.path.join(
+        os.environ.get("TMPDIR", "/tmp"), f"wirecap-verify-{port}.jsonl"
+    )
+    if os.path.exists(out_path):
+        os.remove(out_path)
+
+    holder = {}
+    thread = threading.Thread(
+        target=serve, args=(port, out_path, lambda srv: holder.setdefault("srv", srv)),
+        daemon=True,
+    )
+    thread.start()
+    for _ in range(100):
+        if "srv" in holder:
+            break
+        time.sleep(0.02)
+    if "srv" not in holder:
+        print("FAIL: server did not start")
+        return 1
+
+    secret = "sk-ant-THIS-MUST-NOT-REACH-DISK"
+    needle = "PINEAPPLE-QUASAR-7731"
+    payload = json.dumps({
+        "model": "m", "stream": True,
+        "system": [{"type": "text", "text": f"marker {needle}"}],
+        "messages": [{"role": "user", "content": "hi"}],
+    }).encode()
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/v1/messages",
+        data=payload,
+        headers={
+            "content-type": "application/json",
+            "authorization": f"Bearer {secret}",
+            "x-api-key": secret,
+            "user-agent": "wirecap-verify",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        body = response.read().decode()
+    holder["srv"].shutdown()
+
+    if "message_stop" not in body:
+        failures.append("canned SSE reply did not contain message_stop")
+
+    raw = open(out_path, encoding="utf-8").read()
+
+    # 1. The body must be captured verbatim.
+    if needle not in raw:
+        failures.append("captured file does not contain the planted body needle")
+
+    # 2. A credential must never be written, not once, in any header.
+    if secret in raw:
+        failures.append("SECRET LEAKED TO DISK -- redaction failed")
+
+    records = load(out_path)
+    if len(records) != 1:
+        failures.append(f"expected 1 captured record, got {len(records)}")
+    else:
+        rec = records[0]
+        if rec["headers"].get("authorization") != REDACTED:
+            failures.append("authorization header was not redacted")
+        if rec["headers"].get("x-api-key") != REDACTED:
+            failures.append("x-api-key header was not redacted")
+        if rec["headers"].get("user-agent") != "wirecap-verify":
+            failures.append("a non-secret header was lost")
+        if not rec["body_parsed"]:
+            failures.append("JSON body was not parsed")
+        flat = dict(texts_of(rec))
+        if not any(needle in text for text in flat.values()):
+            failures.append("texts_of() did not surface the planted needle")
+
+    # 3. diff() must report an added line and must not invent one.
+    other = out_path + ".other"
+    with open(other, "w", encoding="utf-8") as fh:
+        rec = json.loads(raw.splitlines()[0])
+        rec["body"]["system"][0]["text"] = "marker"
+        fh.write(json.dumps(rec) + "\n")
+    only_a, only_b = diff(out_path, other)
+    if not any(needle in line for line in only_a):
+        failures.append("diff() failed to report a line present only in A")
+    if only_b != ["marker"]:
+        failures.append(f"diff() B-side wrong: {only_b}")
+
+    os.remove(out_path)
+    os.remove(other)
+
+    print()
+    if failures:
+        for item in failures:
+            print(f"FAIL: {item}")
+        return 1
+    print("wirecap --verify: OK (capture verbatim, credentials redacted, diff reports both sides)")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8787)
+    parser.add_argument("--out", default="capture.jsonl")
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument("--diff", nargs=2, metavar=("A", "B"))
+    args = parser.parse_args()
+
+    if args.verify:
+        return verify()
+    if args.diff:
+        diff(*args.diff)
+        return 0
+
+    print(f"wirecap listening on http://127.0.0.1:{args.port} -> {args.out}", flush=True)
+    serve(args.port, args.out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #722.

## Hypothesis

The #717 downgrade rests on a premise nobody tested: that a model must **derive** where its memory index was cut. If the harness instead injects a truncation notice, the boundary is simply *told*, reconstruction is far cheaper than the addendum claims, and the confound is worse.

## Finding: it is told

A wire capture of the outbound request body — not a question put to the model — shows the harness appending one of two notices **inside the same `<system-reminder>` as the index**, at read time, in a session with no file tools and no `Edit`:

```
> WARNING: MEMORY.md is 29.4KB (limit: 24.4KB) — index entries are too long. Only part of it was loaded. …
> WARNING: MEMORY.md is 300 lines (limit: 200). Only part of it was loaded. …
```

Present in the over-cap arm, **absent from the under-cap control**, reproduced across two runs with different prompts.

So every over-cap arm in the 2026-08-23 corpus carried its own answer key — the cap stated in the notice, the width visible in the index:

```
floor(24.4 × 1024 / 201) = 124        # what a model TOLD the limit computes
lines 1..124 of 150 on the wire       # what was actually sent
```

`lines300` is starker: its notice reads `(limit: 200)` and the answer is `200`, a literal in its own prompt.

## Why the instrument is sound

Self-report on this question is established unsound in **both** directions, so nothing here asks the model anything. `tools/wirecap.py` stands in as `ANTHROPIC_BASE_URL`, records the POST body, answers locally. Nothing is forwarded; credential headers are redacted before anything reaches disk (`--verify` plants a secret and asserts it never lands).

Reading bytes that were *sent* cannot be confused with bytes that were *computed*, so the reconstruction ruler does not apply to this instrument at all.

## Also measured

The cut is whole-line at `floor(cap/units-per-line)` clamped by the 200-line cap — **read from the wire**, the first non-behavioural confirmation in this corpus. It agrees with the behavioural arms exactly, which is a point in the earlier run's favour: the instrument was confounded, not wrong.

## Two corrections, annotated in place

- **`--tools ""` is not tool-zero.** One server-side tool survives it (`advisor`, `advisor_20260301`, enabled by `advisorModel` in `settings.json`). Benign here — the read-out is the wire, and `advisor` cannot read a file off disk — but the 2026-08-23 method section stated it flatly and it is machine-dependent.
- **The slug transform maps `.` → `-`.** `memcap-fixture.py`'s hand-rolled `slug()` does not implement that. This probe *discovers* the store instead of computing it; a computed path would have written all three fixtures where nothing reads them and reported no index at all. Concrete support for #720, found by following it.

## Negative evidence

`capgeom.py` gains the wire arms and the notice arithmetic so every figure is re-derived rather than quoted, plus `--selftest-negative`, which mutates each recorded figure **in memory** — no mutant on disk to strand — and asserts `--verify` goes red:

```
6 of 6 mutations killed, baseline green
```

## Not in this PR

- **The raw captures.** The request body is the whole assembled context, including `device_id`, `account_uuid`, `session_id` and the operator's email. That is what makes the instrument useful and what makes it unpublishable. Only the notice strings and canary counts are committed.
- **The upstream comment.** Drafted at `tests/results/2026-08-25-truncation-notice-probe/UPSTREAM-DRAFT.md`, deliberately **not posted** — three other parties' brackets rest on this premise, and posting is the operator's call.

## What this does not claim

One build (2.1.245), one platform (WSL2/Ubuntu, linux-x64). Nothing about whether the model *attends* to the notice — presence in context is not use, and that remains unanswerable by asking. No improvement to the cap bracket: `24.4KB` rounds to a 102-unit window, four times wider than the behavioural `[24999, 25023)`, and is the harness describing its own constant rather than a measurement.

## Gates

`line-endings`, `integrity`, `scripts-test` (670 pass), `cli-test` (115 pass, 2 skipped), `check-readmes`, `ratchet`, `content-style --added` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yKCWG7uvJezdapqRMc2Wf
