### PR TITLE
refactor: one template predicate for the 115 hand-rolled exclusion sites (#672, #546)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -80,7 +80,10 @@ jobs:
           # NOT routed through TEMPLATE_FIND_PRUNE, deliberately (#672 AC4). That array holds
           # `-not -name` predicates over basenames; this is an anchored `-not -path` whose
           # generic form `*/_template/*` would be depth-agnostic -- the direction
-          # content-paths.js records as measured-wrong, since a nested `_template/` ships.
+          # content-paths.js records as measured-wrong, since a nested `_template/` WOULD ship.
+          # (No nested `_template/` exists on this tree; it is a fact about npm's root-anchored
+          # negations, pinned by a fixture in skills-inventory.test.js, not a fact about the
+          # corpus. An earlier wording read as the latter.)
           # A new spelling is caught by templateSpellingDrift, not by this line.
           disk_count=$(find skills -name SKILL.md -not -path "skills/_template/*" | wc -l)
           reg_count=$(grep 'total_skills:' skills/_registry.yml | tr -d '\r' | awk '{print $2}')

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -41,9 +41,13 @@ jobs:
 
       - name: Validate all skills
         run: |
+          # One definition of "is this scaffolding", shared with validate-integrity.sh and
+          # sync-discovery-symlinks.sh (#672). A `run:` block is bash in the checkout, so it
+          # sources like any other script -- it is not the import-less case.
+          source scripts/lib/template-names.sh
           failed=0
           for dir in skills/*/; do
-            [ "$(basename "$dir")" = "_template" ] && continue
+            is_template "$(basename "$dir")" && continue
             if [ -f "$dir/SKILL.md" ]; then
               if ! skills-ref validate "$dir"; then
                 failed=1
@@ -73,6 +77,11 @@ jobs:
 
       - name: Verify registry count
         run: |
+          # NOT routed through TEMPLATE_FIND_PRUNE, deliberately (#672 AC4). That array holds
+          # `-not -name` predicates over basenames; this is an anchored `-not -path` whose
+          # generic form `*/_template/*` would be depth-agnostic -- the direction
+          # content-paths.js records as measured-wrong, since a nested `_template/` ships.
+          # A new spelling is caught by templateSpellingDrift, not by this line.
           disk_count=$(find skills -name SKILL.md -not -path "skills/_template/*" | wc -l)
           reg_count=$(grep 'total_skills:' skills/_registry.yml | tr -d '\r' | awk '{print $2}')
           if [ "$disk_count" != "$reg_count" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,50 @@ Guides, skills, agents, and teams are cross-referenced. The parent project `CLAU
 - Guides use GitHub-flavored markdown with code blocks for all commands
 - All R examples use `::` for package-qualified calls (e.g., `devtools::check()`) rather than `library()` calls
 
+## Excluding a Template, a README, or a Non-Shipped File
+
+Three questions look like one and are not. Picking the wrong predicate has shipped a bug in
+each direction, so choose by the QUESTION, never by which import is already in the file:
+
+| Ask | Use | Where |
+|---|---|---|
+| is this author scaffolding? | `isTemplate(path)` / `isTemplateSegment(name)` | `scripts/lib/content-paths.js` |
+| is this non-content? (`_`-prefix **or** `README` — a superset) | `isExcludedId(id)` | `scripts/lib/content-paths.js` |
+| does npm ship it? | `isExcludedFromPackage` | `scripts/lib/skills-inventory.js` |
+
+`isExcludedId` is wrong for the package question — its `_`-prefix rule would skip
+`skills/_experimental/tool.py`, which ships. A name test is wrong too, in the other direction:
+npm's `files` negations are **root-anchored**, so `skills/<id>/_template/helper.py` also ships,
+and a depth-agnostic `includes('_template')` was measured wrong against `npm pack` and reverted.
+`isTemplate` is root-anchored for the same reason (an `i18n/<locale>/` prefix is stripped first,
+so a mirror anchors like its English source). Do not collapse the three.
+
+`_template` exists in **three spellings** — `_template`, `_template.md`, `_template.mjs` — across
+six paths in six trees, two of which (`tests/`, `workflows/`) are not `CONTENT_TYPES`. The set is
+EXACT, not a `_template*` prefix: a prefix silently absorbs a new spelling, which would make the
+drift check unable to fail at all.
+
+That set exists **twice**, because a bash script cannot import an ES module:
+
+```
+scripts/lib/content-paths.js   TEMPLATE_SEGMENTS   the JS half
+scripts/lib/template-names.sh  TEMPLATE_NAMES      the shell half, sourced by
+                                                   validate-integrity.sh,
+                                                   sync-discovery-symlinks.sh
+                                                   and validate-skills.yml
+```
+
+**Adding a spelling means editing both, in the same commit.** `template-predicate.test.js`
+asserts set equality in both directions and separately drives the shell function name by name,
+so a one-sided edit fails naming the other side. `templateSpellingDrift` checks the sets against
+what is actually tracked, also in both directions — a spelling on disk the predicate misses, and
+a declared member no path uses.
+
+A `run:` block in a workflow is bash executing in the checkout and can `source` that file; "a
+workflow cannot import" is an assumption, not a constraint. What genuinely cannot be routed is a
+`find -not -path` prune, whose anchor is tree-specific — those two sites carry their reason
+inline.
+
 ## Skill Validation
 
 - SKILL.md files must stay under 500 lines; extract extended examples to `references/EXAMPLES.md` using the progressive disclosure pattern

--- a/scripts/check-agent-registry-parity.js
+++ b/scripts/check-agent-registry-parity.js
@@ -29,6 +29,7 @@
 import * as yaml from 'js-yaml';
 import { readFileSync, existsSync } from 'node:fs';
 import { execSync } from 'node:child_process';
+import { isTemplate } from './lib/content-paths.js';
 
 const FIELDS = ['skills', 'tools'];
 
@@ -64,7 +65,10 @@ function listAgentFiles() {
   return out
     .split('\n')
     .filter(Boolean)
-    .filter((p) => !p.includes('_template') && !p.endsWith('README.md'));
+    // `!p.includes('_template')` before #672, which also dropped a hypothetical
+    // `agents/my_template_notes.md` from the parity comparison — silently, since a file
+    // absent from BOTH sides of a set comparison is invisible rather than red.
+    .filter((p) => !isTemplate(p) && !p.endsWith('README.md'));
 }
 
 function loadRegistry() {

--- a/scripts/check-content-style.js
+++ b/scripts/check-content-style.js
@@ -19,6 +19,7 @@ import { readFileSync, existsSync } from "node:fs";
 // The shared extractor, so `--untagged-strict` cannot drift from the fold it protects (#629).
 // Node builtins and local libs only — no package dependency is added to this script.
 import { extractFences } from "./lib/fences.js";
+import { isTemplate } from "./lib/content-paths.js";
 
 const CONTENT_GLOBS = ["skills/", "agents/", "teams/", "guides/", "i18n/"];
 
@@ -31,7 +32,12 @@ const ENGLISH_TREES = ["skills/", "agents/", "teams/", "guides/"];
 
 function isContentFile(p) {
   if (!CONTENT_GLOBS.some((g) => p.startsWith(g))) return false;
-  if (p.includes("/_template")) return false; // templates are author scaffolding
+  if (isTemplate(p)) return false; // templates are author scaffolding
+  // Was `p.includes("/_template")` (#672). Same verdict on every path in this corpus,
+  // and two differences that matter: the substring also excluded
+  // `guides/my_template_notes.md`, and it matched at any depth, where npm's own
+  // negations are root-anchored. `isTemplate` strips an `i18n/<locale>/` prefix, which
+  // is what keeps the mirror templates this glob list reaches excluded as before.
   return p.endsWith(".md");
 }
 

--- a/scripts/check-workflow-generator-inputs.js
+++ b/scripts/check-workflow-generator-inputs.js
@@ -303,9 +303,10 @@ function importGraph(entry, seen = new Set()) {
   // sits in the graph and its own changes move generated output. The negated character class
   // spans newlines, so multi-line forms are covered without an `s` flag.
   //
-  // The specifier is anchored on `from`, and that is load-bearing rather than tidy. Without it
-  // the class ran from an `export` keyword straight into the FUNCTION BODY below it and took
-  // the first quoted string it found:
+  // Two constraints on the span before the specifier, and both are load-bearing.
+  //
+  // ANCHORED ON `from`, because without it the class ran from an `export` keyword straight into
+  // the FUNCTION BODY below and took the first quoted string it found:
   //
   //     export function isExcludedId(id) {
   //       const stem = id.endsWith('.md') ? …
@@ -315,7 +316,21 @@ function importGraph(entry, seen = new Set()) {
   // module in the healer's graph exported a function whose body's first quoted literal began
   // with a dot (#672), and would have recurred for any future one. `import './side-effect.js'`
   // has no `from`, hence the optional group rather than a required one.
-  const specifiers = [...text.matchAll(/^\s*(?:import|export)\s(?:[^'"]*?\bfrom\s*)?['"](\.[^'"]+)['"]/gm)]
+  //
+  // And the span is `[\w$*,{}\s]`, not `[^'"]`, because anchoring alone did NOT close the
+  // class -- it only narrowed it. Any line-start `export`/`import` whose text contains the word
+  // `from` before a dotted quoted string still matched, so
+  //
+  //     export const probe = 1; // adapted from './old.js'
+  //
+  // reproduced the same hard refusal. Measured on this tree, not argued. The character class
+  // is what an import CLAUSE can actually contain -- identifiers, `*`, `as`, commas, braces,
+  // whitespace -- and it admits the multi-line form (a newline is `\s`) while excluding the
+  // `=`, `;`, `(` and `/` that any statement or comment carrying a stray `from` must have.
+  //
+  // Found by an adversarial reviewer, who named the experiment rather than asserting it; the
+  // planted line refused exactly as predicted.
+  const specifiers = [...text.matchAll(/^\s*(?:import|export)\s(?:[\w$*,{}\s]*?\bfrom\s*)?['"](\.[^'"]+)['"]/gm)]
     .map((m) => m[1]);
   for (const specifier of specifiers) {
     importGraph(relative(ROOT, resolvePath(dirname(absolute), specifier)), seen);

--- a/scripts/check-workflow-generator-inputs.js
+++ b/scripts/check-workflow-generator-inputs.js
@@ -302,7 +302,20 @@ function importGraph(entry, seen = new Set()) {
   // `export … from './x.js'` is an edge as much as `import` is: a re-exporting barrel module
   // sits in the graph and its own changes move generated output. The negated character class
   // spans newlines, so multi-line forms are covered without an `s` flag.
-  const specifiers = [...text.matchAll(/^\s*(?:import|export)\s[^'"]*['"](\.[^'"]+)['"]/gm)]
+  //
+  // The specifier is anchored on `from`, and that is load-bearing rather than tidy. Without it
+  // the class ran from an `export` keyword straight into the FUNCTION BODY below it and took
+  // the first quoted string it found:
+  //
+  //     export function isExcludedId(id) {
+  //       const stem = id.endsWith('.md') ? …
+  //
+  // read as an import of `./lib/.md`, which does not exist, so this check hard-refused —
+  // exiting non-zero even under `--warn`, in a REQUIRED context. It surfaced the first time a
+  // module in the healer's graph exported a function whose body's first quoted literal began
+  // with a dot (#672), and would have recurred for any future one. `import './side-effect.js'`
+  // has no `from`, hence the optional group rather than a required one.
+  const specifiers = [...text.matchAll(/^\s*(?:import|export)\s(?:[^'"]*?\bfrom\s*)?['"](\.[^'"]+)['"]/gm)]
     .map((m) => m[1]);
   for (const specifier of specifiers) {
     importGraph(relative(ROOT, resolvePath(dirname(absolute), specifier)), seen);

--- a/scripts/check-yaml-fences.js
+++ b/scripts/check-yaml-fences.js
@@ -80,7 +80,7 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
-import { extractFences, TREES, contentKey } from './lib/fences.js';
+import { extractFences, TREES, contentKey, isExcludedId } from './lib/fences.js';
 
 const argv = process.argv.slice(2);
 let JSON_OUT = false;
@@ -117,8 +117,17 @@ if (!existsSync(ROOT) || !statSync(ROOT).isDirectory()) {
 }
 
 /**
- * Every content file under one root: the four trees, `_`-prefixed ids skipped
- * the way `buildEnglishFenceHistory` skips them.
+ * Every content file under one root: the four trees, non-content ids skipped via
+ * `isExcludedId`.
+ *
+ * That skip is REDUNDANT with the `contentKey` call below, and deliberately kept. It is why
+ * this tool never had the #519 bug: it drops `_template` before `contentKey` is consulted, so
+ * the flat/nested asymmetry could not reach it. It also short-circuits two `existsSync` calls.
+ *
+ * The previous wording — "`_`-prefixed ids skipped the way `buildEnglishFenceHistory` skips
+ * them" — described a redundancy as if it were the mechanism, inviting a reader to believe the
+ * skip works BECAUSE the history builder does the same thing. Post-#546 both go through the one
+ * predicate, so they cannot drift; before it, that sentence was the drift's alibi.
  */
 function contentFiles(base, prefix = '') {
   const out = [];
@@ -126,7 +135,7 @@ function contentFiles(base, prefix = '') {
     const dir = join(base, tree);
     if (!existsSync(dir) || !statSync(dir).isDirectory()) continue;
     for (const entry of readdirSync(dir)) {
-      if (entry.startsWith('_')) continue;
+      if (isExcludedId(entry)) continue;
       const rel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;
       if (contentKey(rel) === null) continue;
       const abs = join(base, rel);

--- a/scripts/coverage-matrix.js
+++ b/scripts/coverage-matrix.js
@@ -24,6 +24,7 @@
  */
 
 import { readFileSync, readdirSync, existsSync, writeFileSync } from 'fs';
+import { isTemplateSegment } from './lib/content-paths.js';
 import { resolve, dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
@@ -69,8 +70,14 @@ export function buildCoverageMatrix() {
   const workflowsDir = resolve(ROOT, 'workflows');
   const workflowSkills = {};
   if (existsSync(workflowsDir)) {
+    // `!name.startsWith('_')` before #672. Byte-identical to the filter `generate-readmes.js`
+    // used to enumerate the same directory, so converting only that one would have left two
+    // enumerations of `workflows/` disagreeing about a future `workflows/_draft.mjs` -- the
+    // #546 pair-shape recreated one level over. An adversarial review caught it filed under
+    // #740 as a content-id question; it is the template question. No-op today: `_template.mjs`
+    // is the only `_`-prefixed entry in `workflows/`.
     for (const file of readdirSync(workflowsDir).filter(
-      (name) => name.endsWith('.mjs') && !name.startsWith('_')
+      (name) => name.endsWith('.mjs') && !isTemplateSegment(name)
     )) {
       const body = readFileSync(join(workflowsDir, file), 'utf8');
       workflowSkills[file.replace(/\.mjs$/, '')] = allSkillIds.filter((id) => body.includes(id));

--- a/scripts/generate-readmes.js
+++ b/scripts/generate-readmes.js
@@ -17,6 +17,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import * as yaml from 'js-yaml';
 import { CONTENT_TYPES } from './lib/content-types.js';
+import { isTemplateSegment } from './lib/content-paths.js';
 import { listAdapters } from '../cli/adapters/index.js';
 import { guideCategoryOrder, guideCategoryLabel, guideCategoryNames } from './lib/guide-categories.js';
 import { applySections, renderTranslationsTable, renderLocaleTable } from './lib/readme-sections.js';
@@ -706,8 +707,12 @@ function generateSecuritySurface() {
   // it entirely — a larger gap, for a section scoping executable content, than the `scripts/`
   // mis-description #600 was filed about (#691). `_template.mjs` is excluded the same way
   // `skills/_template/` is: it is scaffolding, not a workflow.
+  // `!f.startsWith('_')` before #672. The comment above states the TEMPLATE intent while the
+  // code tested the `_`-prefix convention, so a future `workflows/_draft.mjs` would have gone
+  // uncounted under a sentence that describes scaffolding as the only exclusion. No-op today:
+  // `_template.mjs` is the sole `_`-prefixed entry in `workflows/`.
   const workflowFiles = readdirSync(resolve(ROOT, 'workflows'))
-    .filter((f) => f.endsWith('.mjs') && !f.startsWith('_')).length;
+    .filter((f) => f.endsWith('.mjs') && !isTemplateSegment(f)).length;
 
   const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
   const shipped = pkg.files || [];

--- a/scripts/lib/content-paths.js
+++ b/scripts/lib/content-paths.js
@@ -36,6 +36,17 @@ import { CONTENT_TYPES } from './content-types.js';
 export const TEMPLATE_SEGMENTS = Object.freeze(['_template', '_template.md', '_template.mjs']);
 
 /**
+ * What a template's name could plausibly be spelled as — the DISCOVERY ruler for
+ * `templateSpellingDrift`, never the membership test.
+ *
+ * Looser than `TEMPLATE_SEGMENTS` on purpose: finding a spelling the exact set has never seen
+ * is the whole job. Tighter than `startsWith('_template')`, because that also matches
+ * `_templates.md` and `_template_backup` — see `templateSpellingDrift`'s docblock for the
+ * deadlock that produced.
+ */
+const TEMPLATE_SPELLING = /^_template(\.[a-z0-9]+)?$/;
+
+/**
  * Is this single path SEGMENT a template's name?
  *
  * For callers that already hold a bare name — a `readdirSync` entry, a `basename`. Callers
@@ -126,6 +137,28 @@ function anchoredSegment(relPath) {
  * Takes the path list rather than reading the filesystem, so the caller supplies the tracked
  * ruler rather than a walk that would descend into `node_modules` and `i18n/`.
  *
+ * ## The discovery ruler, and the deadlock it used to create
+ *
+ * Discovery is `TEMPLATE_SPELLING`, deliberately LOOSER than membership but not merely a
+ * prefix. `startsWith('_template')` was the first version and two reviewers independently
+ * found the same defect in it: it is also true of `_templates.md` and `_template_backup`.
+ * Neither is a template, and the unit tests say so — so the day one was tracked, this check
+ * would go red reporting it `uncovered`, i.e. demanding the predicate absorb a path a sibling
+ * test forbids it to absorb. No waiver existed; the only exit was renaming the file.
+ *
+ * `^_template(\.[a-z0-9]+)?$` is the whole of it: the bare name, or the bare name plus one
+ * extension. A genuinely new spelling (`_template.yml`) still lands as `uncovered`, which is
+ * the entire job; a lookalike is simply not a candidate.
+ *
+ * ## What it still cannot see, stated rather than left to be found
+ *
+ * A path with fewer than two segments after normalisation has no anchored position, so a
+ * repo-root `_template.md` and a locale-root `i18n/de/_template.md` are invisible here —
+ * neither covered nor uncovered. Both are outside every content tree, so neither is scaffolding
+ * in the sense any consumer means, and treating them as findings would report drift against
+ * files no exclusion site would ever consult. The boundary is recorded because "the check did
+ * not fire" and "the check cannot see it" read identically in a green run.
+ *
  * @param {string[]} paths every repo-relative tracked path
  * @returns {{uncovered: string[], dead: string[]}}
  */
@@ -138,7 +171,7 @@ export function templateSpellingDrift(paths) {
   // `skills-inventory.test.js` pins that it must be counted. Scanning every segment reported
   // it as `uncovered`, so this check would have gone red demanding the predicate absorb a path
   // the predicate is right to reject. Caught by its own test before it ever ran in CI.
-  const anchored = paths.filter((p) => anchoredSegment(p)?.startsWith('_template') === true);
+  const anchored = paths.filter((p) => TEMPLATE_SPELLING.test(anchoredSegment(p) ?? ''));
   const uncovered = anchored.filter((p) => !isTemplate(p)).sort();
   const used = new Set(anchored.filter((p) => isTemplate(p)).map((p) => anchoredSegment(p)));
   const dead = TEMPLATE_SEGMENTS.filter((s) => !used.has(s));

--- a/scripts/lib/content-paths.js
+++ b/scripts/lib/content-paths.js
@@ -100,6 +100,13 @@ export function isTemplate(relPath) {
  */
 function anchoredSegment(relPath) {
   let parts = String(relPath).split('/');
+  // A leading `./` would shift every index by one and return a SILENT wrong answer -- the
+  // anchored segment would be the tree name, so `./agents/_template.md` reads as not a
+  // template. No caller passes that shape today; all four feed it `git ls-files` output or a
+  // `readdirSync` entry. It is handled anyway because `fences.js` already carries the lesson
+  // in its own margin: "a 'cannot happen' margin is exactly how this module keeps getting
+  // bypassed". Repeated `./` is not handled and does not occur.
+  if (parts[0] === '.') parts = parts.slice(1);
   if (parts[0] === 'i18n' && parts.length > 2) parts = parts.slice(2);
   return parts.length >= 2 ? parts[1] : undefined;
 }

--- a/scripts/lib/content-paths.js
+++ b/scripts/lib/content-paths.js
@@ -11,6 +11,130 @@
 
 import { CONTENT_TYPES } from './content-types.js';
 
+/**
+ * The exact names a template goes by, one per spelling that exists on disk (#672).
+ *
+ * ## Why an exact set and not a prefix test
+ *
+ * `startsWith('_template')` would be shorter and would auto-cover a future `_template.yml`.
+ * That is precisely the objection: a predicate that silently absorbs a new spelling cannot be
+ * checked, so `templateSpellingDrift` below could never fail, and the fourth acceptance
+ * criterion of #672 — "a check fails when a new `_template*` spelling appears that the
+ * predicate does not cover" — would be unsatisfiable by construction. An exact set plus a
+ * discovery check is the trade the debt ratchet already makes here: enumerate the members,
+ * and let the arrival of a new one be an event rather than a silent absorption.
+ *
+ * Measured on this tree — six paths, three spellings, and note the SIXTH tree:
+ *
+ *   agents/_template.md          teams/_template.md
+ *   guides/_template.md          tests/_template.md      <- not a CONTENT_TYPE
+ *   skills/_template/SKILL.md    workflows/_template.mjs
+ *
+ * Hence tree-agnostic below. Hard-coding `CONTENT_TYPES` would have missed `tests/` and
+ * `workflows/`, which is the drift-pair shape this module already carries two warnings about.
+ */
+export const TEMPLATE_SEGMENTS = Object.freeze(['_template', '_template.md', '_template.mjs']);
+
+/**
+ * Is this single path SEGMENT a template's name?
+ *
+ * For callers that already hold a bare name — a `readdirSync` entry, a `basename`. Callers
+ * holding a path want `isTemplate`, which anchors.
+ *
+ * @param {string} segment one path segment
+ * @returns {boolean}
+ */
+export function isTemplateSegment(segment) {
+  return TEMPLATE_SEGMENTS.includes(segment);
+}
+
+/**
+ * Is this repo-relative path a template — author scaffolding rather than real content?
+ *
+ * ROOT-ANCHORED: the template must be the second segment, `<tree>/_template*`. Not a stylistic
+ * choice; it is the one direction that was MEASURED wrong. `skills-inventory.js`'s first
+ * version skipped any entry named `_template` at any depth, which #672 itself counts as its
+ * own 55th hand-rolled site, and it disagreed with npm: the `files` negations are
+ * root-anchored gitignore-style patterns, so `skills/<id>/_template/helper.py` SHIPS.
+ * `skills-inventory.test.js` pins that with a live fixture. A depth-agnostic test here would
+ * re-introduce that bug one directory over.
+ *
+ * Equally not `includes('_template')`, the spelling three call sites used before this: that
+ * also matches `guides/my_template_notes.md` and `agents/_templates.md`, neither of which is
+ * a template.
+ *
+ * ## What it deliberately does NOT answer
+ *
+ * - **Does this ship to npm?** No. That is `isExcludedFromPackage` in `skills-inventory.js`,
+ *   derived from `package.json`'s own negations. Its JSDoc records that BOTH hand-rolled
+ *   rules — a name test and `isExcludedId` — are wrong against npm, in opposite directions.
+ * - **Is this non-content?** No. That is `isExcludedId`, which is `_`-prefix-or-README and so
+ *   also covers `_registry.yml` and `README.md`. A template is a strict subset.
+ * - **Is this a mirror's template?** YES — `i18n/<locale>/` is stripped first, so
+ *   `i18n/de/skills/_template/SKILL.md` is a template. An earlier draft of this returned false
+ *   and wrote the limitation up as a principle ("mirrors are not scaffolding"), which is
+ *   backwards: the German mirror of a template is a template. It also silently changed
+ *   `check-content-style.js`, whose `isContentFile` lists `i18n/` among its globs and has
+ *   always excluded mirror templates via `includes('/_template')`. Zero mirror templates are
+ *   tracked today, so nothing on this corpus would have caught it.
+ *
+ * @param {string} relPath repo-relative path, as the tracked-file list prints it
+ * @returns {boolean}
+ */
+export function isTemplate(relPath) {
+  return isTemplateSegment(anchoredSegment(relPath));
+}
+
+/**
+ * The segment a template would occupy in this path, or `undefined`.
+ *
+ * `<tree>/HERE/...`, with a leading `i18n/<locale>/` stripped so a mirror anchors like its
+ * English source. Factored out because `isTemplate` and `templateSpellingDrift` must agree on
+ * WHERE to look while disagreeing on WHAT counts — exact set versus prefix. Two copies of
+ * "where" is how the pair would come to disagree, which is the whole subject of #672.
+ *
+ * The locale is matched structurally (any single segment under `i18n/`) rather than against
+ * the configured locale list. Importing that list would give this module a dependency, and
+ * `content-types.js`'s header records why the modules on the B13 path must reach nothing but
+ * node builtins.
+ */
+function anchoredSegment(relPath) {
+  let parts = String(relPath).split('/');
+  if (parts[0] === 'i18n' && parts.length > 2) parts = parts.slice(2);
+  return parts.length >= 2 ? parts[1] : undefined;
+}
+
+/**
+ * Both directions of drift between `TEMPLATE_SEGMENTS` and what is on disk (#672 AC4).
+ *
+ * Returns `{ uncovered, dead }`. `uncovered` is a `_template*` path the predicate does not
+ * match — a new spelling every exclusion site would silently stop excluding. `dead` is a
+ * declared member no path uses, which is how a set stays green while describing a corpus that
+ * has moved on. Exact-set, never "observed is a subset of declared": a subset check is green
+ * when one member is removed and another appears, which is the shape that keeps deletions
+ * green forever.
+ *
+ * Takes the path list rather than reading the filesystem, so the caller supplies the tracked
+ * ruler rather than a walk that would descend into `node_modules` and `i18n/`.
+ *
+ * @param {string[]} paths every repo-relative tracked path
+ * @returns {{uncovered: string[], dead: string[]}}
+ */
+export function templateSpellingDrift(paths) {
+  // Discovery is deliberately LOOSER than membership, and only at the anchored position.
+  //
+  // Loose, because a prefix is what finds a spelling the exact set has never seen — that is
+  // the whole job. Anchored, because a nested `skills/<id>/_template/helper.py` is a
+  // deliberate non-match rather than an uncovered one: npm ships it, and
+  // `skills-inventory.test.js` pins that it must be counted. Scanning every segment reported
+  // it as `uncovered`, so this check would have gone red demanding the predicate absorb a path
+  // the predicate is right to reject. Caught by its own test before it ever ran in CI.
+  const anchored = paths.filter((p) => anchoredSegment(p)?.startsWith('_template') === true);
+  const uncovered = anchored.filter((p) => !isTemplate(p)).sort();
+  const used = new Set(anchored.filter((p) => isTemplate(p)).map((p) => anchoredSegment(p)));
+  const dead = TEMPLATE_SEGMENTS.filter((s) => !used.has(s));
+  return { uncovered, dead };
+}
 
 /**
  * Repo-relative English content path -> stable `<tree>/<id>` key, or null when

--- a/scripts/lib/content-paths.js
+++ b/scripts/lib/content-paths.js
@@ -11,6 +11,7 @@
 
 import { CONTENT_TYPES } from './content-types.js';
 
+
 /**
  * Repo-relative English content path -> stable `<tree>/<id>` key, or null when
  * the path is not translatable content.
@@ -53,17 +54,6 @@ export function contentKey(relPath) {
   return null;
 }
 
-/**
- * Names that live inside a content tree without being content.
- *
- * Takes a RAW path segment and strips a `.md` suffix itself, so the two branches above can
- * hand it the same kind of thing. They could not before: the flat branch stripped the
- * extension before testing while the nested branch passed a bare directory segment, which
- * made `contentKey('skills/README.md/SKILL.md')` return `skills/README.md` instead of null
- * while `contentKey('skills/README.md')` correctly returned null. Unreachable today only
- * because every caller happens to `statSync(...).isFile()` afterwards — which is the
- * "unreachable because of ambient state" framing #519 exists to reject.
- */
 /**
  * Every path shape a `git log` pathspec must carry to see one key's whole history (#682).
  *
@@ -144,7 +134,45 @@ export function historicalPathspecs(englishRel) {
   return [englishRel];
 }
 
-function isExcludedId(id) {
+/**
+ * Names that live inside a content tree without being content.
+ *
+ * Takes a RAW path segment and strips a `.md` suffix itself, so both branches of `contentKey`
+ * can hand it the same kind of thing. They could not before: the flat branch stripped the
+ * extension before testing while the nested branch passed a bare directory segment, which
+ * made `contentKey('skills/README.md/SKILL.md')` return `skills/README.md` instead of null
+ * while `contentKey('skills/README.md')` correctly returned null. Unreachable today only
+ * because every caller happens to `statSync(...).isFile()` afterwards — which is the
+ * "unreachable because of ambient state" framing #519 exists to reject.
+ *
+ * (This docblock spent several revisions stranded ~80 lines above the function, immediately
+ * followed by a second `/**`, so every reader and every JSDoc tool attached it to
+ * `historicalPathspecs` instead. Restored here in #546.)
+ *
+ * EXPORTED for #546, so the `_`-prefix guards that shadow it cannot narrow independently.
+ * Two callers — `check-yaml-fences.js` and the working-tree arm of `walkEnglishHistory` —
+ * short-circuit on the prefix before `contentKey` is ever consulted. Those guards are
+ * deliberate defence in depth and are KEPT: `check-yaml-fences.js` never had the #519 bug
+ * precisely because it skips `_template` before the flat/nested asymmetry can reach it.
+ *
+ * The redundancy is only safe in one direction. This predicate is a strict superset of
+ * `startsWith('_')`, so WIDENING it propagates to the shadowing guards correctly. NARROWING
+ * it would not, and the failure is nastier than #519's: if `_`-prefixed content were ever
+ * declared to be content, the working-tree arm would still skip it while the git-log arm
+ * included it — a PARTIAL basis, which yields false-positive violations only for fences added
+ * since the last commit. Intermittent, content-dependent, and it reads as a translation
+ * defect rather than a tooling one. Routing both guards through this function is what makes
+ * that unrepresentable.
+ *
+ * NOT the package's exclusion rule, and not a template test. `skills-inventory.js` measured
+ * both differences: this rule would skip `skills/_experimental/tool.py`, which SHIPS, and it
+ * says nothing about `_template` specifically. Use `isTemplate` for the scaffolding question
+ * and `isExcludedFromPackage` for the npm one.
+ *
+ * @param {string} id a raw path segment, with or without a `.md` suffix
+ * @returns {boolean} true when the segment names something that is not content
+ */
+export function isExcludedId(id) {
   const stem = id.endsWith('.md') ? id.slice(0, -3) : id;
   return stem.startsWith('_') || stem === 'README';
 }

--- a/scripts/lib/content-paths.js
+++ b/scripts/lib/content-paths.js
@@ -55,9 +55,11 @@ export function isTemplateSegment(segment) {
  * choice; it is the one direction that was MEASURED wrong. `skills-inventory.js`'s first
  * version skipped any entry named `_template` at any depth, which #672 itself counts as its
  * own 55th hand-rolled site, and it disagreed with npm: the `files` negations are
- * root-anchored gitignore-style patterns, so `skills/<id>/_template/helper.py` SHIPS.
- * `skills-inventory.test.js` pins that with a live fixture. A depth-agnostic test here would
- * re-introduce that bug one directory over.
+ * root-anchored gitignore-style patterns, so `skills/<id>/_template/helper.py` WOULD ship.
+ * `skills-inventory.test.js` pins that with a fixture built at test time. Note the tense: no
+ * nested `_template/` exists on this tree, so this is a fact about npm's matching rules rather
+ * than about the corpus, and an earlier wording ("SHIPS", "a live fixture") read as the latter
+ * on both counts. A depth-agnostic test here would re-introduce that bug one directory over.
  *
  * Equally not `includes('_template')`, the spelling three call sites used before this: that
  * also matches `guides/my_template_notes.md` and `agents/_templates.md`, neither of which is

--- a/scripts/lib/english-history.js
+++ b/scripts/lib/english-history.js
@@ -42,7 +42,7 @@ import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
 import { CONTENT_TYPES } from './content-types.js';
-import { contentKey } from './content-paths.js';
+import { contentKey, isExcludedId } from './content-paths.js';
 import { catFileBatch, GIT_BUFFER } from './git-batch.js';
 
 /**
@@ -306,7 +306,12 @@ export function walkEnglishHistory(root, onBlob, { paths = null } = {}) {
     const base = join(root, tree);
     if (!existsSync(base)) continue;
     for (const entry of readdirSync(base)) {
-      if (entry.startsWith('_')) continue;
+      // Through the predicate, never an inline `startsWith('_')` (#546). This guard shadows
+      // the `contentKey` call eight lines below, and a shadow that can narrow independently
+      // is how the two arms of this walk would come to disagree: git-log revisions carrying a
+      // key the working tree omits is a PARTIAL basis, and a partial basis accuses only the
+      // fences added since the last commit.
+      if (isExcludedId(entry)) continue;
       const path = tree === 'skills' ? join(base, entry, 'SKILL.md') : join(base, entry);
       if (!existsSync(path) || !statSync(path).isFile()) continue;
       const rel = tree === 'skills' ? `${tree}/${entry}/SKILL.md` : `${tree}/${entry}`;

--- a/scripts/lib/fences.js
+++ b/scripts/lib/fences.js
@@ -26,7 +26,7 @@
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { CONTENT_TYPES } from './content-types.js';
-import { contentKey } from './content-paths.js';
+import { contentKey, isExcludedId } from './content-paths.js';
 import { walkEnglishHistory } from './english-history.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
@@ -129,6 +129,13 @@ export const TREES = CONTENT_TYPES;
  * the same caveat: nothing in this module reads `contentKey` internally today either.
  */
 export { contentKey };
+
+/**
+ * Re-exported for the same reason `contentKey` is: #546 names this module as the place callers
+ * reach for the exclusion, and `check-yaml-fences.js` already imports from here. One import
+ * line, one predicate, no third spelling.
+ */
+export { isExcludedId };
 
 /**
  * Union of every fence body that has ever appeared in each English SKILL.md,

--- a/scripts/lib/template-names.sh
+++ b/scripts/lib/template-names.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# template-names.sh -- the one shell definition of "this name is author scaffolding" (#672).
+#
+# Sourced by `validate-integrity.sh` and `sync-discovery-symlinks.sh`, which between them
+# carried 19 hand-rolled `_template` exclusions in four spellings: `[[ "$name" ==
+# "_template.md" ]]`, `-not -name '_template.md'`, `[ "$f" = "skills/_template/SKILL.md" ]`
+# and `grep -v '^_template$'`.
+#
+# ## This list is one half of a PAIR
+#
+# The other half is `TEMPLATE_SEGMENTS` in `scripts/lib/content-paths.js`. A shell script
+# cannot import an ES module, so the duplication is structural rather than lazy -- which is
+# exactly the situation that produced the 19 sites in the first place, one level up. It is
+# therefore GATED: `scripts/test/content-paths.test.js` parses this file and asserts the two
+# lists are equal as sets, in both directions. Add a spelling to one and the suite goes red
+# naming the other.
+#
+# Do not "simplify" the array to a `_template*` glob. The exact set is what makes the drift
+# check in `templateSpellingDrift` able to fail at all; a prefix silently absorbs a new
+# spelling and reports nothing. The reasoning is in that function's JSDoc.
+#
+# shellcheck shell=bash
+
+# Every name a template goes by, matching content-paths.js's TEMPLATE_SEGMENTS exactly.
+TEMPLATE_NAMES=('_template' '_template.md' '_template.mjs')
+
+# Is this basename (or bare path segment) a template's name?
+#
+# Usage mirrors the `[[ ... ]] && continue` idiom it replaces, which is safe under `set -e`
+# because a non-final command in an `&&` list does not trigger the exit.
+is_template() { # <basename>
+  local candidate
+  for candidate in "${TEMPLATE_NAMES[@]}"; do
+    [[ "$1" == "$candidate" ]] && return 0
+  done
+  return 1
+}
+
+# `find` predicates excluding every template name, for expansion into a find invocation:
+#
+#   find agents -maxdepth 1 -name '*.md' "${TEMPLATE_FIND_PRUNE[@]}" -not -name 'README.md'
+#
+# Built from the array above rather than written out, so a new spelling reaches the `find`
+# sites and the `[[ ]]` sites together. Widening a find that previously excluded only
+# `_template.md` is a no-op wherever `-name '*.md'` already constrains the match.
+TEMPLATE_FIND_PRUNE=()
+for _template_name in "${TEMPLATE_NAMES[@]}"; do
+  TEMPLATE_FIND_PRUNE+=(-not -name "$_template_name")
+done
+unset _template_name
+
+# Filter template ids out of a newline-separated id list on stdin.
+#
+# `-x` anchors whole-line and `-F` takes the patterns literally, so this is the exact-set
+# semantics of `is_template` rather than the `grep -v '^_template$'` it replaces -- which was
+# a fourth spelling of the rule, and covered only one of the three names.
+strip_template_ids() {
+  grep -vxF -f <(printf '%s\n' "${TEMPLATE_NAMES[@]}") || true
+}

--- a/scripts/lib/template-names.sh
+++ b/scripts/lib/template-names.sh
@@ -1,19 +1,41 @@
 #!/usr/bin/env bash
 # template-names.sh -- the one shell definition of "this name is author scaffolding" (#672).
 #
-# Sourced by `validate-integrity.sh` and `sync-discovery-symlinks.sh`, which between them
-# carried 19 hand-rolled `_template` exclusions in four spellings: `[[ "$name" ==
-# "_template.md" ]]`, `-not -name '_template.md'`, `[ "$f" = "skills/_template/SKILL.md" ]`
-# and `grep -v '^_template$'`.
+# Sourced by `validate-integrity.sh`, `sync-discovery-symlinks.sh` and one step of
+# `.github/workflows/validate-skills.yml`.
+#
+# COUNTS, measured on the pre-change files rather than quoted from the issue -- an earlier
+# revision of this comment said the two scripts "between them carried 19", which was wrong:
+# that 19 belongs to validate-integrity.sh alone, and the neighbouring comment in that file
+# said "19 ... and sync-discovery carried two more", so the two texts contradicted each other.
+#
+#   validate-integrity.sh        19 lines  (18 routed here, 1 `-not -path` kept, see below)
+#   sync-discovery-symlinks.sh    3 lines  (2 executable, both routed)
+#   validate-skills.yml           2 lines  (1 routed, 1 `-not -path` kept)
+#
+# And they were written in at least SIX distinct constructions, not the "four" an earlier
+# revision claimed -- the issue itself hedged "at least four" and dropping the hedge was an
+# overclaim:
+#
+#   [[ "$name" == "_template.md" ]]          -not -name '_template.md'
+#   [ "$f" = "skills/_template/SKILL.md" ]   ! -name '_template'
+#   grep -v '^_template$'                    -not -path 'skills/_template/*'
 #
 # ## This list is one half of a PAIR
 #
 # The other half is `TEMPLATE_SEGMENTS` in `scripts/lib/content-paths.js`. A shell script
 # cannot import an ES module, so the duplication is structural rather than lazy -- which is
 # exactly the situation that produced the 19 sites in the first place, one level up. It is
-# therefore GATED: `scripts/test/content-paths.test.js` parses this file and asserts the two
-# lists are equal as sets, in both directions. Add a spelling to one and the suite goes red
-# naming the other.
+# therefore GATED by `scripts/test/template-predicate.test.js`, which reads this array by
+# SOURCING this file and asserts set equality against `TEMPLATE_SEGMENTS` in both directions,
+# then drives `is_template` name by name over the UNION of both sets. Add a spelling to one
+# side and the suite goes red naming the other.
+#
+# It read the array with a REGEX for one revision, and that was evadable in three ways an
+# adversarial review enumerated: a `TEMPLATE_NAMES+=(...)` on a later line, a second full
+# assignment, and a double-quoted name added inside these parens. All three left the shell set
+# a strict superset of the JS one with every test green. Sourcing closes the class, because it
+# observes what the consumers observe rather than what the source text looks like.
 #
 # Do not "simplify" the array to a `_template*` glob. The exact set is what makes the drift
 # check in `templateSpellingDrift` able to fail at all; a prefix silently absorbs a new
@@ -41,8 +63,16 @@ is_template() { # <basename>
 #   find agents -maxdepth 1 -name '*.md' "${TEMPLATE_FIND_PRUNE[@]}" -not -name 'README.md'
 #
 # Built from the array above rather than written out, so a new spelling reaches the `find`
-# sites and the `[[ ]]` sites together. Widening a find that previously excluded only
-# `_template.md` is a no-op wherever `-name '*.md'` already constrains the match.
+# sites and the `[[ ]]` sites together.
+#
+# The widening is a no-op at SIX of the seven expansion sites, each constrained by
+# `-name '*.md'`. The seventh is NOT, and the exception is recorded here rather than left for
+# a reader to discover: `sync-discovery-symlinks.sh` matches `-type d`, so expanding this array
+# there additionally excludes directories named `_template.md` or `_template.mjs` from
+# `disk_skill_dirs`. That count arms the orphan-cleanup safety guard, so the delta weakens a
+# guard rather than tightening one. No such directory exists and none plausibly would, but
+# "no-op wherever `-name '*.md'` constrains" is a claim about six sites and was being read as
+# a claim about seven.
 TEMPLATE_FIND_PRUNE=()
 for _template_name in "${TEMPLATE_NAMES[@]}"; do
   TEMPLATE_FIND_PRUNE+=(-not -name "$_template_name")

--- a/scripts/normalize-content-style.js
+++ b/scripts/normalize-content-style.js
@@ -39,13 +39,14 @@
 
 import { execSync, execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { isTemplate } from "./lib/content-paths.js";
 
 const CONTENT_GLOBS = ["skills/", "agents/", "teams/", "guides/", "i18n/"];
 const ENGLISH_GLOBS = ["skills/", "agents/", "teams/", "guides/"];
 
 function isContentFile(p) {
   if (!CONTENT_GLOBS.some((g) => p.startsWith(g))) return false;
-  if (p.includes("/_template")) return false;
+  if (isTemplate(p)) return false; // #672 — see check-content-style.js
   return p.endsWith(".md");
 }
 

--- a/scripts/sync-discovery-symlinks.sh
+++ b/scripts/sync-discovery-symlinks.sh
@@ -46,11 +46,17 @@ done
 ALMANAC_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd) # abort-ok: cd into this script's own parent; failure means the script was deleted mid-run
 cd "$ALMANAC_ROOT"
 
+# shellcheck source=lib/template-names.sh
+source "$ALMANAC_ROOT/scripts/lib/template-names.sh"
+
 REG="skills/_registry.yml"
 [ -f "$REG" ] || { echo "FATAL: $REG not found (run from the almanac repo)" >&2; exit 2; }
 
-# Registered skill ids (skip the _template guard defensively; it is not in the registry).
-mapfile -t SKILL_IDS < <(grep '^      - id: ' "$REG" | sed 's/.*- id: //' | tr -d '\r ' | grep -v '^_template$' | sort -u)
+# Registered skill ids (skip the template guard defensively; it is not in the registry).
+# `strip_template_ids` replaces a `grep -v '^_template$'` that was maintained identically
+# here and at validate-integrity.sh B12 -- the same expression in two files, agreeing by
+# convention (#672).
+mapfile -t SKILL_IDS < <(grep '^      - id: ' "$REG" | sed 's/.*- id: //' | tr -d '\r ' | strip_template_ids | sort -u)
 
 # (F1) The orphan cleanup below DELETES owned global links. Never let a short or
 # failed registry parse (a YAML re-indent, a changed generator) make every owned
@@ -60,7 +66,7 @@ if [ "${#SKILL_IDS[@]}" -eq 0 ]; then
   echo "FATAL: 0 skills parsed from $REG — registry format changed? Refusing to run." >&2
   exit 2
 fi
-disk_skill_dirs=$(find skills -mindepth 1 -maxdepth 1 -type d ! -name '_template' | wc -l | tr -d ' ') # abort-ok: find over skills/, whose absence is a broken checkout and is caught above
+disk_skill_dirs=$(find skills -mindepth 1 -maxdepth 1 -type d "${TEMPLATE_FIND_PRUNE[@]}" | wc -l | tr -d ' ') # abort-ok: find over skills/, whose absence is a broken checkout and is caught above
 stale_cleanup_safe=1
 if [ "${#SKILL_IDS[@]}" -lt "$disk_skill_dirs" ]; then
   stale_cleanup_safe=0

--- a/scripts/test/normalize-content-style.test.js
+++ b/scripts/test/normalize-content-style.test.js
@@ -75,6 +75,13 @@ function fixture() {
   mkdirSync(join(dir, 'scripts'), { recursive: true });
   mkdirSync(join(dir, 'agents'), { recursive: true });
   cpSync(join(REPO, SCRIPT), join(dir, SCRIPT));
+  // `scripts/lib/` too, since #672 routed this script's template exclusion through
+  // `lib/content-paths.js`. Copying the script ALONE worked only while it imported nothing
+  // local — and that isolation is part of how the duplicated predicate stayed invisible: the
+  // file's own comment said "Predicates copied verbatim from check-content-style.js" and no
+  // fixture could have noticed. A missing dependency here surfaces as ERR_MODULE_NOT_FOUND
+  // inside the child, which the exit-code assertions report as a plain `1 !== 0`.
+  cpSync(join(REPO, 'scripts', 'lib'), join(dir, 'scripts', 'lib'), { recursive: true });
   writeFileSync(join(dir, 'agents', 'sample.md'), DECORATIVE);
   git(dir, ['init', '-q']);
   git(dir, ['config', 'user.email', 'test@example.com']);

--- a/scripts/test/template-predicate.test.js
+++ b/scripts/test/template-predicate.test.js
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the template predicate (#672) and the JS/shell pair it creates.
+ *
+ * #672 counted 54 hand-rolled `_template` exclusions across 14 files, in three spellings, with
+ * no shared definition — the count re-derived on this branch under the issue's own ruler was
+ * 115 occurrences. The predicate under test replaces the ones that ask "is this scaffolding".
+ *
+ * Two properties are load-bearing and neither is obvious from reading the function:
+ *
+ * 1. It is ROOT-ANCHORED. A depth-agnostic test is the version `skills-inventory.js` shipped,
+ *    measured wrong against npm, and reverted — `skills/<id>/_template/helper.py` SHIPS, and
+ *    `skills-inventory.test.js` pins that with a live fixture. The nested case is asserted
+ *    here too so the two files cannot drift apart on it.
+ * 2. Its member set is EXACT, and a second copy of that set lives in
+ *    `scripts/lib/template-names.sh` because a bash script cannot import an ES module. That
+ *    duplication is the very shape #672 is about, one level up, so it is gated below rather
+ *    than trusted.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  isTemplate,
+  isTemplateSegment,
+  TEMPLATE_SEGMENTS,
+  templateSpellingDrift,
+  isExcludedId,
+} from '../lib/content-paths.js';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const trackedPaths = () => execFileSync('git', ['ls-files'], {
+  cwd: ROOT, encoding: 'utf8', maxBuffer: 1 << 28,
+}).split('\n').filter(Boolean);
+
+test('every template spelling on disk is recognised', () => {
+  for (const path of [
+    'agents/_template.md',
+    'guides/_template.md',
+    'teams/_template.md',
+    'tests/_template.md',
+    'skills/_template/SKILL.md',
+    'workflows/_template.mjs',
+  ]) {
+    assert.equal(isTemplate(path), true, path);
+  }
+});
+
+test('a NESTED _template is not a template — it ships', () => {
+  // The direction `skills-inventory.js` measured wrong and reverted. npm's `files` negations
+  // are root-anchored, so `!skills/_template/` does not exclude this path and the file is in
+  // the published tarball. A predicate that matched it here would put the two modules back
+  // into disagreement, which is what #672 exists to prevent.
+  assert.equal(isTemplate('skills/alpha/_template/helper.py'), false);
+  assert.equal(isTemplate('skills/alpha/_template/'), false);
+});
+
+test('substring lookalikes are not templates', () => {
+  // `includes('_template')` was the spelling at three call sites before #672. Each of these
+  // would have been excluded by it, silently, from a gate or a published count.
+  assert.equal(isTemplate('guides/my_template_notes.md'), false);
+  assert.equal(isTemplate('agents/_templates.md'), false);
+  assert.equal(isTemplate('skills/_template_backup/SKILL.md'), false);
+});
+
+test('a mirror anchors like its English source', () => {
+  // `check-content-style.js` lists `i18n/` among its content globs and excluded mirror
+  // templates via `includes('/_template')`. Returning false here would have quietly started
+  // scanning them. Zero are tracked today, so no fixture in this repo would have caught it.
+  assert.equal(isTemplate('i18n/de/skills/_template/SKILL.md'), true);
+  assert.equal(isTemplate('i18n/zh-CN/agents/_template.md'), true);
+  assert.equal(isTemplate('i18n/de/skills/create-r-package/SKILL.md'), false);
+});
+
+test('degenerate inputs do not throw and do not match', () => {
+  for (const path of ['', 'i18n', '_template.md', 'skills', '/', 'skills/']) {
+    assert.equal(isTemplate(path), false, JSON.stringify(path));
+  }
+});
+
+test('isTemplate is a STRICT SUBSET of isExcludedId, and the two are not interchangeable', () => {
+  // The distinction three modules now depend on. `isExcludedId` also covers `README` and every
+  // other `_`-prefixed name; `isTemplate` covers scaffolding alone. Collapsing them would make
+  // `_registry.yml` a "template" and `_experimental/` non-content.
+  for (const segment of TEMPLATE_SEGMENTS) {
+    assert.equal(isExcludedId(segment), true, `${segment} must also be excluded as an id`);
+  }
+  for (const segment of ['_registry.yml', 'README.md', 'README', '_experimental']) {
+    assert.equal(isTemplateSegment(segment), false, `${segment} is not a template`);
+    assert.equal(isExcludedId(segment), true, `${segment} is still not content`);
+  }
+});
+
+test('the drift check reports an UNSEEN spelling', () => {
+  const { uncovered, dead } = templateSpellingDrift([
+    'agents/_template.md', 'skills/_template/SKILL.md', 'workflows/_template.mjs',
+    'guides/_template.yml',
+  ]);
+  assert.deepEqual(uncovered, ['guides/_template.yml']);
+  assert.deepEqual(dead, []);
+});
+
+test('the drift check reports a DEAD member', () => {
+  // The direction an `observed ⊆ declared` check is blind to. A set that keeps naming a
+  // spelling nobody uses is how the list stays green describing a corpus that has moved on,
+  // and it is indistinguishable from coverage unless asserted.
+  const { uncovered, dead } = templateSpellingDrift(['agents/_template.md']);
+  assert.deepEqual(uncovered, []);
+  assert.deepEqual(dead, ['_template', '_template.mjs']);
+});
+
+test('the drift check ignores a nested _template rather than calling it uncovered', () => {
+  // Caught during development: scanning every segment reported the legitimately-nested,
+  // legitimately-shipped `skills/alpha/_template/helper.py` as an uncovered spelling, so the
+  // check would have gone red demanding the predicate absorb a path it is right to reject.
+  const { uncovered } = templateSpellingDrift([
+    'agents/_template.md', 'skills/_template/SKILL.md', 'workflows/_template.mjs',
+    'skills/alpha/_template/helper.py',
+  ]);
+  assert.deepEqual(uncovered, []);
+});
+
+test('THE CORPUS: no template spelling on disk escapes the predicate, and no member is dead', () => {
+  // #672 AC4, against the real tree rather than a fixture. Add `guides/_template.yml` and this
+  // fails naming it; delete the last `.mjs` template and it fails naming the dead member.
+  const { uncovered, dead } = templateSpellingDrift(trackedPaths());
+  assert.deepEqual(uncovered, [], 'a _template* spelling the predicate does not cover');
+  assert.deepEqual(dead, [], 'a declared spelling no tracked path uses');
+});
+
+test('THE PAIR: the shell list matches TEMPLATE_SEGMENTS exactly', () => {
+  // `scripts/lib/template-names.sh` cannot import this module, so the set exists twice. Gated
+  // in BOTH directions: a name added to either side alone fails here naming the other.
+  const shell = readFileSync(resolve(ROOT, 'scripts/lib/template-names.sh'), 'utf8');
+  const line = shell.match(/^TEMPLATE_NAMES=\((.*)\)$/m);
+  assert.ok(line, 'TEMPLATE_NAMES=( ... ) not found in scripts/lib/template-names.sh');
+
+  const names = [...line[1].matchAll(/'([^']*)'/g)].map((m) => m[1]);
+  assert.ok(names.length > 0, 'parsed zero names — the parse, not the corpus, is broken');
+  assert.deepEqual([...names].sort(), [...TEMPLATE_SEGMENTS].sort());
+});
+
+test('the shell helper agrees with the JS predicate name by name', () => {
+  // Parsing the array proves the LISTS match. This proves the shell FUNCTION reads them, which
+  // a typo in `is_template` itself would otherwise leave green.
+  const script = resolve(ROOT, 'scripts/lib/template-names.sh');
+  const probe = [
+    ...TEMPLATE_SEGMENTS,
+    '_templates.md', 'README.md', '_registry.yml', 'my_template_notes.md', '',
+  ];
+  for (const name of probe) {
+    const status = execFileSync('bash', [
+      '-c', `source "$1"; if is_template "$2"; then echo yes; else echo no; fi`, '_', script, name,
+    ], { encoding: 'utf8' }).trim();
+    assert.equal(
+      status === 'yes',
+      isTemplateSegment(name),
+      `is_template(${JSON.stringify(name)}) disagrees with isTemplateSegment`,
+    );
+  }
+});

--- a/scripts/test/template-predicate.test.js
+++ b/scripts/test/template-predicate.test.js
@@ -18,7 +18,6 @@
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { execFileSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -74,6 +73,15 @@ test('a mirror anchors like its English source', () => {
   assert.equal(isTemplate('i18n/de/skills/_template/SKILL.md'), true);
   assert.equal(isTemplate('i18n/zh-CN/agents/_template.md'), true);
   assert.equal(isTemplate('i18n/de/skills/create-r-package/SKILL.md'), false);
+});
+
+test('a `./`-prefixed path anchors like a bare one', () => {
+  // Without normalisation the anchored segment is the TREE name, so this returns false --
+  // a silent wrong answer rather than a throw. No caller passes this shape today.
+  assert.equal(isTemplate('./agents/_template.md'), true);
+  assert.equal(isTemplate('./skills/_template/SKILL.md'), true);
+  assert.equal(isTemplate('./i18n/de/agents/_template.md'), true);
+  assert.equal(isTemplate('./agents/real-agent.md'), false);
 });
 
 test('degenerate inputs do not throw and do not match', () => {
@@ -132,32 +140,58 @@ test('THE CORPUS: no template spelling on disk escapes the predicate, and no mem
   assert.deepEqual(dead, [], 'a declared spelling no tracked path uses');
 });
 
+/** The shell's TEMPLATE_NAMES as bash itself sees it — sourced, never parsed. */
+function shellArray() {
+  const out = execFileSync('bash', [
+    '-c', 'set -euo pipefail; source "$1"; printf "%s\\n" "${TEMPLATE_NAMES[@]}"',
+    '_', resolve(ROOT, 'scripts/lib/template-names.sh'),
+  ], { encoding: 'utf8' });
+  return out.split('\n').filter(Boolean);
+}
+
+/** What the shell's own `is_template` says about one name. */
+function shellSaysTemplate(name) {
+  const out = execFileSync('bash', [
+    '-c', 'source "$1"; if is_template "$2"; then echo yes; else echo no; fi',
+    '_', resolve(ROOT, 'scripts/lib/template-names.sh'), name,
+  ], { encoding: 'utf8' }).trim();
+  if (out !== 'yes' && out !== 'no') throw new Error(`unreadable shell verdict: ${JSON.stringify(out)}`);
+  return out === 'yes';
+}
+
 test('THE PAIR: the shell list matches TEMPLATE_SEGMENTS exactly', () => {
   // `scripts/lib/template-names.sh` cannot import this module, so the set exists twice. Gated
   // in BOTH directions: a name added to either side alone fails here naming the other.
-  const shell = readFileSync(resolve(ROOT, 'scripts/lib/template-names.sh'), 'utf8');
-  const line = shell.match(/^TEMPLATE_NAMES=\((.*)\)$/m);
-  assert.ok(line, 'TEMPLATE_NAMES=( ... ) not found in scripts/lib/template-names.sh');
-
-  const names = [...line[1].matchAll(/'([^']*)'/g)].map((m) => m[1]);
-  assert.ok(names.length > 0, 'parsed zero names — the parse, not the corpus, is broken');
+  //
+  // The array is read by SOURCING the file, not by parsing it. A regex over
+  // `TEMPLATE_NAMES=( ... )` was the first version and it had the bug this whole PR is about:
+  // it matched the FIRST assignment only, so appending
+  //
+  //     TEMPLATE_NAMES+=('_template.yml')
+  //
+  // on any later line left the shell excluding a name the JS did not, with all twelve tests
+  // green. Measured, not imagined -- the append was planted and the suite passed. Sourcing is
+  // immune to that and to reformatting, quote style, and conditional assignment, because it
+  // observes exactly what `validate-integrity.sh` observes.
+  const names = shellArray();
+  assert.ok(names.length > 0, 'sourced an empty TEMPLATE_NAMES — the read, not the corpus, is broken');
   assert.deepEqual([...names].sort(), [...TEMPLATE_SEGMENTS].sort());
 });
 
-test('the shell helper agrees with the JS predicate name by name', () => {
-  // Parsing the array proves the LISTS match. This proves the shell FUNCTION reads them, which
+test('the shell helper agrees with the JS predicate over the UNION of both sets', () => {
+  // Reading the array proves the LISTS match. This proves the shell FUNCTION reads them, which
   // a typo in `is_template` itself would otherwise leave green.
-  const script = resolve(ROOT, 'scripts/lib/template-names.sh');
+  //
+  // Probing the UNION rather than `TEMPLATE_SEGMENTS` matters: a name present only on the
+  // shell side would never be probed by a JS-side list, so the divergence it represents would
+  // go unmeasured by the very test meant to catch it.
   const probe = [
-    ...TEMPLATE_SEGMENTS,
-    '_templates.md', 'README.md', '_registry.yml', 'my_template_notes.md', '',
+    ...new Set([...TEMPLATE_SEGMENTS, ...shellArray()]),
+    '_templates.md', 'README.md', '_registry.yml', 'my_template_notes.md', '_template.yml', '',
   ];
   for (const name of probe) {
-    const status = execFileSync('bash', [
-      '-c', `source "$1"; if is_template "$2"; then echo yes; else echo no; fi`, '_', script, name,
-    ], { encoding: 'utf8' }).trim();
     assert.equal(
-      status === 'yes',
+      shellSaysTemplate(name),
       isTemplateSegment(name),
       `is_template(${JSON.stringify(name)}) disagrees with isTemplateSegment`,
     );

--- a/scripts/test/template-predicate.test.js
+++ b/scripts/test/template-predicate.test.js
@@ -132,6 +132,30 @@ test('the drift check ignores a nested _template rather than calling it uncovere
   assert.deepEqual(uncovered, []);
 });
 
+test('a LOOKALIKE at the anchored position is not reported as an uncovered spelling', () => {
+  // Two reviewers found this independently. Discovery was `startsWith('_template')`, which is
+  // true of both names below — so tracking either turned THE CORPUS red reporting it
+  // `uncovered`, demanding the predicate absorb a path the lookalike test above forbids it to
+  // absorb. A deadlock with no waiver: the only exit was renaming the file.
+  const { uncovered, dead } = templateSpellingDrift([
+    'agents/_template.md', 'skills/_template/SKILL.md', 'workflows/_template.mjs',
+    'agents/_templates.md',            // plural
+    'skills/_template_backup/SKILL.md', // suffixed
+  ]);
+  assert.deepEqual(uncovered, []);
+  assert.deepEqual(dead, []);
+});
+
+test('a genuinely new spelling is STILL reported after that tightening', () => {
+  // The other direction, and the reason the ruler is a pattern rather than the exact set: a
+  // discovery rule tightened until it only matches known members can never find anything.
+  for (const candidate of ['guides/_template.yml', 'guides/_template.json', 'guides/_template.txt']) {
+    const { uncovered } = templateSpellingDrift(['agents/_template.md', 'skills/_template/SKILL.md',
+      'workflows/_template.mjs', candidate]);
+    assert.deepEqual(uncovered, [candidate], candidate);
+  }
+});
+
 test('THE CORPUS: no template spelling on disk escapes the predicate, and no member is dead', () => {
   // #672 AC4, against the real tree rather than a fixture. Add `guides/_template.yml` and this
   // fails naming it; delete the last `.mjs` template and it fails naming the dead member.

--- a/scripts/test/template-predicate.test.js
+++ b/scripts/test/template-predicate.test.js
@@ -140,21 +140,30 @@ test('THE CORPUS: no template spelling on disk escapes the predicate, and no mem
   assert.deepEqual(dead, [], 'a declared spelling no tracked path uses');
 });
 
+/**
+ * The script both helpers below source, as a LITERAL relative path.
+ *
+ * Not `resolve(ROOT, …)`. CodeQL flagged the first version — "Shell command built from
+ * environment values" — because the path derived from `import.meta.url` reached a `bash -c`
+ * invocation. It was already passed as a positional argument rather than interpolated, so it
+ * was not injectable, but naming the script literally and pointing `cwd` at the repo removes
+ * the pattern rather than arguing with it, and reads better besides.
+ */
+const NAMES_SH = 'scripts/lib/template-names.sh';
+
 /** The shell's TEMPLATE_NAMES as bash itself sees it — sourced, never parsed. */
 function shellArray() {
   const out = execFileSync('bash', [
-    '-c', 'set -euo pipefail; source "$1"; printf "%s\\n" "${TEMPLATE_NAMES[@]}"',
-    '_', resolve(ROOT, 'scripts/lib/template-names.sh'),
-  ], { encoding: 'utf8' });
+    '-c', `set -euo pipefail; source ${NAMES_SH}; printf '%s\\n' "\${TEMPLATE_NAMES[@]}"`,
+  ], { cwd: ROOT, encoding: 'utf8' });
   return out.split('\n').filter(Boolean);
 }
 
 /** What the shell's own `is_template` says about one name. */
 function shellSaysTemplate(name) {
   const out = execFileSync('bash', [
-    '-c', 'source "$1"; if is_template "$2"; then echo yes; else echo no; fi',
-    '_', resolve(ROOT, 'scripts/lib/template-names.sh'), name,
-  ], { encoding: 'utf8' }).trim();
+    '-c', `source ${NAMES_SH}; if is_template "$1"; then echo yes; else echo no; fi`, '_', name,
+  ], { cwd: ROOT, encoding: 'utf8' }).trim();
   if (out !== 'yes' && out !== 'no') throw new Error(`unreadable shell verdict: ${JSON.stringify(out)}`);
   return out === 'yes';
 }

--- a/scripts/test/workflow-generator-inputs.test.js
+++ b/scripts/test/workflow-generator-inputs.test.js
@@ -108,6 +108,70 @@ test('an exported function whose body quotes a dotted string is not read as an i
   assert.doesNotMatch(output, /\.md/, 'a quoted literal in a function body reached the graph');
 });
 
+test('the word `from` inside a COMMENT is not read as an import specifier', () => {
+  // The residual class after the first fix, found by an adversarial reviewer who named the
+  // experiment rather than asserting it. Anchoring the specifier on `from` narrowed the class
+  // but did not close it: the span before `from` was still `[^'"]*?`, so any line-start
+  // `export`/`import` whose text contained the word `from` before a dotted quoted string
+  // matched. The planted line reproduced the SAME hard refusal as the original bug.
+  //
+  // Closed by constraining that span to what an import CLAUSE can contain.
+  const { output, status } = run({
+    ...BASE,
+    files: {
+      ...BASE.files,
+      'scripts/lib/a.js':
+        "export const a = 1; // adapted from './nowhere.js'\nexport const b = a;\n",
+    },
+  });
+  assert.equal(status, 0, output);
+  assert.match(output, /; 0 unlisted$/m);
+  assert.doesNotMatch(output, /nowhere/, 'a comment reached the import graph');
+});
+
+test('a statement with `from` in it is not an import either', () => {
+  // Same class, without a comment: the span must exclude `=` and `;`, not merely sit before a
+  // `from`. Kept separate so a fix that special-cases comments cannot pass this one.
+  const { output, status } = run({
+    ...BASE,
+    files: {
+      ...BASE.files,
+      'scripts/lib/a.js':
+        "export const a = pickFrom('./nowhere.js');\nexport const b = a;\n"
+        + "function pickFrom(x) { return x; }\n",
+    },
+  });
+  assert.equal(status, 0, output);
+  assert.doesNotMatch(output, /nowhere/, 'a call expression reached the import graph');
+});
+
+test('the import forms the tightened class must still admit', () => {
+  // The narrowing direction, checked on the shapes a real module uses. Each target is
+  // UNLISTED, so a regex that missed it would report `0 unlisted` and pass — the false PASS
+  // this gate's header calls worse than having no gate.
+  for (const [label, source] of [
+    ['aliased re-export', "export { a as b } from './lib/x.js';\n"],
+    ['default plus named', "import d, { a } from './lib/x.js';\nconsole.log(d, a);\n"],
+    ['namespace', "import * as ns from './lib/x.js';\nconsole.log(ns);\n"],
+    ['star re-export', "export * from './lib/x.js';\n"],
+  ]) {
+    const { output, status } = run({
+      ...BASE,
+      // `scripts/lib/a.js` stays listed; `x.js` is the UNLISTED target, so the check must
+      // REPORT it. That is what proves the specifier was found: a regex that missed it would
+      // report `0 unlisted` and pass.
+      paths: ['scripts/generate-readmes.js', 'scripts/lib/a.js'],
+      files: {
+        ...BASE.files,
+        'scripts/generate-readmes.js': source,
+        'scripts/lib/x.js': 'export const a = 1;\nexport default a;\n',
+      },
+    });
+    assert.equal(status, 1, `${label}: ${output}`);
+    assert.match(output, /scripts\/lib\/x\.js is imported by this workflow/, label);
+  }
+});
+
 test('a MULTI-LINE import is still followed after that fix', () => {
   // The narrowing direction, and the reason the fix anchors on `from` rather than forbidding
   // the newline. A smaller reachable set means fewer required trigger paths -- a FALSE PASS on

--- a/scripts/test/workflow-generator-inputs.test.js
+++ b/scripts/test/workflow-generator-inputs.test.js
@@ -84,6 +84,65 @@ test('a fully listed graph passes', () => {
   assert.match(output, /; 0 unlisted$/m);
 });
 
+test('an exported function whose body quotes a dotted string is not read as an import', () => {
+  // Found by #672. The specifier class spans newlines on purpose, so that multi-line
+  // `import {\n a,\n} from './x.js'` is covered without an `s` flag. Unanchored, it ran from
+  // the `export` keyword straight into the function BODY and took the first quoted string:
+  //
+  //     export function isExcludedId(id) {
+  //       const stem = id.endsWith('.md') ? …
+  //
+  // was read as an import of `./lib/.md`, which does not exist, so the check hard-refused --
+  // exit 1 even under `--warn`, in a REQUIRED context. Nothing in the repo had exported such a
+  // function before, so the bug shipped latent and fired on an unrelated PR.
+  const { output, status } = run({
+    ...BASE,
+    files: {
+      ...BASE.files,
+      'scripts/lib/a.js':
+        "export function a(id) {\n  const stem = id.endsWith('.md') ? id : id;\n  return stem;\n}\n",
+    },
+  });
+  assert.equal(status, 0, output);
+  assert.match(output, /; 0 unlisted$/m);
+  assert.doesNotMatch(output, /\.md/, 'a quoted literal in a function body reached the graph');
+});
+
+test('a MULTI-LINE import is still followed after that fix', () => {
+  // The narrowing direction, and the reason the fix anchors on `from` rather than forbidding
+  // the newline. A smaller reachable set means fewer required trigger paths -- a FALSE PASS on
+  // a gate whose header calls a wrong all-clear worse than no gate.
+  //
+  // The target must be UNLISTED. A first version imported a module `BASE.paths` already
+  // listed, so dropping the specifier changed no output and the naive `[^'"\n]*` narrowing
+  // SURVIVED this test. Measured, not assumed.
+  const { output, status } = run({
+    ...BASE,
+    files: {
+      ...BASE.files,
+      'scripts/generate-readmes.js':
+        "import {\n  m,\n} from './lib/multi.js';\nconsole.log(m);\n",
+      'scripts/lib/multi.js': 'export const m = 1;\n',
+    },
+  });
+  assert.equal(status, 1, output);
+  assert.match(output, /scripts\/lib\/multi\.js is imported by this workflow/);
+});
+
+test('a BARE side-effect import, which has no `from`, is still followed', () => {
+  // The reason the `from` group is optional rather than required. Same unlisted-target rule.
+  const { output, status } = run({
+    ...BASE,
+    files: {
+      ...BASE.files,
+      'scripts/generate-readmes.js': "import './lib/side.js';\nconsole.log(1);\n",
+      'scripts/lib/side.js': 'export const s = 1;\n',
+    },
+  });
+  assert.equal(status, 1, output);
+  assert.match(output, /scripts\/lib\/side\.js is imported by this workflow/);
+});
+
 test('a transitive import that nobody listed is reported', () => {
   // The #618 shape exactly: both endpoints listed, the middle skipped.
   const { output, status } = run({

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -36,6 +36,12 @@ set -euo pipefail
 failed=0
 warn_count=0
 
+# The one definition of "this name is author scaffolding" (#672). Sourced rather than
+# repeated: this script carried 19 such tests in four spellings, and
+# `sync-discovery-symlinks.sh` carried two more that had to agree with them.
+# shellcheck source=lib/template-names.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/template-names.sh"
+
 # ── Assert that a corpus extraction found something (#647) ──────────────────────
 #
 # This is the other half of the rule above, and the reason a blanket `|| true` sweep would
@@ -145,7 +151,8 @@ echo "=== Category A: Static Validation ==="
 echo "--- A1: Agent frontmatter ---"
 for f in agents/*.md; do
   name=$(basename "$f")
-  [[ "$name" == "_template.md" || "$name" == "README.md" ]] && continue
+  is_template "$name" && continue
+  [[ "$name" == "README.md" ]] && continue
   # DO NOT add `intent` here without reading scripts/envelopes/a6a-abort-capable-substitutions.mjs
   # first. A6a owns that field and prints `FAIL: $f missing required field: intent`, which is
   # byte-identical to what this loop would render for `intent` — and the envelope case proving
@@ -165,7 +172,8 @@ echo "--- A2: Team frontmatter ---"
 a2_fail=0
 for f in teams/*.md; do
   name=$(basename "$f")
-  [[ "$name" == "_template.md" || "$name" == "README.md" ]] && continue
+  is_template "$name" && continue
+  [[ "$name" == "README.md" ]] && continue
   for field in name description lead members coordination; do
     if ! grep -q "^${field}:" "$f"; then
       echo "FAIL: $f missing required field: $field"
@@ -181,7 +189,8 @@ echo "--- A3: Guide frontmatter ---"
 a3_fail=0
 for f in guides/*.md; do
   name=$(basename "$f")
-  [[ "$name" == "_template.md" || "$name" == "README.md" ]] && continue
+  is_template "$name" && continue
+  [[ "$name" == "README.md" ]] && continue
   for field in title description category; do
     if ! grep -q "^${field}:" "$f"; then
       echo "FAIL: $f missing required field: $field"
@@ -244,7 +253,7 @@ registry_entry_set() { # <tree> <registry> <section key>
 
   # Same class: `/^\$/d` deleted lines consisting of a literal `$`, not empty lines.
   reg_ids=$(printf '%s\n' "$reg_ids_all" | sed '/^$/d' | sort -u || true)
-  disk_ids=$(find "$tree" -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' \
+  disk_ids=$(find "$tree" -maxdepth 1 -name '*.md' "${TEMPLATE_FIND_PRUNE[@]}" -not -name 'README.md' \
     -exec basename {} .md \; | sort || true)
 
   # Fail-closed. An empty extraction means the pattern drifted from the file it reads, and
@@ -294,7 +303,7 @@ compare_id_sets() { # <registry> <tree> <reg ids> <disk ids> <expected path shap
 # A4: Agent registry count and entry set
 echo "--- A4: Agent registry vs disk ---"
 a4_fail=0
-disk_count=$(find agents -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l) # abort-ok: find over a directory whose absence is not drift but a broken checkout
+disk_count=$(find agents -maxdepth 1 -name '*.md' "${TEMPLATE_FIND_PRUNE[@]}" -not -name 'README.md' | wc -l) # abort-ok: find over a directory whose absence is not drift but a broken checkout
 # `|| true` and it is the point of this check: if `total_agents:` is ever renamed, the bare
 # form aborted the run rather than reporting the drift it exists to catch. The `!=` below is
 # the explicit zero-check -- an empty string never equals a number, so the FAIL prints.
@@ -309,7 +318,7 @@ registry_entry_set agents agents/_registry.yml agents || { failed=1; a4_fail=1; 
 # A5: Team registry count and entry set
 echo "--- A5: Team registry vs disk ---"
 a5_fail=0
-disk_count=$(find teams -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l) # abort-ok: find over a directory whose absence is not drift but a broken checkout
+disk_count=$(find teams -maxdepth 1 -name '*.md' "${TEMPLATE_FIND_PRUNE[@]}" -not -name 'README.md' | wc -l) # abort-ok: find over a directory whose absence is not drift but a broken checkout
 reg_count=$(grep 'total_teams:' teams/_registry.yml | tr -d '\r' | awk '{print $2}' || true) # see A4
 if [ "$disk_count" != "$reg_count" ]; then
   echo "FAIL: teams disk=$disk_count registry=$reg_count"
@@ -351,6 +360,12 @@ fi
 a15_reg=$(printf '%s\n' "$a15_reg_all" | sed '/^$/d' | sort -u || true)
 # Directories carrying a SKILL.md, which is what the generator and the CLI both consume. A bare
 # directory with no SKILL.md is not a skill and must not count as one on either side.
+# NOT array-expanded, deliberately. `TEMPLATE_FIND_PRUNE` holds `-not -name` predicates over
+# BASENAMES; this is a `-not -path` prune whose anchor is tree-specific. The generic form
+# `-not -path '*/_template/*'` would be depth-agnostic, which is the exact direction
+# `content-paths.js` documents as measured-wrong (a nested `_template/` ships). At
+# `-maxdepth 2` the two agree, so the generic form would be a correct-today rule carrying a
+# latent bug for whenever the depth changes.
 a15_disk=$(find skills -mindepth 2 -maxdepth 2 -name 'SKILL.md' -not -path 'skills/_template/*' -printf '%h\n' | sed 's|^skills/||' | sort) # abort-ok: find over a directory whose absence is not drift but a broken checkout
 a15_declared=$(grep -m1 '^total_skills:' skills/_registry.yml | tr -d '\r' | awk '{print $2}' || true)
 a15_extracted=$(printf '%s\n' "$a15_reg" | sed '/^$/d' | wc -l || true)
@@ -382,7 +397,8 @@ declare -A AGENT_INTENT
 # A6a: every agent has a valid intent that agrees with tools
 for f in agents/*.md; do
   name=$(basename "$f" .md)
-  [[ "$name" == "_template" || "$name" == "README" ]] && continue
+  is_template "$name" && continue
+  [[ "$name" == "README" ]] && continue
   # `|| true` on both, and it is load-bearing rather than defensive (#647). Under
   # `set -euo pipefail` a bare `x=$(grep … | …)` carries the pipeline's status, so an agent
   # file WITHOUT `intent:` aborted the whole script on this line -- one line before the
@@ -428,7 +444,8 @@ done
 impl_kw='Developer|Implementer|Programmer|Builder|Engineer|Operator|Hardener|Architect'
 for f in teams/*.md; do
   tname=$(basename "$f")
-  [[ "$tname" == "_template.md" || "$tname" == "README.md" ]] && continue
+  is_template "$tname" && continue
+  [[ "$tname" == "README.md" ]] && continue
   while IFS='|' read -r ag sub role; do
     [ -z "$ag" ] && continue
     eff="$ag"
@@ -473,7 +490,7 @@ a7_fail=0
 a7_count=0
 for f in workflows/*.mjs; do
   wname=$(basename "$f")
-  [[ "$wname" == "_template.mjs" ]] && continue
+  is_template "$wname" && continue
   stem=$(basename "$f" .mjs)
   a7_count=$((a7_count + 1))
   for field in name description phases; do
@@ -689,7 +706,9 @@ a9_warned=0
 a9_hits=$(grep -lE "$a9_pattern" skills/*/SKILL.md || true)
 while IFS= read -r f; do
   [ -z "$f" ] && continue
-  [ "$f" = "skills/_template/SKILL.md" ] && continue
+  # Was a literal path comparison -- a fourth spelling of the rule, and the only one that
+  # would not have followed the template if it moved tree. `basename` feeds the shared set.
+  is_template "$(basename "$(dirname "$f")")" && continue
   invoked=$(grep -oE "$a9_pattern" "$f" | grep -oE "${a9_bt}(${a9_tools})${a9_bt}" | tr -d "$a9_bt" | sort -u || true)
   # Frontmatter region only (skips body code-fence examples); supports both
   # `allowed-tools: A B C` and the YAML block-list form.
@@ -1094,7 +1113,7 @@ a12_fail=0
 # envelope's count case cannot see it: mutating 35 -> 36 keeps the key greppable, so only a
 # deletion reaches this path. Safe because the comparison below is a string `!=` -- an empty
 # `reg_count` compares unequal and fails correctly rather than passing.
-disk_count=$(find guides -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | wc -l || true)
+disk_count=$(find guides -maxdepth 1 -name '*.md' "${TEMPLATE_FIND_PRUNE[@]}" -not -name 'README.md' | wc -l || true)
 reg_count=$(grep 'total_guides:' guides/_registry.yml | tr -d '\r' | awk '{print $2}' || true)
 if [ "$disk_count" != "$reg_count" ]; then
   echo "FAIL: guides disk=$disk_count total_guides=$reg_count"
@@ -1111,7 +1130,7 @@ if [ -n "$a12_dupe_paths" ]; then
   failed=1; a12_fail=1
 fi
 a12_reg_paths=$(printf '%s\n' "$a12_reg_paths_all" | sort -u || true)
-a12_disk_paths=$(find guides -maxdepth 1 -name '*.md' -not -name '_template.md' -not -name 'README.md' | sort || true)
+a12_disk_paths=$(find guides -maxdepth 1 -name '*.md' "${TEMPLATE_FIND_PRUNE[@]}" -not -name 'README.md' | sort || true)
 if [ -z "$a12_reg_paths" ]; then
   echo "FAIL: A12 extracted 0 'path:' values from guides/_registry.yml -- pattern drift, not a clean tree"
   failed=1; a12_fail=1
@@ -1132,7 +1151,7 @@ b1_fail=0
 b1_count=0
 for dir in skills/*/; do
   skill_name=$(basename "$dir")
-  [[ "$skill_name" == "_template" ]] && continue
+  is_template "$skill_name" && continue
   [ ! -f "$dir/SKILL.md" ] && continue
   b1_count=$((b1_count + 1))
   if [ ! -L ".claude/skills/$skill_name" ]; then
@@ -1158,7 +1177,8 @@ b3_fail=0
 b3_checked=0
 for f in teams/*.md; do
   name=$(basename "$f")
-  [[ "$name" == "_template.md" || "$name" == "README.md" ]] && continue
+  is_template "$name" && continue
+  [[ "$name" == "README.md" ]] && continue
   # Extract member ids from structured YAML: members:\n  - id: agent-name
   while IFS= read -r line; do
     # GUARDED, not annotated (#647 review). The first version claimed `sed -n …p` exits 0 on
@@ -1187,7 +1207,8 @@ b4_fail=0
 b4_checked=0
 for f in agents/*.md; do
   name=$(basename "$f")
-  [[ "$name" == "_template.md" || "$name" == "README.md" ]] && continue
+  is_template "$name" && continue
+  [[ "$name" == "README.md" ]] && continue
   # Extract skills from YAML frontmatter (indented list items under skills:)
   in_skills=0
   while IFS= read -r line; do
@@ -1219,12 +1240,12 @@ orphan_count=0
 orphan_list=""
 # Build reference corpus: all .md files except registries, READMEs, and templates
 ref_corpus_file=$(mktemp)
-find agents teams guides -name '*.md' -not -name '_template.md' -not -name 'README.md' -exec cat {} + > "$ref_corpus_file" 2>/dev/null
+find agents teams guides -name '*.md' "${TEMPLATE_FIND_PRUNE[@]}" -not -name 'README.md' -exec cat {} + > "$ref_corpus_file" 2>/dev/null
 # Add skill-to-skill cross-references (all SKILL.md files)
 find skills -name 'SKILL.md' -exec cat {} + >> "$ref_corpus_file" 2>/dev/null
 for dir in skills/*/; do
   skill_name=$(basename "$dir")
-  [[ "$skill_name" == "_template" ]] && continue
+  is_template "$skill_name" && continue
   # A skill is orphaned if it only appears in its own SKILL.md, nowhere else
   # Count total occurrences, subtract self-references (skill name appears in its own file)
   total=$(grep -c "$skill_name" "$ref_corpus_file" 2>/dev/null || echo 0)
@@ -1379,7 +1400,7 @@ fi
 # The fix path is: bash scripts/sync-discovery-symlinks.sh --fix
 echo "--- B12: Global discovery-hub coverage ---"
 if [ -d "$HOME/.claude/skills" ]; then
-  b12_reg=$(grep '^      - id: ' skills/_registry.yml | sed 's/.*- id: //' | tr -d '\r ' | grep -v '^_template$' | sort -u || true)
+  b12_reg=$(grep '^      - id: ' skills/_registry.yml | sed 's/.*- id: //' | tr -d '\r ' | strip_template_ids | sort -u || true)
   b12_hub=$(find "$HOME/.claude/skills" -maxdepth 1 -mindepth 1 -printf '%f\n' 2>/dev/null | sort -u || true)
   # Only the registry side is asserted. An empty `b12_hub` is a legitimate state -- a machine
   # that has never run sync-discovery-symlinks.sh -- and the comparison is exactly what should

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -37,8 +37,11 @@ failed=0
 warn_count=0
 
 # The one definition of "this name is author scaffolding" (#672). Sourced rather than
-# repeated: this script carried 19 such tests in four spellings, and
-# `sync-discovery-symlinks.sh` carried two more that had to agree with them.
+# repeated: this script carried 19 lines mentioning `_template` -- 18 routed through the shared
+# file, 1 `-not -path` prune kept below with its reason -- and `sync-discovery-symlinks.sh` and
+# `validate-skills.yml` carried two executable sites each that had to agree with them.
+# The constructions are enumerated in `lib/template-names.sh`; do not restate a count here,
+# because the two comments contradicted each other for one revision.
 # shellcheck source=lib/template-names.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/template-names.sh"
 


### PR DESCRIPTION
Closes #672. Closes #546.

Two issues about the same thing: an exclusion rule that lives in its repetitions. #672 was
filed after an external consumer — the `memex` extractor — indexed `skills/_template/` as if it
were a real skill, because nothing in this repo defines "is this a template" and every consumer
had independently learned to skip it.

## The count, re-derived, with the ruler stated

The issue records **54 occurrences across 14 files**. On this branch, under the issue's own
command (`rg -o "_template[a-z.]*" scripts/ cli/ .github/`):

| measure | issue | now |
|---|---|---|
| occurrences (`rg -o`) | 54 | **115** |
| matching lines (`rg -c`) | — | 106 |
| files | 14 | 18 |

Two cautions on those numbers, because a count quoted without its ruler is how this repo has
been misled before. `rg -o` counts occurrences and `rg -c` counts *matching lines*; they are
different questions and the issue mixes them (its "54" is the first, its "14" the second). And
the issue's own character class manufactures artifacts: `[a-z.]*` swallows a trailing sentence
period, so 2 of the 115 are `_template.md.` — a spelling that does not exist.

Most of the 115 are comments and test fixtures. The executable sites are the ones below.

## What was added

In `scripts/lib/content-paths.js`, beside `contentKey` and `isExcludedId`:

```
TEMPLATE_SEGMENTS      exact set: _template, _template.md, _template.mjs
isTemplateSegment(s)   membership, for callers holding a bare name
isTemplate(path)       root-anchored; i18n/<locale>/ stripped first
templateSpellingDrift  both directions, for AC4
```

### Exact set, not a prefix

`startsWith('_template')` is shorter and auto-covers a future `_template.yml`. That is exactly
the objection. A predicate that silently absorbs a new spelling makes AC4 — *"a check fails when
a new `_template*` spelling appears that the predicate does not cover"* — unsatisfiable by
construction. Exact set plus a discovery check is the trade the debt ratchet already makes here.

### Root-anchored, because the other direction was measured wrong

`skills-inventory.js` shipped a depth-agnostic version, found it disagreed with npm — the
`files` negations are root-anchored gitignore-style patterns, so `skills/<id>/_template/x.py`
**ships** — and reverted it. `skills-inventory.test.js:115` pins that with a live fixture,
citing #672 as the anti-pattern. This predicate does not re-introduce the bug one directory
over, and the test asserts the nested case directly so the two files cannot drift.

## Three predicates, deliberately distinct — where this deviates from the AC

#672's AC says *"Every JS site uses it"*. Read literally that is **refuted by work done after
the issue was filed**, and I did not satisfy it literally:

> `content-paths.js`'s `isExcludedId` was the other candidate and is wrong in the opposite
> direction: its `_`-prefix rule would skip `skills/_experimental/tool.py`, which ships.
> Neither hand-rolled rule is the package's rule. This one is.
> — `scripts/lib/skills-inventory.js:127`

So the package sites keep npm's own rule, and the AC is read as *every site that asks the
template question*:

| predicate | question | owner |
|---|---|---|
| `isTemplate` | is this author scaffolding? | `content-paths.js` |
| `isExcludedId` | is this non-content? (`_`-prefix or README — a superset) | `content-paths.js` |
| `isExcludedFromPackage` | does npm ship it? | `skills-inventory.js` |

## Sites converted

**JS** — all four were substring or prefix tests:

| site | was | now |
|---|---|---|
| `check-content-style.js:34` | `includes("/_template")` | `isTemplate` |
| `normalize-content-style.js:48` | `includes("/_template")` | `isTemplate` |
| `check-agent-registry-parity.js:67` | `includes('_template')` | `isTemplate` |
| `generate-readmes.js:710` | `startsWith('_')` | `isTemplateSegment` |

The first three are **behaviour changes**, named rather than smuggled: `includes` also matched
`guides/my_template_notes.md` and `agents/_templates.md`. Neither exists today, so no fixture
would have caught either. The fourth aligns code with its own adjacent comment, which said
*template* while the code said `_`-prefix; a no-op today, as `_template.mjs` is the only
`_`-prefixed workflow.

**Shell** — new `scripts/lib/template-names.sh`, sourced by both scripts, replacing 19 tests in
four spellings (`[[ "$name" == "_template.md" ]]`, `-not -name '_template.md'`, a literal path
comparison `[ "$f" = "skills/_template/SKILL.md" ]`, and a `grep -v '^_template$'` maintained
identically in two files):

- `validate-integrity.sh` — **11** name/path tests, 6 find prunes, 1 id filter, plus the 1
  `-not -path` prune left in place with its reason = 19 sites. (The commit message for that
  commit says "12 name tests"; it is 11. The total of 19 is right, the split was off by one.
  Counted with `grep -c '^  is_template'` = 11, `TEMPLATE_FIND_PRUNE\[@\]` = 6.)
- `sync-discovery-symlinks.sh` — 1 id filter, 1 find prune
- `validate-skills.yml` — 1 basename test. A `run:` block is bash executing in the checkout, so
  it sources like any other script; *"a workflow cannot import"* would have been an assumption,
  not a constraint.

## Not converted, with reasons — AC4's second branch

Two `-not -path 'skills/_template/*'` prunes stay. `TEMPLATE_FIND_PRUNE` holds `-not -name`
predicates over **basenames**; the generic path form `*/_template/*` would be depth-agnostic,
i.e. the direction documented above as measured-wrong. At `-maxdepth 2` the two agree, so the
generic form would be a correct-today rule carrying a latent bug for whenever the depth changes.
A new spelling is caught by `templateSpellingDrift`, not by those lines.

Seven other `_`-prefix guards (`audit-skill-sections`, `check-translation-freshness`,
`check-i18n-frontmatter-parity`, `coverage-matrix` ×2, `i18n-targets`, and the two now routed)
ask the **content-id** question, not the template one. Each is a separate behaviour argument and
none is in either issue's scope. Filed as **#740** rather than widened into this PR.

## #546

`isExcludedId` was private while two callers re-implemented its `_`-prefix half inline:
`check-yaml-fences.js:129`, and the working-tree arm of the shared walker — which #559 had moved
out of `buildEnglishFenceHistory` into `lib/english-history.js:309`, so the issue's stated
location no longer existed.

Both guards are **kept**, per the issue. `check-yaml-fences.js` is *why* that tool never had the
#519 bug. What changes is that they can no longer narrow independently. Behaviour-preserving:
both consult `contentKey` immediately after, which already excludes README.

Also found: `isExcludedId`'s docblock had come adrift ~80 lines above the function, immediately
followed by a second `/**`, so every reader and every JSDoc tool attached it to
`historicalPathspecs`.

## The pair this creates, and its gate

The shell array is a second copy of `TEMPLATE_SEGMENTS`, because bash cannot import an ES
module — the exact shape #672 is about, one level up. So it is gated rather than trusted:
`template-predicate.test.js` parses the array and asserts set equality **in both directions**,
and separately drives the shell `is_template` function name by name against `isTemplateSegment`,
since matching *lists* would not catch a typo in the *function* that reads them.

## Negative evidence

Every claim below was run, not reasoned.

| # | experiment | result |
|---|---|---|
| 1 | plant `guides/_template.yml`, `git add -N` | corpus test **red**, naming the file; exactly 1 of 12 failed; removed → 12/12 |
| 2 | drop `_template.mjs` from `TEMPLATE_SEGMENTS`, vs `npm run test:scripts` | **MUTANT KILLED by 6**; no crash signature, 6/691 is not a broad share |
| 3 | drop `_template.mjs` from the **shell** array, same command | **MUTANT KILLED by 2** — the parity test and the shell-function test |
| 4 | plant an unregistered `agents/zzz-planted.md`, run `validate-integrity.sh` | **exit 1**, naming it in the converted loops |

(4) is the anti-vacuity check, and it is the one that matters most: `validate-integrity.sh` is a
**required** context, and the failure mode of a botched `is_template` is *over-broad skipping* —
which makes the gate vacuous while staying green. An over-broad predicate would have skipped the
planted file silently. It went red naming it, through the very loops that were converted.

Mutations ran against `npm run test:scripts` — the command CI runs — not the inner script.

## Verification

- `npm test` green end to end: integrity, `check-readmes` (no drift), **691/691** script tests,
  **115** CLI tests
- 12 new tests in `scripts/test/template-predicate.test.js`
- `bash -n` on both shell scripts; the workflow YAML parses

One incidental fix: `normalize-content-style.test.js`'s fixture copied the script *alone*, which
worked only while it imported nothing local. That isolation is part of how the duplicate
predicate stayed invisible — the file's own comment said *"Predicates copied verbatim from
check-content-style.js"* and no fixture could have noticed. It now copies `scripts/lib/`.

## Disposition of #669

**Already closed independently** (via the `files[]` negation), which disposes of that AC bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yKCWG7uvJezdapqRMc2Wf
