### PR TITLE
fix(release): point the publish path at NPM_TOKEN, the secret that exists (#696)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         continue-on-error: ${{ github.event_name == 'push' }}
         run: npm whoami
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_2 }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # `npm publish --dry-run`, NOT `npm pack --dry-run`, and the difference is the whole value of
       # the rehearsal. Measured: `pack --dry-run` runs `prepack` alone, while `publish --dry-run`
@@ -87,7 +87,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: npm publish --dry-run
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_2 }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # The dispatch arm is spelled with an explicit `github.event_name` test rather than leaning
       # on `inputs.dry_run` alone. On any non-dispatch event `inputs` is empty, `inputs.dry_run` is
@@ -110,7 +110,7 @@ jobs:
           startsWith(github.ref, 'refs/tags/'))
         run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_2 }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Same condition as the publish, deliberately. Guarding this on `push` alone meant the exact
       # scenario the dispatch was built for — tag pushed, tests green, publish died, token fixed,


### PR DESCRIPTION
The maintainer rotated the npm credential — `NPM_TOKEN` updated, `NPM_TOKEN_2` deleted. `release.yml` still referenced the deleted name in **all three** places that need a credential.

```
:75   npm whoami             advisory on a tag, a gate on a dry run
:90   npm publish --dry-run  the rehearsal
:113  npm publish            the real PUT
```

This mattered quietly: a missing GitHub secret resolves to the **empty string** rather than failing the step, which is how this repo reached E401 the first time.

Verified the secret side rather than assuming it:

```console
$ gh secret list
NPM_TOKEN          2026-08-26T06:03:55Z
README_DEPLOY_KEY  2026-07-16T08:53:32Z
```

Swept the whole repo instead of trusting the three lines I had already seen — `NPM_TOKEN_2` and `NPM_TOKEN` occur **only** in this file. No doc, no CLAUDE.md section, no script mentions either name, so there is nothing else to keep in sync.

Behaviour otherwise untouched: the conditional `continue-on-error` still keeps `whoami` advisory on the tag path and a gate on dispatch, and the publish arm still requires a tag ref.

## Not verified here, deliberately

A green `whoami` proves the token is **alive**, not that it can **write**. A read-only token, and a granular token whose package list omits this package, both authenticate fine and then 404 the PUT — the comment at `:55` already records this as the permanent boundary of what that step can diagnose.

The honest next step is a `workflow_dispatch` **dry run**, which runs `prepublishOnly` and everything the real publish does except the PUT. That is the maintainer's to fire; firing a live publish as a test is exactly what this file exists to prevent.

Refs #696.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yKCWG7uvJezdapqRMc2Wf