### PR TITLE
docs(release): reattach the publish-arm comment to the step it describes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,19 +89,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # The dispatch arm is spelled with an explicit `github.event_name` test rather than leaning
-      # on `inputs.dry_run` alone. On any non-dispatch event `inputs` is empty, `inputs.dry_run` is
-      # null, and GitHub casts both null and false to 0 — so `inputs.dry_run == false` is TRUE on
-      # every such event. That is harmless while `push` is the only other trigger, because its own
-      # disjunct is already true; add a third trigger and the publish step arms itself on it with
-      # nobody having touched this line.
-      #
-      # `startsWith(github.ref, 'refs/tags/')` is not about privilege — anyone who can dispatch can
-      # already push a tag. It is about EVIDENCE. A tag-push publish anchors the published bytes to
-      # a tag and a release; a dispatch publish from a branch leaves a version on the registry
-      # corresponding to no ref marker at all, and this repo's stated threat model is the
-      # agent-driven accident, where a stray `-f dry_run=false` is one flag against a deliberate
-      # multi-step tag push.
       # THE TAG IS NOT THE VERSION. `npm publish` takes the version from package.json and never
       # looks at the ref; `gh release create` takes its title from the ref and never looks at the
       # manifest. Nothing downstream compares them, so a mismatch is not merely unguarded — it is
@@ -129,6 +116,19 @@ jobs:
           fi
           echo "tag $GITHUB_REF_NAME matches package.json $PKG"
 
+      # The dispatch arm is spelled with an explicit `github.event_name` test rather than leaning
+      # on `inputs.dry_run` alone. On any non-dispatch event `inputs` is empty, `inputs.dry_run` is
+      # null, and GitHub casts both null and false to 0 — so `inputs.dry_run == false` is TRUE on
+      # every such event. That is harmless while `push` is the only other trigger, because its own
+      # disjunct is already true; add a third trigger and the publish step arms itself on it with
+      # nobody having touched this line.
+      #
+      # `startsWith(github.ref, 'refs/tags/')` is not about privilege — anyone who can dispatch can
+      # already push a tag. It is about EVIDENCE. A tag-push publish anchors the published bytes to
+      # a tag and a release; a dispatch publish from a branch leaves a version on the registry
+      # corresponding to no ref marker at all, and this repo's stated threat model is the
+      # agent-driven accident, where a stray `-f dry_run=false` is one flag against a deliberate
+      # multi-step tag push.
       - name: Publish to npm
         if: >-
           github.event_name == 'push' ||

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ The first release to actually reach npm since `1.3.0`. `1.9.0` was tagged on 202
 - **`release.yml` never checked that the git tag matched `package.json`.** `npm publish` takes its version from the manifest and ignores the ref; `gh release create` takes its title from the ref and ignores the manifest. A mismatch was silent and green: tagging `v1.9.1` against a manifest reading `1.9.0` would have published 1.9.0 — a free version, so the PUT succeeds — under a release titled "Release v1.9.1", leaving `npm i agent-almanac@1.9.1` a permanent `E404`. Guarded on the tag path.
 - `package-lock.json` declared `1.3.0` while `package.json` declared `1.9.0` — the earlier bump was hand-edited. Both now move together via `npm version`.
 
-
 ## [1.9.0] - 2026-08-19
 
 The last release of the JavaScript CLI. The version number is deliberate: `2.0.0` is held for the Rust port (#256), so this line ends at `1.9.x`.


### PR DESCRIPTION
Found by adversarial review of #747 (finding F6a).

Inserting the tag-vs-manifest guard orphaned the thirteen-line comment explaining the **publish** step's `if:`. It ended up abutting the guard's own comment block, with the guard step following — so a reader going top-down attaches reasoning about `inputs.dry_run` casting and the dispatch arm's evidence argument to a step whose condition is `startsWith(github.ref, 'refs/tags/')` and nothing else.

Documentation of a control drifting from the control it describes, in a **release workflow** — read under exactly the pressure that makes misreading costly.

## Verification

No step, condition, `env` or ordering changed. YAML re-parsed; the six steps are in the same order:

```
Run tests
Who is the runner (advisory on a tag, a gate on a dry run)
Rehearse the publish (everything the real publish does except the PUT)
The tag must match the manifest
Publish to npm
Create GitHub Release
```

Guard re-exercised under `bash -e` after the move:

```
v1.9.1  -> exit 0
v1.9.0  -> exit 1
v2.0.0  -> exit 1
1.9.1   -> exit 1   (no leading v)
```

`check-readmes` clean. Also collapses the stray double blank line the CHANGELOG edit left before `## [1.9.0]` (F6b).

## Review items already resolved on #747

- **F1** (tag-aim hazard) — operational, handled at tag time: the tag will be aimed at merge commit `b2f67e1bf`, whose tree carries version `1.9.1`, the guard, and a matching lockfile. Verified before any push.
- **F2** — `git diff --stat v1.9.0..b2f67e1bf -- cli/` is **empty**, `cli/test/` included, so the CHANGELOG's "byte-identical" claim stands without qualification.
- **F3** — read from the dry-run log rather than trusting npm's negation-order semantics: **zero** `_template` files in the tarball, and `CHANGELOG.md` / `SECURITY.md` / `plugin.json` all absent.
- **`readmes`** check reported and green on #747.
- **F4** (`plugin.json` stale at `1.0.0`, counts `361/65/72/17`) — does not ship; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yKCWG7uvJezdapqRMc2Wf