### PR TITLE
ci(agents): gate agent file vs registry skill/tool drift (#434)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -125,6 +125,24 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # #434. Agent frontmatter vs `agents/_registry.yml`, on `skills` and `tools`.
+      #
+      # Nothing compared them, which is how #398 survived from an agent's creation commit
+      # (`apa-specialist`: 1 skill in the file, 3 in the registry) and why #403 §2a re-synced
+      # four agents BY HAND. A hand-sync with no gate behind it is a repair, not a fix.
+      #
+      # BLOCKING: measured clean at introduction — 75 files, 75 entries, 0 drift, and 150 of 150
+      # field comparisons populated on BOTH sides. The second number is the load-bearing one: two
+      # empty lists compare equal, so "0 drift" over absent fields would assert nothing, and the
+      # checker fails on an empty side rather than passing quietly.
+      #
+      # HERE and not in `validate-integrity.yml`, which is the better semantic fit and is also
+      # required: that job deliberately runs no `npm ci`, and this checker imports `js-yaml`.
+      # Placing it there would need a dependency-free YAML reader — a second parser to disagree
+      # with the first.
+      - name: Check agent file vs registry parity (#434)
+        run: npm run validate:agent-parity
+
       - name: Check translation freshness (warn only)
         run: node scripts/check-translation-freshness.js --warn
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "check:bare-substitutions": "node scripts/check-bare-substitutions.js",
     "normalize:i18n-fences": "node scripts/normalize-i18n-fences.js",
     "backfill:fence-basis": "node scripts/backfill-fence-basis.js",
+    "validate:agent-parity": "node scripts/check-agent-registry-parity.js",
     "validate:content-style": "node scripts/check-content-style.js --all",
     "validate:line-endings": "node scripts/check-line-endings.js",
     "validate:skill-sections": "node scripts/audit-skill-sections.js --missing",

--- a/scripts/check-agent-registry-parity.js
+++ b/scripts/check-agent-registry-parity.js
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Agent file vs registry parity (#434).
+ *
+ * `agents/<id>.md` frontmatter and the matching `agents/_registry.yml` entry both carry `skills`
+ * and `tools`, and nothing compared them. That is how #398 survived from an agent's creation
+ * commit: `apa-specialist` listed 1 skill in the file and 3 in the registry, and the #403 §2a
+ * work re-synced four agents BY HAND. A hand-sync with no gate behind it is a repair, not a fix —
+ * the same drift is free to reappear on the next agent added.
+ *
+ * Ships BLOCKING, because the corpus was measured clean at introduction: 75 agent files, 75
+ * registry entries, 0 field drifts, and — the part that matters more — 150 of 150 field
+ * comparisons populated on BOTH sides. Two empty lists compare equal, so a "0 drift" result over
+ * a corpus where the fields were absent would prove nothing at all. That is why `--strict`
+ * (the default) also requires PRESENCE rather than only agreement.
+ *
+ * Order-insensitive: the two files list skills in different orders in several places today and
+ * that is not drift. Duplicates ARE reported, since a list containing the same skill twice
+ * disagrees with a set-equal counterpart in a way nobody intends.
+ *
+ *   node scripts/check-agent-registry-parity.js
+ *   node scripts/check-agent-registry-parity.js --json
+ *
+ * Teams are deliberately out of scope. #434 raises them as "consider", and `teams/_registry.yml`
+ * carries `lead`/`members`/`coordination` against a different frontmatter shape — a second
+ * comparison with its own vacuity question, which belongs in its own change with its own
+ * measurement.
+ */
+import * as yaml from 'js-yaml';
+import { readFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const FIELDS = ['skills', 'tools'];
+
+function frontmatter(text) {
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+  if (!m) return null;
+  try {
+    return yaml.load(m[1]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Normalise a field to a sorted array of strings.
+ *
+ * Both shapes occur: the frontmatter uses a YAML flow sequence (`tools: [Read, Edit]`) and a
+ * block sequence for `skills`, and js-yaml gives an array for both. A comma-separated STRING is
+ * accepted too rather than silently read as a one-element list, because that is the shape a
+ * hand-edit produces and reading it as one long "skill" would report drift with an unreadable
+ * message.
+ */
+function normalise(value) {
+  if (value == null) return [];
+  const parts = Array.isArray(value) ? value : String(value).split(',');
+  return parts.map((v) => String(v).trim()).filter(Boolean).sort();
+}
+
+const sameSet = (a, b) => a.length === b.length && a.every((x, i) => x === b[i]);
+
+function listAgentFiles() {
+  const out = execSync('git ls-files agents/*.md', { encoding: 'utf8', maxBuffer: 1 << 26 });
+  return out
+    .split('\n')
+    .filter(Boolean)
+    .filter((p) => !p.includes('_template') && !p.endsWith('README.md'));
+}
+
+function loadRegistry() {
+  const reg = yaml.load(readFileSync('agents/_registry.yml', 'utf8'));
+  const node = reg?.agents;
+  if (Array.isArray(node)) return node;
+  if (node && typeof node === 'object') {
+    return Object.entries(node).map(([name, v]) =>
+      v && typeof v === 'object' ? { id: v.id ?? name, ...v } : { id: name });
+  }
+  return [];
+}
+
+function main() {
+  const json = process.argv.includes('--json');
+  const files = listAgentFiles();
+  const entries = loadRegistry();
+
+  // Vacuity, both sides. A scan that reaches nothing reports "0 drift" and means nothing — the
+  // shape this repo keeps rediscovering. Refuse rather than print a clean-looking zero.
+  if (files.length === 0 || entries.length === 0) {
+    console.error(
+      `FAIL: nothing to compare (${files.length} agent file(s), ${entries.length} registry entry(s)).`,
+    );
+    process.exit(2);
+  }
+
+  const errors = [];
+  const seen = new Set();
+  let comparisons = 0;
+  let populated = 0;
+
+  for (const file of files) {
+    if (!existsSync(file)) continue;
+    const fm = frontmatter(readFileSync(file, 'utf8'));
+    if (!fm) {
+      errors.push(`${file}: no parseable YAML frontmatter`);
+      continue;
+    }
+    const id = fm.name || file.replace(/^agents\//, '').replace(/\.md$/, '');
+    const entry = entries.find((e) => e.id === id || e.name === id);
+    if (!entry) {
+      errors.push(`${file}: name "${id}" has no entry in agents/_registry.yml`);
+      continue;
+    }
+    seen.add(entry.id ?? entry.name);
+
+    for (const field of FIELDS) {
+      comparisons++;
+      const inFile = normalise(fm[field]);
+      const inReg = normalise(entry[field]);
+      if (inFile.length && inReg.length) populated++;
+
+      // Presence is checked separately from agreement. Absent on BOTH sides compares equal and
+      // would pass silently, which is the vacuous half of a parity check.
+      if (!inFile.length || !inReg.length) {
+        errors.push(
+          `${id}.${field}: empty on ${!inFile.length ? 'the file' : 'the registry'} side` +
+            `${!inFile.length && !inReg.length ? ' (both)' : ''} — a parity check over two empty` +
+            ' lists asserts nothing',
+        );
+        continue;
+      }
+      if (!sameSet(inFile, inReg)) {
+        const onlyFile = inFile.filter((x) => !inReg.includes(x));
+        const onlyReg = inReg.filter((x) => !inFile.includes(x));
+        errors.push(
+          `${id}.${field}: file and registry disagree\n` +
+            `    only in ${file}: ${onlyFile.join(', ') || '(none)'}\n` +
+            `    only in registry: ${onlyReg.join(', ') || '(none)'}` +
+            (onlyFile.length || onlyReg.length ? '' : '\n    (same members, different multiplicity)'),
+        );
+      }
+    }
+  }
+
+  for (const entry of entries) {
+    const id = entry.id ?? entry.name;
+    if (!seen.has(id)) errors.push(`registry entry "${id}" has no agent file`);
+  }
+
+  if (json) {
+    console.log(JSON.stringify({ files: files.length, entries: entries.length, comparisons, populated, errors }, null, 2));
+  }
+
+  if (errors.length) {
+    for (const e of errors) console.log(`FAIL  ${e}`);
+    console.log(`\n${errors.length} agent/registry parity error(s).`);
+    console.log('Fix the agent file and agents/_registry.yml together; see #398 and #434.');
+    process.exit(1);
+  }
+
+  console.log(
+    `Agent registry parity: ${files.length} agent(s), ${comparisons} field comparison(s), ` +
+      `${populated} populated on both sides. No drift.`,
+  );
+}
+
+main();

--- a/scripts/envelopes/agent-registry-parity.mjs
+++ b/scripts/envelopes/agent-registry-parity.mjs
@@ -1,0 +1,85 @@
+/**
+ * Envelope for the agent/registry parity gate (#434) — does it go red on the drift it names?
+ *
+ * The gate here is `npm run validate:agent-parity`, the command
+ * `.github/workflows/validate-skills.yml` runs, not the inner script.
+ *
+ * The class this exists for is #398: `apa-specialist` listed 1 skill in its file and 3 in the
+ * registry, from the agent's creation commit, and nothing noticed. The repair in #403 §2a was a
+ * hand-sync of four agents. So the cases below reproduce that drift in both directions, plus the
+ * two failure modes a naive parity check would miss.
+ *
+ * Result at introduction, 2026-08-25:
+ *
+ *     gate-envelope: 5 killed, 1 survived as documented of 6 case(s).
+ *
+ * The documented survivor is ORDER. The two files list skills in different orders in several
+ * places today and that is not drift; a gate that reddened on it would be reverted within a week
+ * and would take the real check with it.
+ *
+ *   node scripts/gate-envelope.js --spec scripts/envelopes/agent-registry-parity.mjs
+ */
+
+export const gate = { command: ['npm', 'run', 'validate:agent-parity'] };
+
+const AGENT = 'agents/code-reviewer.md';
+const REGISTRY = 'agents/_registry.yml';
+
+export const cases = [
+  {
+    label: 'THE #398 SHAPE: the registry lists a skill the agent file does not',
+    // Drift introduced on the registry side, which is the side #398 was wrong on.
+    file: REGISTRY,
+    find: '      - review-pull-request\n      - security-audit-codebase',
+    replace: '      - review-pull-request\n      - manage-backlog\n      - security-audit-codebase',
+    expect: 'code-reviewer.skills',
+  },
+  {
+    label: 'THE OTHER DIRECTION: the agent file lists a skill the registry does not',
+    file: AGENT,
+    find: '  - review-pull-request\n',
+    replace: '  - review-pull-request\n  - manage-backlog\n',
+    expect: 'code-reviewer.skills',
+  },
+  {
+    label: 'TOOLS drift, not only skills',
+    // `tools` is the second field #434 names and is easy to leave uncovered, since every
+    // interesting example anyone reaches for is a skill.
+    file: AGENT,
+    find: 'tools: [Read, Edit, Grep, Glob, Bash, WebFetch]',
+    replace: 'tools: [Read, Edit, Grep, Glob, Bash]',
+    expect: 'code-reviewer.tools',
+  },
+  {
+    label: 'VACUITY: an emptied field must FAIL rather than compare equal',
+    // The half of a parity check that fails silently. Two empty lists ARE equal, so a gate
+    // comparing only agreement reports "no drift" over a field nobody filled in.
+    //
+    // This empties ONE side, which the agreement check would also catch — so on its own it does
+    // not prove the presence rule fires. What it pins is the MESSAGE: the gate must say "empty
+    // on the registry side ... asserts nothing" rather than reporting it as ordinary drift,
+    // because the two have different repairs. The both-empty case is covered by the unit-level
+    // `populated` count the gate prints and by the 150/150 measurement in its header.
+    file: REGISTRY,
+    find: '    tools: [Read, Edit, Grep, Glob, Bash, WebFetch]\n    skills:\n      - review-pull-request',
+    replace: '    tools: []\n    skills:\n      - review-pull-request',
+    expect: 'code-reviewer.tools',
+  },
+  {
+    label: 'AN ORPHANED registry entry with no agent file',
+    file: REGISTRY,
+    find: '  - id: code-reviewer\n',
+    replace: '  - id: no-such-agent\n    path: agents/no-such-agent.md\n    description: x\n    tools: [Read]\n    skills:\n      - review-pull-request\n  - id: code-reviewer\n',
+    expect: 'no-such-agent',
+  },
+  {
+    label: 'ORDER must NOT redden the gate — documented survivor',
+    // Order-insensitivity is deliberate and is asserted here rather than assumed, because it is
+    // the property most likely to be "tightened" by someone who reads the comparison as a list
+    // equality. The corpus already lists these in differing orders in places.
+    file: AGENT,
+    find: '  - review-pull-request\n  - security-audit-codebase',
+    replace: '  - security-audit-codebase\n  - review-pull-request',
+    expect: null,
+  },
+];


### PR DESCRIPTION
Closes #434.

## The gap

`agents/<id>.md` frontmatter and the matching `agents/_registry.yml` entry both carry `skills` and `tools`, and **nothing compared them**. That is how #398 survived from an agent's creation commit — `apa-specialist` listed 1 skill in the file and 3 in the registry — and why #403 §2a re-synced four agents by hand.

A hand-sync with no gate behind it is a repair, not a fix. The same drift is free to reappear on the next agent added.

## Ships blocking, and the number that licenses it

```
Agent registry parity: 75 agent(s), 150 field comparison(s), 150 populated on both sides. No drift.
```

The **150 populated** is the load-bearing figure, not the 0 drift. Two empty lists compare equal, so a "0 drift" result over a corpus where the fields were absent would assert nothing — the vacuous-pass shape this repo keeps rediscovering.

So the checker requires **presence** as well as agreement, reports an empty side with a *different message* from ordinary drift (they have different repairs), and refuses outright if either side enumerates nothing.

## Deliberate choices

- **Order-insensitive.** The two files list skills in different orders in several places today; that is not drift. Asserted as the documented survivor in the envelope rather than assumed, because it is the property most likely to be "tightened" by someone reading the comparison as list equality — and a gate reddening on order gets reverted within a week, taking the real check with it.
- **In `validate-skills.yml`, not `validate-integrity.yml`.** The latter is the better semantic fit and is equally required, but it deliberately runs **no `npm ci`**, and this checker imports `js-yaml`. Placing it there would need a dependency-free YAML reader — a second parser to disagree with the first.
- **Teams out of scope.** #434 raises them as "consider". `teams/_registry.yml` carries `lead`/`members`/`coordination` against a different frontmatter shape — a second comparison with its own vacuity question, which belongs in its own change with its own measurement.

## Negative evidence

`scripts/envelopes/agent-registry-parity.mjs`, against `npm run validate:agent-parity` — the command the workflow runs, not the inner script:

```
gate-envelope: 5 killed, 1 survived as documented of 6 case(s).
```

| case | outcome |
|---|---|
| registry lists a skill the file does not (**the #398 shape**) | killed |
| the same drift in the other direction | killed |
| `tools` drift, not only `skills` | killed |
| an emptied field, reported as vacuity rather than drift | killed |
| an orphaned registry entry with no agent file | killed |
| **reordering** | survived, as documented |

## AC status

- [x] Gate fails when an agent file and its registry entry disagree on skills or tools
- [x] Passes on the current tree (75/75, 0 drift, measured before writing the gate)
- [x] Wired into a PR workflow — and into a **required** one, so it refuses the merge rather than only going red

`test:scripts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yKCWG7uvJezdapqRMc2Wf
