### PR TITLE
fix(i18n): pin the untagged-fence assumption and the tie-break (#629, #630)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -175,6 +175,29 @@ jobs:
       - name: Check i18n code-fence parity (warn only until #477)
         run: node scripts/check-i18n-fence-parity.js --warn
 
+      # #629. BLOCKING, unlike the two warn-only gates below it, and the difference is that this
+      # one shipped on a clean corpus: 558 English content files, 0 untagged openers, templates
+      # included. A gate that ships clean can block; one that ships dirty needs a ratchet first.
+      #
+      # What it protects: `foldedTagSequence` folds an untagged English fence to `text`. Under
+      # default-deny an untagged fence is FROZEN, so the fold means a translation may replace an
+      # untagged English fence with a localised ```text one and produce an IDENTICAL folded
+      # sequence -- no tag-sequence finding, no tag-drift finding, and the body check skips it
+      # because gating is read off the translated file. That is the #481 escape surviving through
+      # the check built to close it.
+      #
+      # The fold is not the bug and must stay (removing it makes every untagged-vs-`text` pairing
+      # from `normalize-content-style.js --mode fences` read as a retag -- the false-positive
+      # class that stranded 169 repairable fences across 73 files). The bug is that the fold's
+      # safety rested on a REMEMBERED measurement in a comment. This is that measurement, checked.
+      #
+      # It lives in this workflow, not validate-content-style.yml, because that workflow is
+      # path-filtered and a path-filtered workflow cannot be a required check -- it does not
+      # report outside its filter, so a required context would sit on "Expected" forever. This
+      # job is one of the five required contexts and carries no `paths:`.
+      - name: Check for untagged code fences in the English trees (#629)
+        run: npm run validate:untagged-fences
+
       # Node-set parity between the viz PUT annotations and the committed
       # `viz/public/data/workflow.mmd` (#590, dependency-free slice).
       #

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "normalize:i18n-fences": "node scripts/normalize-i18n-fences.js",
     "backfill:fence-basis": "node scripts/backfill-fence-basis.js",
     "validate:content-style": "node scripts/check-content-style.js --all",
+    "validate:untagged-fences": "node scripts/check-content-style.js --untagged-strict",
     "validate:line-endings": "node scripts/check-line-endings.js",
     "validate:skill-sections": "node scripts/audit-skill-sections.js --missing",
     "validate:locales-json": "node scripts/validate-locales-json.js",

--- a/scripts/check-content-style.js
+++ b/scripts/check-content-style.js
@@ -7,6 +7,8 @@
 //                       Decorative-dash table separators AND untagged opening code
 //                       fences on added lines FAIL (exit 1).
 //   --all               Repo-wide informational scan. Always exits 0 (warn-only).
+//   --untagged-strict   Repo-wide, ENGLISH trees only, untagged openers only. FAILS
+//                       on any, not merely on added lines (#629).
 //
 // Detection is fence-aware: every file is parsed with code-fence state so that
 // (a) separators inside code blocks are ignored, and (b) closing fences are never
@@ -17,9 +19,25 @@ import { readFileSync, existsSync } from "node:fs";
 
 const CONTENT_GLOBS = ["skills/", "agents/", "teams/", "guides/", "i18n/"];
 
+// English only. `i18n/` is deliberately absent: an untagged fence in a TRANSLATION is a
+// translation defect owned by check-i18n-fence-parity.js, and #629 is about a property of
+// English -- specifically, that `foldedTagSequence` folds an untagged English fence to `text`,
+// so a translation may replace it with a localised ```text one and produce an identical folded
+// sequence. That escape is only reachable if an untagged English opener exists at all.
+const ENGLISH_TREES = ["skills/", "agents/", "teams/", "guides/"];
+
 function isContentFile(p) {
   if (!CONTENT_GLOBS.some((g) => p.startsWith(g))) return false;
   if (p.includes("/_template")) return false; // templates are author scaffolding
+  return p.endsWith(".md");
+}
+
+// NOT `isContentFile` with a different prefix list. Templates are INCLUDED here, because #629
+// asks for "an untagged fence opener anywhere in skills/, agents/, teams/, guides/" and a
+// template lives in those trees. Measured safe at introduction: 0 untagged openers in templates,
+// so including them costs nothing and removes a carve-out that would have to be remembered.
+function isEnglishContentFile(p) {
+  if (!ENGLISH_TREES.some((g) => p.startsWith(g))) return false;
   return p.endsWith(".md");
 }
 
@@ -158,12 +176,63 @@ function runAll() {
   console.log("Normalization is tracked separately; see guides/content-styleguide.md.");
 }
 
+// #629. Blocking, repo-wide, English only, untagged openers only.
+//
+// Why not just make `--all` blocking: `runAll` also counts decorative separators, a class with
+// 11 live members, so flipping it would redden every PR for a different debt. Why not rely on
+// `--added`: it fails only for an opener on a line the diff marks as added, which misses the
+// case where a fence BECOMES an opener because a preceding fence's parity flipped -- no line of
+// its own was touched, so there is no added line to catch. That is the #628 shape.
+//
+// This ships blocking rather than warn-only because the corpus was measured at zero when the
+// gate was introduced: 558 English .md files, 0 untagged openers, templates included. A gate
+// that ships clean can block; one that ships dirty needs a ratchet.
+function runUntaggedStrict() {
+  const out = execSync(`git ls-files ${ENGLISH_TREES.join(" ")}`, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  const files = out.split("\n").filter(isEnglishContentFile);
+
+  // A scan that matched no files would report "0 violations" and mean nothing -- the vacuous
+  // pass this repo has shipped before. Refuse rather than report a clean-looking zero.
+  if (files.length === 0) {
+    console.error("FAIL: no English content files matched; the scan would be vacuous.");
+    process.exit(2);
+  }
+
+  const errors = [];
+  for (const file of files) {
+    if (!existsSync(file)) continue;
+    const { untaggedOpeners } = scanFile(readFileSync(file, "utf8"));
+    for (const ln of untaggedOpeners) errors.push(`${file}:${ln}`);
+  }
+
+  if (errors.length) {
+    for (const e of errors) console.log(`FAIL  ${e}  untagged code fence (add a language tag)`);
+    console.log(
+      `\n${errors.length} untagged fence opener(s) in the English trees.\n` +
+        "An untagged English fence folds to `text`, so a translation may replace it with a\n" +
+        "localised ```text fence and produce an identical folded tag sequence -- the #481 escape,\n" +
+        "invisible to every gate. Tag the English source. See guides/content-styleguide.md.",
+    );
+    process.exit(1);
+  }
+  console.log(
+    `Untagged-fence gate: 0 untagged openers across ${files.length} English content file(s).`,
+  );
+}
+
 const [, , mode, arg] = process.argv;
 if (mode === "--added") {
   runAdded(arg || "origin/main");
 } else if (mode === "--all") {
   runAll();
+} else if (mode === "--untagged-strict") {
+  runUntaggedStrict();
 } else {
-  console.error("usage: check-content-style.js --added <baseRef> | --all");
+  console.error(
+    "usage: check-content-style.js --added <baseRef> | --all | --untagged-strict",
+  );
   process.exit(2);
 }

--- a/scripts/check-content-style.js
+++ b/scripts/check-content-style.js
@@ -16,6 +16,9 @@
 
 import { execSync } from "node:child_process";
 import { readFileSync, existsSync } from "node:fs";
+// The shared extractor, so `--untagged-strict` cannot drift from the fold it protects (#629).
+// Node builtins and local libs only — no package dependency is added to this script.
+import { extractFences } from "./lib/fences.js";
 
 const CONTENT_GLOBS = ["skills/", "agents/", "teams/", "guides/", "i18n/"];
 
@@ -202,10 +205,31 @@ function runUntaggedStrict() {
   }
 
   const errors = [];
+  let scanned = 0;
   for (const file of files) {
-    if (!existsSync(file)) continue;
-    const { untaggedOpeners } = scanFile(readFileSync(file, "utf8"));
-    for (const ln of untaggedOpeners) errors.push(`${file}:${ln}`);
+    // Was `if (!existsSync(file)) continue;`, copied from the informational `runAll`. In a
+    // BLOCKING gate a silent skip is the green-over-nothing shape this repo bans -- and the
+    // success line counted `files.length`, so a skipped file would still have read as covered.
+    // Refuse instead: git named it, so it should be readable.
+    let text;
+    try {
+      text = readFileSync(file, "utf8");
+    } catch (err) {
+      console.error(`FAIL: ${file} is listed by git but unreadable (${err.code}).`);
+      console.error("A blocking gate must not silently skip its own subject.");
+      process.exit(2);
+    }
+    scanned++;
+    // `extractFences`, NOT this file's local `scanFile`. The escape #629 protects against is
+    // defined by `foldedTagSequence`, which folds an untagged fence to `text` -- and an untagged
+    // fence is exactly `info === ''` in the shared extractor. Detecting openers with a second
+    // state machine would make this gate a THIRD fence parser, against the repo's own doctrine
+    // ("A second copy would drift"), and that copy already had a divergence to show for it: the
+    // local FENCE_RE uses `(.*)$` and normalises only CRLF, where `toLines` also normalises a
+    // lone CR -- so a committed lone-CR file yields openers the fold sees and the gate did not.
+    for (const fence of extractFences(text)) {
+      if (fence.info === "") errors.push(`${file}:${fence.line}`);
+    }
   }
 
   if (errors.length) {
@@ -219,7 +243,9 @@ function runUntaggedStrict() {
     process.exit(1);
   }
   console.log(
-    `Untagged-fence gate: 0 untagged openers across ${files.length} English content file(s).`,
+    // `scanned`, not `files.length`: the two are equal only because nothing was skipped, and
+    // reporting the list size would have claimed coverage a skip did not deliver.
+    `Untagged-fence gate: 0 untagged openers across ${scanned} English content file(s).`,
   );
 }
 

--- a/scripts/envelopes/untagged-fence-gate.mjs
+++ b/scripts/envelopes/untagged-fence-gate.mjs
@@ -1,0 +1,78 @@
+/**
+ * Envelope for the untagged-fence gate (#629) — does it actually go red, and on exactly the
+ * corpus it claims?
+ *
+ * A gate that has only ever been seen GREEN is a green light of unknown wiring, and this one
+ * ships blocking in a required job, so the cost of it being dead is a merge that should have
+ * been refused. `scripts/check-content-style.js` already had a fence-aware scanner and reported
+ * `untagged code fences: 0 across 0 files` for months — as INFORMATION, from a mode that never
+ * exits non-zero. The whole change is that a finding now fails, so "it fails" is the claim that
+ * needs evidence.
+ *
+ * The gate here is `npm run validate:untagged-fences`, the exact command
+ * `.github/workflows/validate-skills.yml` runs — not the inner script. A mutation that dies
+ * against `node scripts/check-content-style.js` but survives the npm indirection would otherwise
+ * pass unnoticed, which is the wiring failure this repo has shipped before.
+ *
+ * Every case mutates a real tracked file against the real corpus. The mutation is always the
+ * same shape — strip a fence's info string — because that is the only way an untagged opener
+ * arrives in practice: someone deletes or forgets a tag.
+ *
+ * Result at introduction, 2026-08-25:
+ *
+ *     gate-envelope: 3 killed, 1 survived as documented of 4 case(s).
+ *
+ * The documented survivor is the scope boundary, measured rather than asserted. #629 is about a
+ * property of ENGLISH — the fold that turns an untagged English fence into `text` — so an
+ * untagged fence in a TRANSLATION must leave this gate green and be owned by
+ * `check-i18n-fence-parity.js` instead. If that row ever starts being killed, the gate has
+ * quietly widened into i18n and will begin reporting a population nobody triaged.
+ *
+ *   node scripts/gate-envelope.js --spec scripts/envelopes/untagged-fence-gate.mjs
+ */
+
+export const gate = { command: ['npm', 'run', 'validate:untagged-fences'] };
+
+export const cases = [
+  {
+    label: 'ENGLISH SKILL: a fence loses its tag',
+    // The case the gate exists for. `foldedTagSequence` would fold this to `text`, so a
+    // translation could then legally carry a localised ```text fence at the same ordinal and
+    // leave the body check entirely — the #481 escape, invisible to every other gate.
+    file: 'skills/add-rcpp-integration/SKILL.md',
+    find: '```bash',
+    replace: '```',
+    expect: 'skills/add-rcpp-integration/SKILL.md',
+  },
+  {
+    label: 'TEMPLATE: a fence loses its tag',
+    // Templates are deliberately IN scope, unlike `isContentFile`, which skips them. #629 says
+    // "anywhere in skills/, agents/, teams/, guides/" and a template lives there. This row is
+    // what stops the carve-out from being reintroduced by someone reusing `isContentFile`.
+    // The template carries two ```bash openers, so the fence alone is an ambiguous mutation and
+    // the envelope refuses it. Anchor on the line that follows the second one.
+    file: 'skills/_template/SKILL.md',
+    find: '```bash\nnext_command',
+    replace: '```\nnext_command',
+    expect: 'skills/_template/SKILL.md',
+  },
+  {
+    label: 'GUIDE: a fence loses its tag',
+    // A second tree, because ENGLISH_TREES is a list and a list can lose an entry. Covering only
+    // skills/ would leave three quarters of the claimed scope unmeasured.
+    file: 'guides/content-styleguide.md',
+    find: '```bash',
+    replace: '```',
+    expect: 'guides/content-styleguide.md',
+  },
+  {
+    label: 'SCOPE BOUNDARY: an untagged fence in a TRANSLATION must NOT redden this gate',
+    // Documented survivor. English-only is deliberate: an untagged fence in a translation is a
+    // translation defect, and routing it here would report a population nobody has read — the
+    // exact mistake #591 forbids. Owned by check-i18n-fence-parity.js.
+    file: 'i18n/de/skills/create-dockerfile/SKILL.md',
+    find: '```bash',
+    replace: '```',
+    expect: null,
+  },
+];

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -53,10 +53,23 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
  * would fire 268 times to catch 3 real defects and would forbid the thing the
  * locale exists for.
  *
- * Untagged fences are frozen, not exempt. Measured cost: zero — there are no
- * untagged fence openers in either tree, because `guides/content-styleguide.md`
- * already requires a tag. The remedy for a future one is to tag the English
- * source.
+ * Untagged fences are frozen, not exempt — but that is not what makes the fold
+ * below safe. The fold maps an untagged English fence to `text`, so a
+ * translation could replace it with a localised ```text fence and produce an
+ * IDENTICAL folded sequence: no tag-sequence finding, no tag-drift finding, and
+ * the body check skips it because gating is read off the translated file. The
+ * #481 escape, surviving through the check built to close it (#629).
+ *
+ * What makes it safe is that no untagged English opener exists. That was a
+ * measurement taken once and written here, and a style rule in prose is exactly
+ * what this repo violated 1,220 times (#472). It is now CHECKED, blocking, in
+ * the required `skills` job:
+ *
+ *     npm run validate:untagged-fences
+ *
+ * Do not restore a count to this comment. Ask the gate — a number here is a
+ * number that can go stale without anything noticing, which is the failure this
+ * paragraph used to be an instance of.
  *
  * Adding a tag here requires naming which machine consumes that fence.
  *
@@ -431,15 +444,51 @@ export function compareTagSequence(mine, englishSequences) {
 
   // Report against the count-matched revision differing in the FEWEST positions — the nearest
   // legal basis. An arbitrary one inflates a single retag into wholesale divergence.
+  //
+  // TIE-BREAK: prefer a reading that is an ESCAPE. Deterministic, and it fails SAFE (#630).
+  //
+  // Two count-matched revisions can differ from the translation in the same NUMBER of positions
+  // while differing in WHICH positions, so `#4 bash->yaml` and `#4 python->text` can both be
+  // minimal. Since #598 that choice is not cosmetic: `isRetagEscape` classifies from
+  // `positions`, an escape BLOCKS and drift does not, so the tie decides a build outcome.
+  //
+  // This used to be `diff.length < best.length` — a strict `<`, so the FIRST minimal candidate
+  // won, and `sameLength` derives from a Set whose insertion order is the history-walk order.
+  // That is stable for a given history, so it never flickered run to run; it is unstable across
+  // ENGLISH edits, because a new revision landing earlier in the walk can flip an existing
+  // finding's kind without the translation changing at all. And `debt-ratchet.yml` keys members
+  // on file+kind, so such a flip reads as a simultaneous stale-member and added-debt pair whose
+  // message explains neither.
+  //
+  // "Some legal basis says this fence left the gated set" is the safe reading: the gate's job is
+  // to catch a fence leaving, and refusing to look away when one candidate says it did costs a
+  // false positive at worst, where the other direction costs the escape the gate exists for.
+  //
+  // Measured before changing it, on the whole corpus: 6 tag-sequence findings, 0 with more than
+  // one minimal candidate, 0 whose verdict a tie could change. So this alters no current member
+  // and the fixture pinning it is necessarily synthetic — which is exactly why it needs a
+  // fixture, since the corpus cannot notice a regression here.
   let best = null;
+  let minimal = 0;
   for (const candidate of sameLength) {
     const other = candidate === '' ? [] : candidate.split(',');
     const diff = mine
       .map((tag, i) => ({ index: i + 1, english: other[i], translated: tag }))
       .filter((d) => d.english !== d.translated);
-    if (!best || diff.length < best.length) best = diff;
+    if (!best || diff.length < best.length) {
+      best = diff;
+      minimal = 1;
+    } else if (diff.length === best.length) {
+      minimal += 1;
+      // Only an escape displaces an incumbent of equal distance. Without this the loop would
+      // keep the first again, and a `<=` would keep the LAST — equally arbitrary, and it would
+      // additionally make the result depend on Set order in the opposite direction.
+      if (!isRetagEscape(best) && isRetagEscape(diff)) best = diff;
+    }
   }
-  return { positions: best };
+  // `minimalCandidates` is reported so a caller can say the basis was ambiguous rather than
+  // presenting one arbitrary reading as the only one. Nothing gates on it today.
+  return { positions: best, minimalCandidates: minimal };
 }
 
 /**

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -60,16 +60,35 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
  * the body check skips it because gating is read off the translated file. The
  * #481 escape, surviving through the check built to close it (#629).
  *
- * What makes it safe is that no untagged English opener exists. That was a
- * measurement taken once and written here, and a style rule in prose is exactly
- * what this repo violated 1,220 times (#472). It is now CHECKED, blocking, in
- * the required `skills` job:
+ * What makes it safe is that no untagged English opener exists **in the working
+ * tree**. That was a measurement taken once and written here, and a style rule
+ * in prose is exactly what this repo violated 1,220 times (#472). It is now
+ * CHECKED, blocking, in the required `skills` job:
  *
  *     npm run validate:untagged-fences
  *
  * Do not restore a count to this comment. Ask the gate — a number here is a
  * number that can go stale without anything noticing, which is the failure this
  * paragraph used to be an instance of.
+ *
+ * **The gate stops the escape surface GROWING; it does not close it.** The
+ * sequence check accepts a match against ANY pooled revision, and the pool
+ * stores FOLDED joins — so a historical English revision carrying an untagged
+ * fence pools `text` at that ordinal permanently, indistinguishable from a
+ * literal ```text fence, and `git ls-files` cannot see history. A translation
+ * posing as stale against such a revision can carry a localised ```text fence
+ * where English is frozen today, and every check reads green.
+ *
+ * Historical untagged English openers are not hypothetical: the fold exists
+ * precisely because `normalize-content-style.js --mode fences` retro-tagged
+ * untagged blocks, so history demonstrably contains them. The harmful
+ * subpopulation — untagged then, frozen-tagged now — is UNMEASURED and cannot
+ * be measured from the pool, which has already folded the evidence away; it
+ * needs a history re-walk keeping raw info strings. Filed as its own issue.
+ *
+ * One corollary worth stating: the guarantee decays monotonically under bypass.
+ * A violation pushed straight to `main` is pooled before any fix lands, and
+ * widens the surface permanently.
  *
  * Adding a tag here requires naming which machine consumes that fence.
  *
@@ -424,7 +443,7 @@ export function extractFences(text) {
  *
  * @param {string[]} mine folded tag sequence of the translation
  * @param {Set<string>|undefined} englishSequences joined folded sequences from every revision
- * @returns {null | {unalignable: true} | {positions: {index: number, english: string, translated: string}[]}}
+ * @returns {null | {unalignable: true} | {positions: {index: number, english: string, translated: string}[], minimalCandidates: number}}
  */
 export function compareTagSequence(mine, englishSequences) {
   if (!englishSequences || englishSequences.has(mine.join(','))) return null;
@@ -463,6 +482,17 @@ export function compareTagSequence(mine, englishSequences) {
   // "Some legal basis says this fence left the gated set" is the safe reading: the gate's job is
   // to catch a fence leaving, and refusing to look away when one candidate says it did costs a
   // false positive at worst, where the other direction costs the escape the gate exists for.
+  //
+  // TWO LIMITS, both narrower than "deterministic" sounds:
+  //
+  //   1. Deterministic in the KIND, not in the POSITIONS. Once `best` is an escape nothing
+  //      displaces it, so a tie among two escape candidates -- or among all-drift ones -- still
+  //      resolves by Set insertion order. That is bounded to the finding's message text, since
+  //      `debt-ratchet.yml` keys on file+kind and the kind is now order-independent.
+  //   2. This removes the ARBITRARINESS of the kind flip, not the flip. An English edit that
+  //      creates a new equidistant escape reading still deterministically moves a drift member
+  //      to escape, reddening `npm run ratchet` on a PR that touched only English. The old code
+  //      had the same exposure and picked a direction by walk order; this one picks it by rule.
   //
   // Measured before changing it, on the whole corpus: 6 tag-sequence findings, 0 with more than
   // one minimal candidate, 0 whose verdict a tie could change. So this alters no current member

--- a/scripts/test/tag-sequence-parity.test.js
+++ b/scripts/test/tag-sequence-parity.test.js
@@ -37,6 +37,53 @@ test('untagged folds to `text`, and the fold is not optional', () => {
   assert.deepEqual(foldedTagSequence('```yaml\nx\n```\n\n```\ny\n```\n'), ['yaml', 'text']);
 });
 
+test('an equidistant tie is broken toward the ESCAPE, not toward walk order (#630)', () => {
+  // Two count-matched English revisions, each differing from the translation in EXACTLY ONE
+  // position, and they disagree about what that means:
+  //
+  //   candidate A   ['python', 'bash']  ->  #1 python->text   an ESCAPE   (frozen fence freed)
+  //   candidate B   ['text',   'yaml']  ->  #2 yaml->bash     drift       (both stay frozen)
+  //
+  // Before #630 the winner was whichever the history walk reached first, because the loop used a
+  // strict `<`. Since #598 that also decided whether the finding BLOCKS. So the tie is asserted
+  // by VERDICT here, not merely by "a verdict exists".
+  const translated = ['text', 'bash'];
+  const escapeFirst = new Set(['python,bash', 'text,yaml']);
+  const driftFirst = new Set(['text,yaml', 'python,bash']);
+
+  for (const [label, sequences] of [['escape walked first', escapeFirst],
+                                    ['drift walked first', driftFirst]]) {
+    const verdict = compareTagSequence(translated, sequences);
+    assert.equal(verdict.minimalCandidates, 2, `${label}: the fixture must actually tie`);
+    assert.equal(isRetagEscape(verdict.positions), true,
+      `${label}: an equidistant escape reading must win, so the tie fails safe`);
+    assert.deepEqual(verdict.positions,
+      [{ index: 1, english: 'python', translated: 'text' }],
+      `${label}: and it must report the escape's positions, not the drift's`);
+  }
+
+  // Insertion order is the only thing that differs between the two Sets above, so this is the
+  // property that was broken: the answer must not depend on it.
+  assert.deepEqual(compareTagSequence(translated, escapeFirst),
+    compareTagSequence(translated, driftFirst),
+    'walk order must not change the verdict');
+});
+
+test('a tie among equals that are ALL drift stays drift, and reports the ambiguity (#630)', () => {
+  // The fail-safe rule must not manufacture an escape where no legal reading is one. Both
+  // candidates differ in one position and neither frees a frozen fence.
+  const verdict = compareTagSequence(['bash', 'yaml'], new Set(['yaml,yaml', 'bash,bash']));
+  assert.equal(verdict.minimalCandidates, 2);
+  assert.equal(isRetagEscape(verdict.positions), false,
+    'no candidate is an escape, so the finding must stay drift');
+});
+
+test('a lone minimal candidate reports one, so ambiguity is distinguishable (#630)', () => {
+  const verdict = compareTagSequence(['text', 'bash'], new Set(['python,bash', 'json,json']));
+  assert.equal(verdict.minimalCandidates, 1);
+  assert.equal(isRetagEscape(verdict.positions), true);
+});
+
 test('ALL fences are sequenced, not only gated ones — that is the whole point', () => {
   // A gated-only sequence cannot see a retag, because the retag is precisely a fence LEAVING the
   // gated set. This is the property #582 removed from `fenceShape` and #583 records the loss of.
@@ -79,6 +126,11 @@ test('an empty English revision has length 0, not 1', () => {
   assert.equal(compareTagSequence(['markdown'], english), null, 'the 1-fence revision matches');
   assert.deepEqual(compareTagSequence(['r'], english), {
     positions: [{ index: 1, english: 'markdown', translated: 'r' }],
+    // `minimalCandidates` since #630. It is 1 here precisely because the empty revision is
+    // excluded from `sameLength` — if the length-0 regression came back, the empty revision
+    // would tie and this would read 2, so the field doubles as a second witness for the bug
+    // this test is named after.
+    minimalCandidates: 1,
   }, 'the empty revision must not be offered as a 1-fence basis');
   assert.deepEqual(compareTagSequence([], english), null, 'an empty translation matches the empty revision');
 });


### PR DESCRIPTION
Closes #629. Closes #630.

Two blind spots in `scripts/lib/fences.js`, both found by adversarial review of #627, both latent rather than live, and both the same shape: a decision resting on something nothing checks.

## #629 — the fold's safety was a remembered measurement

`foldedTagSequence` folds an untagged English fence to `text`. Under default-deny an untagged fence is **frozen**, so the fold means a translation may replace an untagged English fence with a localised ` ```text ` one and produce an **identical folded sequence** — no tag-sequence finding, no tag-drift finding, and the body check skips it because gating is read off the translated file. The #481 escape, surviving through the check built to close it.

The fold is not the bug and stays: removing it makes every untagged-vs-`text` pairing left by `normalize-content-style.js --mode fences` read as a retag — the false-positive class that stranded 169 repairable fences across 73 files. **The bug is that its safety was a sentence in a comment**, and a style rule in prose is exactly what this repo violated 1,220 times (#472).

```bash
npm run validate:untagged-fences
```

**Corpus recounted at fix time** rather than trusted from the issue, as its AC demands — 558 English content files, **0** untagged openers, templates included. So it ships **blocking**, not warn-only-with-a-ratchet. A gate that ships clean can block.

Three choices worth stating:

- **A third mode, not `--all` made blocking.** `--all` also counts decorative separators, a class with 11 live members; flipping it would redden every PR for unrelated debt.
- **Not `--added`.** That fails only for an opener on a line the diff marks as added, so it misses a fence that *becomes* an opener when a preceding fence's parity flips — the #628 shape, with no line of its own touched.
- **In `validate-skills.yml`, not `validate-content-style.yml`.** The latter is path-filtered, and CLAUDE.md records that a path-filtered workflow cannot be a required check. This job is one of the five required contexts and carries no `paths:`.

`fences.js` now cites the gate and says not to restore a count to the comment.

## #630 — an equidistant tie was broken by history-walk order

`compareTagSequence` reports against the count-matched revision differing in the fewest positions, using a strict `<` — so the **first** minimal candidate won, and `sameLength` derives from a `Set` whose insertion order is the history-walk order. Since #598 that also decides whether the finding **blocks**, because `isRetagEscape` classifies from `positions`.

Stable for a given history, so never flaky run-to-run. Unstable across **English edits**: a new revision landing earlier in the walk flips an existing finding's kind without the translation changing, and `debt-ratchet.yml` keys members on `file`+`kind`, so the flip reads as a simultaneous stale-member and added-debt pair explaining neither.

Now an equidistant **escape** reading displaces a drift incumbent — deterministic, order-independent, and it fails safe: the gate's job is to catch a fence leaving the gated set, so "some legal basis says it did" is the right reading. `minimalCandidates` is returned so a caller can report an ambiguous basis instead of presenting one arbitrary reading as the only one; nothing gates on it.

**Measured on the whole corpus before changing it**, per the issue's own AC:

```
6 tag-sequence findings
0 with more than one minimal candidate
0 whose verdict a tie could change
```

So this alters no current member, the fixture is necessarily synthetic, and that is exactly why it needs one — the corpus cannot notice a regression here.

## Negative evidence

`scripts/envelopes/untagged-fence-gate.mjs`, run against `npm run validate:untagged-fences` — the command the workflow runs, not the inner script:

```
gate-envelope: 3 killed, 1 survived as documented of 4 case(s).
```

Killed: an English skill, a **template** (deliberately in scope, unlike `isContentFile`), and a guide — three trees, because `ENGLISH_TREES` is a list and a list can lose an entry. The documented survivor is the scope boundary measured rather than asserted: an untagged fence in a *translation* must leave this gate green, since routing it here would report a population nobody has read.

For #630, `mutation-check` deleting the tie-break line, against `npm run test:scripts`:

```
MUTANT KILLED — the check can fail.
```

**The failing-test count could not be verified, and that is a separate defect I hit rather than a gap in this change.** `parseFailCount` in `scripts/lib/mutation-verdict.js` matches `/fail\s+(\d+)\s*$/m`, but node:test emits `"[34mℹ fail 0[39m"` — the trailing escape defeats `$`. Measured directly: the regex returns `NO MATCH` on real output and `0` after stripping ANSI. So `--expect-killed-by`, the flag that separates a targeted kill from a crash kill (#621), is unusable whenever colour is on — which is always, locally, and never in CI. Filed separately; not fixed here to keep this diff on its two issues.

## Gates run locally

`test:scripts` (673 pass, was 670), `check-readmes`, `validate:line-endings`, `ratchet`, and the new `validate:untagged-fences`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yKCWG7uvJezdapqRMc2Wf
