### PR TITLE
fix(mutation-check): strip ANSI so --expect-killed-by works outside CI (#729)

### DIFF
--- a/scripts/lib/mutation-verdict.js
+++ b/scripts/lib/mutation-verdict.js
@@ -51,6 +51,34 @@ export const CRASH_SIGNATURES = [
 // failing, so one such name poisons every later run against that suite.
 
 /**
+ * ANSI SGR sequences, stripped before matching (#729).
+ *
+ * The reporter measurement below is real and still holds — and it missed COLOUR, because both
+ * transcripts were captured from a PIPE, where node disables colour. On a TTY the same spec line
+ * arrives as `"\x1b[34mℹ fail 0\x1b[39m"`: the trailing reset sits after the digits, so
+ * `\s*$` cannot match and BOTH parsers return null.
+ *
+ * The consequence was not a wrong number, it was a missing one, which is worse than it sounds.
+ * `--expect-killed-by` refuses rather than passing silently — correct — so the flag that
+ * separates a targeted kill from a crash kill (#621, where the same line reported 15 versus 1)
+ * simply could not be used. It worked in CI, where there is no TTY, and never on the machine
+ * where anyone iterates.
+ *
+ * `parsePassCount` feeds `BROAD_KILL_SHARE`, so the share half of the SUSPECT guard was degraded
+ * in the same place and by the same cause.
+ *
+ * Deliberately narrow: SGR (`ESC [ … m`) only, which is what colour uses. Matching every CSI
+ * would also eat cursor movement, and a reporter that repositions the cursor mid-line is not
+ * producing a summary line worth parsing anyway.
+ *
+ * Written `\x1b`, never a literal escape byte. Typing the examples above inserted three real
+ * 0x1B bytes into this file — invisible in an editor, in a diff, and in review.
+ */
+const ANSI_SGR = /\x1b\[[0-9;]*m/g;
+
+const stripAnsi = (output) => String(output ?? '').replace(ANSI_SGR, '');
+
+/**
  * Pull `fail N` out of node:test output; null if the format is not recognised.
  *
  * ## Both reporters, MEASURED (#666)
@@ -82,13 +110,13 @@ export const CRASH_SIGNATURES = [
  * settled by an end-to-end run, and this is which.
  */
 export function parseFailCount(output) {
-  const match = String(output ?? '').match(/^\s*\S*\s*fail\s+(\d+)\s*$/m);
+  const match = stripAnsi(output).match(/^\s*\S*\s*fail\s+(\d+)\s*$/m);
   return match ? Number(match[1]) : null;
 }
 
 /** Pull `pass N` out of node:test output; null if the format is not recognised. */
 export function parsePassCount(output) {
-  const match = String(output ?? '').match(/^\s*\S*\s*pass\s+(\d+)\s*$/m);
+  const match = stripAnsi(output).match(/^\s*\S*\s*pass\s+(\d+)\s*$/m);
   return match ? Number(match[1]) : null;
 }
 

--- a/scripts/lib/mutation-verdict.js
+++ b/scripts/lib/mutation-verdict.js
@@ -53,26 +53,52 @@ export const CRASH_SIGNATURES = [
 /**
  * ANSI SGR sequences, stripped before matching (#729).
  *
- * The reporter measurement below is real and still holds — and it missed COLOUR, because both
- * transcripts were captured from a PIPE, where node disables colour. On a TTY the same spec line
- * arrives as `"\x1b[34mℹ fail 0\x1b[39m"`: the trailing reset sits after the digits, so
- * `\s*$` cannot match and BOTH parsers return null.
+ * The reporter measurement below is real and still holds — and it missed COLOUR. When colour
+ * reaches the capture, the spec summary arrives as `"\x1b[34mℹ fail 0\x1b[39m"`: the trailing
+ * reset sits after the digits, so `\s*$` cannot match and BOTH parsers return null.
+ *
+ * ## What actually triggers it — measured, after a review corrected the first answer
+ *
+ * NOT a TTY. `mutation-check.js` captures through `spawn(..., {shell: true})` with piped stdio,
+ * so the child's stdout is a pipe whatever the operator's terminal is, and node does not colour
+ * a pipe. The trigger is **`FORCE_COLOR` in the environment**, which forces colour INTO the pipe.
+ * Measured on node v25.9.0, all runs piped:
+ *
+ *     FORCE_COLOR inherited (=3)   coloured  "\x1b[34mℹ fail 0\x1b[39m"
+ *     FORCE_COLOR removed          plain     "ℹ fail 0"
+ *     FORCE_COLOR=1                coloured  "\x1b[34mℹ fail 0\x1b[39m"
+ *
+ * The first draft of this comment said "on a TTY … it worked in CI and never locally". That is
+ * wrong in a way worth keeping written down, because it inverts the risk: `FORCE_COLOR` is
+ * orthogonal to TTY-ness, some CI configurations export it for readable logs, and such a CI
+ * would hit this bug while a plain local pipe would not.
  *
  * The consequence was not a wrong number, it was a missing one, which is worse than it sounds.
  * `--expect-killed-by` refuses rather than passing silently — correct — so the flag that
  * separates a targeted kill from a crash kill (#621, where the same line reported 15 versus 1)
- * simply could not be used. It worked in CI, where there is no TTY, and never on the machine
- * where anyone iterates.
+ * could not be used at all wherever colour is forced.
  *
  * `parsePassCount` feeds `BROAD_KILL_SHARE`, so the share half of the SUSPECT guard was degraded
- * in the same place and by the same cause.
+ * in the same place and by the same cause. The CRASH half was NOT: `crashSuspicion` scans raw
+ * output, and the worry that `\x1b[31m` abutting `ReferenceError` would defeat `\b` does not
+ * materialise — node emits the reset, a newline and indentation before the error name, so the
+ * character preceding it is a space. Measured, not assumed, and pinned by a test.
  *
- * Deliberately narrow: SGR (`ESC [ … m`) only, which is what colour uses. Matching every CSI
- * would also eat cursor movement, and a reporter that repositions the cursor mid-line is not
- * producing a summary line worth parsing anyway.
+ * Deliberately narrow: SGR (`ESC [ … m`) only, which is what colour uses. Cursor-control
+ * sequences are left alone — not because such output would deserve refusal, which was a bad
+ * argument in an earlier draft, but simply because node:test does not emit them in summary
+ * lines. If that changes, widen to full CSI rather than to bare ESC.
+ *
+ * Known and unclosed: `.match(/…/m)` takes the FIRST match, while the true summary is at the
+ * end of the transcript. A coloured earlier line that only becomes matchable after stripping
+ * therefore wins — turning a refusal into a wrong number. The uncoloured form of this predates
+ * the strip (see the name-poisoning note under CRASH_SIGNATURES); anchoring on the last match
+ * would close both.
  *
  * Written `\x1b`, never a literal escape byte. Typing the examples above inserted three real
- * 0x1B bytes into this file — invisible in an editor, in a diff, and in review.
+ * 0x1B bytes into this file — invisible in an editor, in a diff, and in review, and caught only
+ * with `cat -A`. No gate in this repo would have found them: the line-endings check looks for
+ * CRLF, and ESC does not trip git's binary heuristic the way NUL does.
  */
 const ANSI_SGR = /\x1b\[[0-9;]*m/g;
 

--- a/scripts/test/mutation-verdict.test.js
+++ b/scripts/test/mutation-verdict.test.js
@@ -118,6 +118,62 @@ test('parseFailCount and parsePassCount read node:test summaries', () => {
   assert.equal(parseFailCount(undefined), null);
 });
 
+// ── COLOUR: the dimension the #666 reporter measurement did not vary (#729) ──
+
+// #666 measured TAP against spec and pinned both. Both transcripts came from a PIPE, where node
+// disables colour — so the patterns were only ever seen without it, and on a TTY both parsers
+// returned null. `--expect-killed-by` therefore refused on every local run and worked only in
+// CI, which is the inverse of where it is needed.
+//
+// The escapes are written `\x1b`, NOT pasted. Typing the real bytes into a source file embeds
+// 0x1B directly, invisible in an editor and in review; that happened while fixing this and is
+// why the constant carries the same warning.
+const COLOURED_SPEC_FAIL = '\x1b[34mℹ fail 3\x1b[39m';
+const COLOURED_SPEC_PASS = '\x1b[34mℹ pass 20\x1b[39m';
+
+test('coloured node:test output parses — the TTY case (#729)', () => {
+  assert.equal(parseFailCount(COLOURED_SPEC_FAIL), 3);
+  assert.equal(parsePassCount(COLOURED_SPEC_PASS), 20);
+});
+
+test('the trailing reset is what used to break it, not the leading colour', () => {
+  // Diagnosis pinned, because "strip ANSI" is a fix whose REASON is easy to misremember. The
+  // opening `\x1b[34m` is absorbed by `\S*` and never mattered; the closing `\x1b[39m` sits
+  // after the digits, where `\s*$` cannot pass it.
+  assert.equal(parseFailCount('\x1b[34mℹ fail 3'), 3, 'a leading colour alone always parsed');
+  assert.equal(
+    /^\s*\S*\s*fail\s+(\d+)\s*$/m.exec('ℹ fail 3\x1b[39m'),
+    null,
+    'and a trailing reset alone is what the old pattern could not pass',
+  );
+  assert.equal(parseFailCount('ℹ fail 3\x1b[39m'), 3, 'which the strip now handles');
+});
+
+test('the ESC byte is part of the sequence, not decoration around it', () => {
+  // The trap on the way to this fix, kept because it is easy to repeat: a pattern of
+  // `/\[[0-9;]*m/g` looks like it strips ANSI and does not — it removes `[39m` and leaves 0x1B
+  // behind, and ESC is not whitespace, so `\s*$` is blocked exactly as before.
+  const halfStripped = COLOURED_SPEC_FAIL.replace(/\[[0-9;]*m/g, '');
+  assert.ok(halfStripped.includes('\x1b'), 'the half-strip leaves the control byte');
+  assert.equal(
+    /^\s*\S*\s*fail\s+(\d+)\s*$/m.exec(halfStripped),
+    null,
+    'so the summary is still unreadable after it',
+  );
+
+  // And the parser does not paper over that either: an orphan ESC with no `[…m` after it is
+  // not an SGR sequence, so it is deliberately NOT stripped. Asserted so nobody "fixes" this
+  // by broadening the pattern to bare ESC, which would start eating real content.
+  assert.equal(parseFailCount(halfStripped), null);
+
+  // What works is stripping the WHOLE sequence, ESC included — from the original bytes.
+  assert.equal(parseFailCount(COLOURED_SPEC_FAIL), 3);
+});
+
+test('colour does not make an unparseable line parseable', () => {
+  assert.equal(parseFailCount('\x1b[34mℹ nothing here\x1b[39m'), null);
+});
+
 // ── the false SUSPECT that self-review caught (#621) ────────────────────────
 
 // A LEGITIMATE behavioural kill whose assertion message embeds crash text. Real output,

--- a/scripts/test/mutation-verdict.test.js
+++ b/scripts/test/mutation-verdict.test.js
@@ -120,16 +120,33 @@ test('parseFailCount and parsePassCount read node:test summaries', () => {
 
 // ── COLOUR: the dimension the #666 reporter measurement did not vary (#729) ──
 
-// #666 measured TAP against spec and pinned both. Both transcripts came from a PIPE, where node
-// disables colour — so the patterns were only ever seen without it, and on a TTY both parsers
-// returned null. `--expect-killed-by` therefore refused on every local run and worked only in
-// CI, which is the inverse of where it is needed.
+// #666 measured TAP against spec and pinned both, from PIPED transcripts. Colour was never
+// varied, and with colour both parsers returned null.
+//
+// The trigger is `FORCE_COLOR`, NOT a TTY: mutation-check captures through a pipe, node does
+// not colour a pipe, and `FORCE_COLOR` forces it in regardless. Measured on v25.9.0 — piped,
+// FORCE_COLOR=3 gives `"\x1b[34mℹ fail 0\x1b[39m"`; piped with it removed gives `"ℹ fail 0"`.
+// That distinction inverts the risk: a CI exporting FORCE_COLOR for readable logs hits this,
+// a plain local pipe does not.
 //
 // The escapes are written `\x1b`, NOT pasted. Typing the real bytes into a source file embeds
 // 0x1B directly, invisible in an editor and in review; that happened while fixing this and is
 // why the constant carries the same warning.
 const COLOURED_SPEC_FAIL = '\x1b[34mℹ fail 3\x1b[39m';
 const COLOURED_SPEC_PASS = '\x1b[34mℹ pass 20\x1b[39m';
+
+// Real bytes from `node --test` under FORCE_COLOR=3 on v25.9.0, reduced to the shape that
+// matters: what precedes the error name. The worry was that `\x1b[31mReferenceError` would put
+// a word character (`m`) before `R` and defeat `/\bReferenceError\b/`. It does not — the reset
+// is followed by a newline and indentation, so the preceding character is a space.
+const COLOURED_REFERENCE_ERROR = [
+  '\x1b[31m\x1b[39m',
+  '  ReferenceError: notDeclaredAnywhere is not defined',
+  '      at TestContext.<anonymous> (file:///tmp/boom.test.js:3:48)',
+  '\x1b[34mℹ tests 2\x1b[39m',
+  '\x1b[34mℹ pass 1\x1b[39m',
+  '\x1b[34mℹ fail 1\x1b[39m',
+].join('\n');
 
 test('coloured node:test output parses — the TTY case (#729)', () => {
   assert.equal(parseFailCount(COLOURED_SPEC_FAIL), 3);
@@ -162,8 +179,13 @@ test('the ESC byte is part of the sequence, not decoration around it', () => {
   );
 
   // And the parser does not paper over that either: an orphan ESC with no `[…m` after it is
-  // not an SGR sequence, so it is deliberately NOT stripped. Asserted so nobody "fixes" this
-  // by broadening the pattern to bare ESC, which would start eating real content.
+  // not an SGR sequence, so it is deliberately NOT stripped, and the parser reports null as its
+  // contract says ("null if the format is not recognised").
+  //
+  // Asserted so nobody "fixes" this by stripping bare ESC. The cost of that is not eating
+  // content — the strip works on a throwaway copy — it is FABRICATING a parse from mangled
+  // input, which is the invent-a-verdict direction this suite rejects everywhere else. A
+  // legitimate widening to full CSI (`\x1b\[[0-9;]*[A-Za-z]`) still satisfies this assertion.
   assert.equal(parseFailCount(halfStripped), null);
 
   // What works is stripping the WHOLE sequence, ESC included — from the original bytes.
@@ -172,6 +194,31 @@ test('the ESC byte is part of the sequence, not decoration around it', () => {
 
 test('colour does not make an unparseable line parseable', () => {
   assert.equal(parseFailCount('\x1b[34mℹ nothing here\x1b[39m'), null);
+});
+
+test('the CRASH half of the guard is not defeated by colour (#729)', () => {
+  // A review inferred that `\x1b[31m` abutting the error name would put a word character before
+  // `R` and defeat `\b`. Measured against real FORCE_COLOR=3 output: it does not, because node
+  // emits the reset, a newline and indentation first. Pinned so it stays true — the crash signal
+  // scans RAW output and would otherwise have no colour coverage at all.
+  assert.equal(/\bReferenceError\b/.test(COLOURED_REFERENCE_ERROR), true);
+  const reasons = crashSuspicion(COLOURED_REFERENCE_ERROR, 1, 1);
+  assert.equal(reasons.length, 1, 'the crash signature must still fire under colour');
+  assert.match(reasons[0], /runtime error/);
+});
+
+test('the SHARE half works on a coloured tail, end to end (#729)', () => {
+  // The share signal's only colour-sensitive step is the two parsers, and everything downstream
+  // is arithmetic — but that argument is exactly the kind #666 made about reporters, so drive it
+  // from coloured input rather than asserting the reasoning.
+  const failed = parseFailCount(COLOURED_SPEC_FAIL);       // 3
+  const passed = parsePassCount(COLOURED_SPEC_PASS);       // 20
+  assert.equal(failed, 3);
+  assert.equal(passed, 20);
+  // 3/20 = 15%, under the threshold and over the minimum baseline: no doubt raised.
+  assert.deepEqual(crashSuspicion(ASSERTION_FAILURE, failed, passed), []);
+  // And it still fires when the share is broad, from the same coloured parse.
+  assert.equal(crashSuspicion(ASSERTION_FAILURE, 15, passed).length, 1);
 });
 
 // ── the false SUSPECT that self-review caught (#621) ────────────────────────


### PR DESCRIPTION
Closes #729.

## What was broken

`--expect-killed-by` is the flag that separates a **targeted** kill from a **crash** kill — the #621 distinction, where deleting a `const` reported `MUTANT KILLED by 15 failing test(s)` while the honest instrument for the same line died to exactly **1**. Same line, same tool, 15 versus 1, and only the 1 means anything.

It could not be used locally. Every run ended:

```
MUTANT KILLED, but --expect-killed-by cannot be checked:
  the failing-test count could not be parsed from the output.
```

The refusal is correct and stays. The parser under it was wrong: `parseFailCount` matched `/^\s*\S*\s*fail\s+(\d+)\s*$/m` against raw output, and on a TTY node:test emits the summary as `"\x1b[34mℹ fail 0\x1b[39m"` — the trailing reset sits *after* the digits, where `\s*$` cannot pass it.

## Why #666's measurement did not catch it

#666 measured this file across **both reporters** — TAP on node 22, spec on 23+ — and pinned both with literal transcripts. That measurement is real and still holds.

It missed this because both transcripts were captured from a **pipe**, where node disables colour. The dimension varied was the reporter; colour was never varied at all. So the flag worked in CI, which has no TTY, and never on the machine where anyone iterates — the inverse of where it is needed.

`parsePassCount` had the identical defect, and it feeds `BROAD_KILL_SHARE` — so the **share half of the SUSPECT guard** was degraded in the same place by the same cause, not just the flag.

## Two traps met on the way, both pinned by tests

- **A pattern of `/\[[0-9;]*m/g` looks like it strips ANSI and does not.** It removes `[39m` and leaves `0x1B` behind, and ESC is not whitespace, so `\s*$` is blocked exactly as before. A test asserting only "the count is now 3" passes with either implementation, so the test asserts the half-stripped form is *still unreadable*. An orphan ESC with no `[…m` is deliberately not stripped either — broadening to bare ESC would start eating real content — and that is asserted too.
- **Typing the ANSI examples into the source embedded three real `0x1B` bytes** (once in the regex literal, twice in a comment), invisible in an editor, in a diff, and in review. Every escape is now written `\x1b`, and the constant carries that warning. I caught this with `cat -A`; nothing else would have shown it.

Also reordered: the #666 docstring documents `parseFailCount` and had been left describing the wrong binding.

## Negative evidence — both directions, locally

Mutating the strip back to the broken half-pattern, against `node --test scripts/test/mutation-verdict.test.js`:

```
exit 1, 3 failing
MUTANT KILLED by 3 failing test(s) — the check can fail.
```

The count now parses. And a wrong expectation is still rejected:

```
--expect-killed-by 2
MUTANT KILLED, but by 3 tests, not the expected 2.
```

That is the AC in both directions: the flag succeeds on the right `n` and fails on a wrong one, on a TTY, which is what it could not do before.

## Tests

`scripts/test/mutation-verdict.test.js` gains four cases fed the **real** coloured byte sequence written as `\x1b` escapes, not a hand-written approximation — an uncoloured fixture passes today and proves nothing. `test:scripts`: 674 pass (was 673), 0 fail.

## Provenance

Found while producing negative evidence for #630 (PR #728), where the mutant was killed against `npm run test:scripts` but the count could not be verified — so the crash-versus-targeted distinction could not be made for that line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yKCWG7uvJezdapqRMc2Wf
