### PR TITLE
Close both auto-memory caps at their boundary, and implement the redaction gate the skills only specified

### DIFF
--- a/tests/results/2026-08-26-cap-constant-closure/RESULT.md
+++ b/tests/results/2026-08-26-cap-constant-closure/RESULT.md
@@ -16,7 +16,7 @@ published in `tools/wirecap.py`. What remained open:
 |---|---|---|
 | **P1** | the SIZE cap is exactly 25,000 units, threshold strictly `>` | measured on two platforms, neither of them this one; a different platform is a different build |
 | **P2** | the LINE cap is exactly 200, same strict comparison | nobody had fixtured the line boundary at all |
-| **P3** | the cut keeps whole lines, retreating to the last newline at or before the cap, and falls back to exactly the cap only when there is no newline | asserted from behaviour, never isolated |
+| **P3** | the cut keeps whole lines, retreating to the last newline at or before the cap, and falls back to exactly the cap only when there is no newline | asserted from behaviour, never isolated. **Only the fallback half is tested by this run** — see below |
 | **P4** | both counts are taken after trimming | untested by anyone |
 | **P5** | when BOTH caps are exceeded the notice takes a third form, naming lines and size together with **no** `(limit: …)` clause | the thread had two notice variants and believed that was all of them |
 
@@ -29,6 +29,15 @@ session's self-report about its own context is unsound in **both** directions.
 The store path is **discovered, never computed**: each arm runs a throwaway session in its own
 directory and observes which `~/.claude/projects/` entry appears. The slug transform has changed
 before (#720), so a computed one would be a guess.
+
+**This is not a clean room and the write-up does not claim one.** Isolation is per-arm *cwd* —
+a distinct project directory yields a distinct slug and therefore a distinct store, which is all
+the arms require. `CLAUDE_CONFIG_DIR` is **not** isolated: `run_claude()` sets exactly one
+variable, `ANTHROPIC_BASE_URL`, so the throwaway sessions load the operator's real user config.
+An earlier draft of the upstream comment claimed `CLAUDE_CONFIG_DIR` isolation; it was false and
+was caught in review before posting. The measurements are unaffected — the read-out is the
+injected `MEMORY.md` segment, which is per-store — but in a thread where an isolation claim has
+already produced one retraction, the weaker true statement is the one worth making.
 
 **Why the size arms contain no newline.** Under P3 a fixture built out of lines reads the cap
 *through* a line width and can never resolve it better than one line — which is why a week of
@@ -63,7 +72,7 @@ one character is the whole difference between silence and a notice. A cap of 24,
 `line_exact` at 200 lines arrives whole and silent. `line_over1` at 201 lines is cut to exactly
 200 — its last surviving line is `L00200` — and announces `201 lines (limit: 200)`.
 
-#### P3 — whole-line retreat, with a fallback to the cap itself
+#### P3 — the fallback branch holds; the retreat branch is NOT tested here
 
 `size_over7` is the position proof, and it replicates DanceNitra's win32 arm on linux:
 
@@ -74,8 +83,18 @@ the cut lands THREE characters into marker 3,572
 ```
 
 A cut landing on a marker boundary would have indicted the fixture rather than measured anything.
-It does not. And `line_over1` shows the other branch: with newlines present the cut retreats to
-one, discarding 21 units it had room for.
+It does not.
+
+**No arm in this run exercises the size cut's newline retreat, and an earlier draft of this file
+claimed one did.** `line_over1` is cut by the LINE cap — 4,220 units against a 25,000 ceiling, so
+the size cap never binds — and a cut expressed in whole lines lands on a line boundary trivially.
+Its 21 unused units are measured against a budget that was never the constraint. The three size
+arms are newline-free by construction and `both` is line-cut as well, so the branch is untested
+here. Treat P3's retreat clause as open on this build.
+
+The demonstration is in the 2026-08-25 run instead: a 150 × 200-char + LF fixture, 30,149 units,
+cut at exactly line 124 = 24,923 units — the size cut retreating **77 units** from the ceiling to
+reach a newline, where line 125 would have ended at 25,124.
 
 #### P4 — the counts are taken after trimming
 
@@ -135,7 +154,8 @@ lands in a **live** memory store. This is not hypothetical: it is the cause of a
 published upstream and retracted the same day (`anthropics/claude-code#82056`, yacb2, comment
 5424142726 retracting 5423768912 — reported as "a nested session ignores the isolation variables",
 actually a shell-assignment scoping bug). `cap-closure-probe.py` passes `env=` explicitly and pipes
-input via stdin, so the form cannot occur; the docstring is fixed in the same commit as this run.
+input via stdin, so the form cannot occur. The docstring fix is a separate commit from this run
+(`eb1534911`, `tools/wirecap.py` alone), made after the captures were taken.
 
 ### What this does NOT claim
 
@@ -158,8 +178,21 @@ python3 cap-closure-probe.py --analyze "$ROOT"
 python3 cap-closure-probe.py --cleanup "$ROOT"     # fail-closed; run it
 ```
 
-`--analyze` compares each observed notice against a table of expectations declared before the run
-and exits non-zero on any mismatch, so the verdict is not a human reading of the output.
+`--analyze` asserts every cell — wire units, wire line count, and the FULL notice string — against
+a table declared before the run, and exits non-zero on any mismatch.
+
+**It did not always, and the difference is the whole point of recording it.** The first version
+stored a boolean per arm and asserted only whether *a* notice appeared. An independent reviewer
+killed it with a mutant: every wire body corrupted to 5 units and the `both` notice replaced with
+`999.9KB (limit: 24.4KB) - TOTALLY DIFFERENT NOTICE`. It printed `OK`, exit 0. Under that check
+the `both` arm would have passed carrying `300 lines (limit: 200)` — precisely the outcome P5
+predicts against — and every figure in the table above was in fact human-read. The current
+version kills that mutant on all seven arms; the reproduction is worth re-running before trusting
+any future edit to `EXPECTED`.
+
+Independently of the tool, every figure in this file was re-derived from the raw captures by a
+second party using their own parser, explicitly forbidden from importing the probe's helpers, so
+a bug in `_memory_segment` or `utf16_units` could not reproduce itself into the check.
 
 **Run `--cleanup`.** A probe fixture is indistinguishable from a real memory store to anything that
 walks that directory, and left-behind fixtures have already corrupted one published census
@@ -167,6 +200,43 @@ upstream: 75 of 80 "empty memory stores" on one observer's machine turned out to
 residue (`anthropics/claude-code#82056`, comment 5423768912). Cleanup here is fail-closed and
 refuses to guess what to delete. Verified after this run: the projects directory returned to its
 prior count, with zero arms left behind.
+
+### An OS-agnostic reprex, and the trap it caught in itself
+
+`reprex_memory_cap.py` in this directory is the whole run as one self-contained file: Python 3.8+,
+standard library only, no repository, no network. It exists because every other participant in
+`anthropics/claude-code#82056` is on a different platform and has been hand-rolling instruments.
+
+```bash
+python3 reprex_memory_cap.py --selftest    # no `claude` needed; checks the instrument
+python3 reprex_memory_cap.py --run         # the seven arms
+```
+
+It reproduced all seven arms independently of `cap-closure-probe.py` — different code, different
+temporary location, same seven verdicts — a second confirmation of the table above rather than a
+convenience wrapper around it.
+
+**Its first end-to-end run failed, and the failure is worth more than the pass.** It put its arm
+directories beside itself, inside this repository, and all seven arms returned an identical 15,222
+units over 141 lines: this repository's own `MEMORY.md`, read seven times. **Memory is keyed to the
+git repository, not the working directory**, so every arm shared one store and not one fixture was
+ever loaded. Nothing was written to that store and it was unharmed — the fixtures went to the
+per-cwd transcript directories, which cleanup removed — but every number was of the wrong file.
+
+That is the asymmetry JhouCode reported upstream the same morning (inside a repo, `cd` keeps the
+store; outside one, it does not) arriving as an instrument bug rather than as an observation. The
+original probe was unaffected only because its root was under `/tmp`, outside any repository —
+which was luck, not design.
+
+Three guards now make it unreachable, and only the third catches it directly:
+
+1. arms run under the system temp directory, never beside the file
+2. an ancestor `.git` refuses the run outright
+3. **each capture asserts that the index path the harness reports is the store that arm just wrote
+   to** — because reading the wrong store returns perfectly well-formed numbers for the wrong file,
+   which is precisely how this failed
+
+Guard 3 is the one worth copying into any fixture for this question.
 
 ### Disclosure
 

--- a/tests/results/2026-08-26-cap-constant-closure/RESULT.md
+++ b/tests/results/2026-08-26-cap-constant-closure/RESULT.md
@@ -1,0 +1,177 @@
+## Run: 2026-08-26-cap-constant-closure
+
+**Observer**: Claude (Opus 5, one Claude Code session on one machine) | **Relates**: #407, #717, #720, #722, `anthropics/claude-code#82056`
+
+### Objective
+
+Settle, on **linux-x64**, five open questions about the auto-memory index caps that no fixture in
+the corpus has been able to answer, and do it from the wire rather than by asking the model.
+
+Prior work in `anthropics/claude-code#82056` bracketed the size cap and then measured it at
+**25,000 UTF-16 code units** on two platforms — win32 (DanceNitra, comment 5421352343) and
+darwin-arm64 (yacb2, comment 5423768912). Both used the capture instrument this repository
+published in `tools/wirecap.py`. What remained open:
+
+| | prediction | why it was open |
+|---|---|---|
+| **P1** | the SIZE cap is exactly 25,000 units, threshold strictly `>` | measured on two platforms, neither of them this one; a different platform is a different build |
+| **P2** | the LINE cap is exactly 200, same strict comparison | nobody had fixtured the line boundary at all |
+| **P3** | the cut keeps whole lines, retreating to the last newline at or before the cap, and falls back to exactly the cap only when there is no newline | asserted from behaviour, never isolated |
+| **P4** | both counts are taken after trimming | untested by anyone |
+| **P5** | when BOTH caps are exceeded the notice takes a third form, naming lines and size together with **no** `(limit: …)` clause | the thread had two notice variants and believed that was all of them |
+
+### Method
+
+`cap-closure-probe.py` in this directory. Seven arms, one capture each, every figure counted out
+of the captured POST body — nothing is asked of the model, because #717 established that a
+session's self-report about its own context is unsound in **both** directions.
+
+The store path is **discovered, never computed**: each arm runs a throwaway session in its own
+directory and observes which `~/.claude/projects/` entry appears. The slug transform has changed
+before (#720), so a computed one would be a guess.
+
+**Why the size arms contain no newline.** Under P3 a fixture built out of lines reads the cap
+*through* a line width and can never resolve it better than one line — which is why a week of
+line-based fixtures upstream landed on a 24-unit bracket rather than a constant. Remove every
+newline and the whole-line retreat has nothing to retreat to, so the cut lands on the constant
+itself.
+
+### Results — 7 of 7 arms as predicted
+
+| arm | fixture | on disk | on the wire | lines | notice |
+|---|---|---:|---:|---:|---|
+| `size_exact` | 5-char markers × 5,000 | 25,000 | 25,000 | 1 | **(none)** |
+| `size_over1` | the same + one character | 25,001 | 25,000 | 1 | `24.4KB (limit: 24.4KB) — index entries are too long` |
+| `size_over7` | 7-char markers × 4,000 | 28,000 | 25,000 | 1 | `27.3KB (limit: 24.4KB) — index entries are too long` |
+| `line_exact` | 200 lines × 20 chars | 4,199 | 4,199 | 200 | **(none)** |
+| `line_over1` | 201 lines × 20 chars | 4,220 | 4,199 | 200 | `201 lines (limit: 200)` |
+| `both` | 300 lines × 100 chars | 30,299 | 20,199 | 200 | **`300 lines and 29.6KB`** |
+| `trim` | `size_exact` + a trailing blank run | 25,003 | 25,000 | 1 | **(none)** |
+
+Every notice is prefixed `MEMORY.md is ` and suffixed `. Only part of it was loaded. Keep index
+entries to one line under ~200 chars; move detail into topic files.`
+
+#### P1 — the size cap is 25,000, and the threshold is strictly greater-than
+
+`size_exact` and `size_over1` put **byte-identical content on the wire** — both end
+`…M4997M4998M4999M5000` at 25,000 units. They differ by exactly one character *on disk*, and that
+one character is the whole difference between silence and a notice. A cap of 24,999 would have cut
+`size_exact`; a threshold of `>=` would have warned on it.
+
+#### P2 — the line cap is 200, on the same strict comparison
+
+`line_exact` at 200 lines arrives whole and silent. `line_over1` at 201 lines is cut to exactly
+200 — its last surviving line is `L00200` — and announces `201 lines (limit: 200)`.
+
+#### P3 — whole-line retreat, with a fallback to the cap itself
+
+`size_over7` is the position proof, and it replicates DanceNitra's win32 arm on linux:
+
+```
+3,571 whole markers = 24,997 units, remainder 3 units      total 25,000
+last whole marker   M003571
+the cut lands THREE characters into marker 3,572
+```
+
+A cut landing on a marker boundary would have indicted the fixture rather than measured anything.
+It does not. And `line_over1` shows the other branch: with newlines present the cut retreats to
+one, discarding 21 units it had room for.
+
+#### P4 — the counts are taken after trimming
+
+`trim` weighs **25,003** units on disk and arrives **whole**, at 25,000, silent. Its trailing blank
+run is not counted. Nothing else in this corpus separates trimmed from untrimmed counting: every
+other fixture is identical under both readings.
+
+#### P5 — a third notice variant exists
+
+`both` exceeds both caps and produces a form the thread had not seen:
+
+```
+MEMORY.md is 300 lines and 29.6KB. Only part of it was loaded. …
+```
+
+**No `(limit: …)` clause at all**, where each single-cap variant carries one.
+
+The arm also shows that **both figures in the notice describe the whole file, not what survived** —
+300 lines and 29.6KB are the on-disk counts, against 200 lines and 20,199 units on the wire. That
+matches the size-only finding recorded in the 2026-08-25 run: the notice reports what was offered
+and what the ceiling is, so the shortfall is available by subtraction.
+
+**What this arm does NOT show, and an earlier draft of this file claimed it did: the order of the
+two cuts.** At this geometry line-cut-then-size-check and size-cut-then-line-cut produce
+byte-identical output — both 20,199 units over 200 lines — so the observation cannot separate them.
+Separating them requires a fixture where the size cap binds harder than the line cap: fewer, much
+longer lines. Not run here.
+
+#### Incidental: the tools array
+
+`tools` is **`['advisor']`, n=1, in all seven captures** — not empty, despite
+`--tools "" --strict-mcp-config`. That reproduces from the wire the correction published in
+`anthropics/claude-code#82056` comment 5412833938: `--tools` filters client tools and does not
+remove one contributed by `settings.json`. Asserting tool-zero from the CLI's init event is the
+weaker surface; reading the `tools` array out of the captured request is free once you are
+capturing.
+
+### A defect this run found in our own tooling
+
+`tools/wirecap.py`'s usage docstring documented the invocation as:
+
+```
+ANTHROPIC_BASE_URL=http://127.0.0.1:8787 \
+  printf '%s' 'hello' | claude -p --tools "" --strict-mcp-config
+```
+
+Assignments before a pipeline apply to the **first command only**, so `ANTHROPIC_BASE_URL` never
+reaches `claude`. Measured on this box:
+
+```
+piped-form  FOO=[UNSET]
+prefix-form FOO=[bar]
+```
+
+Following our own published docstring, the capture is empty, the real API answers, and the fixture
+lands in a **live** memory store. This is not hypothetical: it is the cause of a false finding
+published upstream and retracted the same day (`anthropics/claude-code#82056`, yacb2, comment
+5424142726 retracting 5423768912 — reported as "a nested session ignores the isolation variables",
+actually a shell-assignment scoping bug). `cap-closure-probe.py` passes `env=` explicitly and pipes
+input via stdin, so the form cannot occur; the docstring is fixed in the same commit as this run.
+
+### What this does NOT claim
+
+- **Nothing about other platforms.** linux-x64, one build. The win32 and darwin figures agree, but
+  they are different compilations and this run does not merge with them.
+- **Nothing about why the constants are what they are.** This measures behaviour at two
+  boundaries. It does not license any statement about the implementation that produces it.
+- **Nothing about whether the model reads the notice.** Presence on the wire is not use. That
+  question is untouched here.
+- **One trial per arm.** The arms are deterministic and each predicted its own outcome in advance,
+  which is a different kind of evidence from repetition, not a substitute for it.
+
+### Reproducing
+
+```bash
+cd tests/results/2026-08-26-cap-constant-closure
+python3 cap-closure-probe.py --build   "$ROOT"
+python3 cap-closure-probe.py --capture "$ROOT"
+python3 cap-closure-probe.py --analyze "$ROOT"
+python3 cap-closure-probe.py --cleanup "$ROOT"     # fail-closed; run it
+```
+
+`--analyze` compares each observed notice against a table of expectations declared before the run
+and exits non-zero on any mismatch, so the verdict is not a human reading of the output.
+
+**Run `--cleanup`.** A probe fixture is indistinguishable from a real memory store to anything that
+walks that directory, and left-behind fixtures have already corrupted one published census
+upstream: 75 of 80 "empty memory stores" on one observer's machine turned out to be their own
+residue (`anthropics/claude-code#82056`, comment 5423768912). Cleanup here is fail-closed and
+refuses to guess what to delete. Verified after this run: the projects directory returned to its
+prior count, with zero arms left behind.
+
+### Disclosure
+
+This run was drafted against `skills/redact-for-public-disclosure` and gated with
+`tools/check-redaction.sh`, which was written for it — the skills specified that scanner and four
+others, and none of them had ever been implemented or invoked. On its first real use the gate
+caught four findings in **this directory's own probe script**, which was headed for a public
+repository. See `tools/check-redaction.sh` and the notes in `tools/README.md`.

--- a/tests/results/2026-08-26-cap-constant-closure/cap-closure-probe.py
+++ b/tests/results/2026-08-26-cap-constant-closure/cap-closure-probe.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""
+agent-almanac #407/#722 follow-up -- close the two INFERRED steps in the binary reading of the
+auto-memory cap, on the same artifact that was dumped.
+
+FIVE PREDICTIONS, EACH WITH AN ARM THAT WOULD FALSIFY IT
+--------------------------------------------------------
+Prior work in anthropics/claude-code#82056 bracketed the size cap behaviourally and, on two
+platforms, measured it at 25,000 UTF-16 code units. This run states the remaining open
+questions as predictions and tests each one, on linux-x64, from the wire:
+
+    P1  the SIZE cap is exactly 25,000 UTF-16 code units, and the notice threshold is
+        strictly greater-than -- so 25,000 loads whole and silent, 25,001 does not
+    P2  the LINE cap is exactly 200, on the same strict comparison
+    P3  the cut keeps WHOLE LINES -- it retreats to the last newline at or before the cap --
+        and falls back to exactly the cap only when the text contains no newline at all
+    P4  both counts are taken AFTER trimming, so trailing whitespace is free
+    P5  when BOTH caps are exceeded the notice takes a third form, naming the line count and
+        the size together, with no "(limit: ...)" clause at all
+
+P1 and P2 are what the two-platform result cannot settle for THIS build: a different platform
+is a different compilation. P3, P4 and P5 have never been tested by anyone.
+
+Each prediction is falsifiable by exactly one arm below, and `--analyze` compares the observed
+notice against `EXPECTED` rather than against a human reading of the output.
+
+THE FIXTURES, AND WHY THEY ARE SHAPED THIS WAY
+----------------------------------------------
+Under P3, a fixture built out of lines reads the cap THROUGH a line width and can never
+resolve it better than one line -- which is why a week of line-based fixtures upstream landed
+on a 24-unit bracket rather than a constant. The size arms below therefore contain no newline
+whatsoever, so the whole-line retreat has nothing to retreat to and the cut lands on the
+constant itself. If P3 is wrong, `size_over7` says so: its cut would fall on a marker
+boundary instead of three characters inside one.
+
+    arm          fixture                        units  lines  expect
+    size_exact   5-char markers x 5,000         25,000     1  silent, whole
+    size_over1   size_exact + one "z"           25,001     1  cut to 25,000 + notice
+    size_over7   7-char markers x 4,000         28,000     1  cut mid-marker 3,572
+    line_exact   200 lines x 20 chars            4,199   200  silent, whole
+    line_over1   201 lines x 20 chars            4,220   201  cut to 200 + notice
+    both         300 lines x 100 chars          30,299   300  BOTH caps -> third variant
+    trim         size_exact + "\n\n\n"      25,000/25,003  1/4 silent IFF .trim() runs first
+
+`size_over7` replicates DanceNitra's win32 arm on linux: 25,000/7 = 3,571.43, so the cut
+lands THREE characters into marker 3,572. A cut landing on a marker edge would indict the
+fixture rather than measure the constant.
+
+`both` produces the third notice variant -- `${r} lines and ${at(o)}`, with no `(limit: ...)`
+at all -- which nobody in anthropics/claude-code#82056 has produced. After line-truncation to
+200 lines the text is 20,199 units, under the size cap, so no second cut occurs.
+
+`trim` is the discriminator for the `.trim()` claim: trimmed it is 25,000 units and silent;
+untrimmed it is 25,003 and cuts. Nothing else in the corpus separates those.
+
+THE READ-OUT IS THE WIRE
+------------------------
+#717 established that a session's self-report about its own context is unsound in BOTH
+directions, so nothing here asks the model anything. Every figure is counted out of the
+captured POST body by `--analyze`.
+
+STORE PATH IS DISCOVERED, NEVER COMPUTED
+----------------------------------------
+The project-slug transform has changed before (#720). Each arm runs a throwaway session in
+its own directory and observes which `~/.claude/projects/` entry appears. If none appears the
+run fails closed rather than writing a fixture somewhere nothing will read it.
+
+INVOCATION HAZARD THIS SCRIPT AVOIDS BY CONSTRUCTION
+----------------------------------------------------
+`VARS printf '%s' hi | claude -p ...` applies the assignments to `printf` ONLY, so
+ANTHROPIC_BASE_URL never reaches `claude`: the capture is empty, the real API answers, and
+the fixture lands in a LIVE store. That is a published false-finding cause in #82056
+(yacb2, retracted in comment 5424142726) and it is the form written in this repository's own
+`tools/wirecap.py` docstring. Every subprocess here passes `env=` explicitly and pipes input
+via stdin, so the form cannot occur.
+
+USAGE
+-----
+    python3 cap-closure-probe.py --build   ROOT [--port P]
+    python3 cap-closure-probe.py --capture ROOT
+    python3 cap-closure-probe.py --analyze ROOT
+    python3 cap-closure-probe.py --cleanup ROOT
+"""
+import argparse
+import json
+import os
+import pathlib
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+import time
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+WIRECAP = REPO / "tools" / "wirecap.py"
+
+# arm -> (kind, params). Built by build_index(); see the docstring table.
+ARMS = {
+    "size_exact": ("markers", {"width": 5, "count": 5000, "tail": ""}),
+    "size_over1": ("markers", {"width": 5, "count": 5000, "tail": "z"}),
+    "size_over7": ("markers", {"width": 7, "count": 4000, "tail": ""}),
+    "line_exact": ("lines", {"nlines": 200, "chars": 20}),
+    "line_over1": ("lines", {"nlines": 201, "chars": 20}),
+    "both": ("lines", {"nlines": 300, "chars": 100}),
+    "trim": ("markers", {"width": 5, "count": 5000, "tail": "\n\n\n"}),
+}
+
+EXPECTED = {
+    # arm: (utf16 units of the RAW file on disk, lineCount of the TRIMMED text, notice expected?)
+    #
+    # The two columns deliberately measure different texts. Units are what the file weighs on
+    # disk, which is what a human writing an index controls. The line figure is the count as
+    # taken under P4 -- i.e. AFTER trimming -- so for every arm but `trim` the two texts are
+    # identical and the distinction is invisible. `trim` is the one arm that separates them,
+    # which is its entire
+    # purpose: 25,003 units on disk, 25,000 after trimming, and therefore SILENT if and only if
+    # the trim really happens before the comparison.
+    "size_exact": (25000, 1, False),
+    "size_over1": (25001, 1, True),
+    "size_over7": (28000, 1, True),
+    "line_exact": (4199, 200, False),
+    "line_over1": (4220, 201, True),
+    "both": (30299, 300, True),
+    "trim": (25003, 1, False),
+}
+
+
+def build_index(kind, params):
+    """Return the fixture text. No trailing newline unless a `tail` asks for one."""
+    if kind == "markers":
+        width, count, tail = params["width"], params["count"], params["tail"]
+        # Fixed-width unique markers, zero-padded so every marker is exactly `width` units
+        # and the marker index is recoverable from the wire by position alone.
+        body = "".join(f"M{i:0{width - 1}d}" for i in range(1, count + 1))
+        return body + tail
+    if kind == "lines":
+        nlines, chars = params["nlines"], params["chars"]
+        return "\n".join(
+            f"L{i:05d}" + "x" * (chars - 6) for i in range(1, nlines + 1)
+        )
+    raise ValueError(kind)
+
+
+def utf16_units(text):
+    return len(text.encode("utf-16-le")) // 2
+
+
+def line_count(text):
+    """The line count as P2/P4 predict it is taken: newlines plus one, on the TRIMMED text.
+
+    This is a PREDICTION the run tests, not a description of anything read. `line_over1` is
+    what would falsify the newlines-plus-one part, and `trim` the trimmed part."""
+    t = text.strip()
+    return t.count("\n") + 1
+
+
+def projects_dir():
+    return pathlib.Path.home() / ".claude" / "projects"
+
+
+def snapshot_projects():
+    root = projects_dir()
+    return {p.name for p in root.iterdir()} if root.exists() else set()
+
+
+def free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def run_claude(arm_dir, port, timeout=180):
+    """Run one throwaway `claude -p` inside `arm_dir` against the local capture server.
+
+    The environment is passed via `env=`, NEVER as a shell assignment prefix -- see the
+    INVOCATION HAZARD note in the module docstring."""
+    env = dict(os.environ)
+    env["ANTHROPIC_BASE_URL"] = f"http://127.0.0.1:{port}"
+    try:
+        return subprocess.run(
+            ["claude", "-p", "--tools", "", "--strict-mcp-config"],
+            cwd=str(arm_dir), input="hi", text=True, env=env,
+            capture_output=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+
+
+class Server:
+    """wirecap.py as a context manager, one capture file per arm."""
+
+    def __init__(self, out_path, port):
+        self.out_path, self.port, self.proc = out_path, port, None
+
+    def __enter__(self):
+        self.proc = subprocess.Popen(
+            [sys.executable, str(WIRECAP), "--port", str(self.port),
+             "--out", str(self.out_path)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        for _ in range(80):                      # wait for the port to accept
+            try:
+                with socket.create_connection(("127.0.0.1", self.port), timeout=0.25):
+                    return self
+            except OSError:
+                time.sleep(0.25)
+        raise RuntimeError(f"wirecap did not come up on port {self.port}")
+
+    def __exit__(self, *_exc):
+        if self.proc:
+            self.proc.terminate()
+            try:
+                self.proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.proc.kill()
+
+
+def build(root, port):
+    root = pathlib.Path(root).resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    manifest = {}
+    only = os.environ.get("CAP_PROBE_ONLY")
+
+    print(f"{'arm':11} {'units':>7} {'lines':>6} {'store':>7}  path")
+    with Server(root / "_discovery.jsonl", port):
+        for name, (kind, params) in ARMS.items():
+            if only and name != only:
+                continue
+            arm_dir = root / name
+            arm_dir.mkdir(parents=True, exist_ok=True)
+
+            before = snapshot_projects()
+            run_claude(arm_dir, port)
+            store = None
+            for _ in range(20):
+                new = snapshot_projects() - before
+                if new:
+                    store = sorted(new)[0]
+                    break
+                time.sleep(0.25)
+            if store is None:
+                print(f"FAIL: no ~/.claude/projects entry appeared for {arm_dir}.",
+                      file=sys.stderr)
+                print("      Refusing to guess the slug transform (#720).", file=sys.stderr)
+                return 1
+
+            text = build_index(kind, params)
+            memdir = projects_dir() / store / "memory"
+            memdir.mkdir(parents=True, exist_ok=True)
+            target = memdir / "MEMORY.md"
+            with open(target, "wb") as fh:       # bytes: never let text mode touch line endings
+                fh.write(text.encode("utf-8"))
+
+            units, lines = utf16_units(text), line_count(text)
+            exp_u, exp_l, _ = EXPECTED[name]
+            if units != exp_u or lines != exp_l:
+                print(f"FAIL: {name} built {units}u/{lines}L, expected {exp_u}u/{exp_l}L",
+                      file=sys.stderr)
+                return 1
+
+            manifest[name] = {
+                "arm_dir": str(arm_dir), "store": store, "memory": str(target),
+                "kind": kind, "params": params,
+                "utf16_units": units, "line_count": lines,
+            }
+            print(f"{name:11} {units:7} {lines:6} {'ok':>7}  {target}")
+
+    path = root / "manifest.json"
+    if path.exists():                            # MERGE: a single-arm run must not drop others
+        existing = json.loads(path.read_text())
+        existing.update(manifest)
+        manifest = existing
+    path.write_text(json.dumps(manifest, indent=2))
+    print(f"\nmanifest: {path} ({len(manifest)} arm(s))")
+    return 0
+
+
+def capture(root):
+    root = pathlib.Path(root).resolve()
+    path = root / "manifest.json"
+    if not path.exists():
+        print(f"FAIL: no manifest at {path}; run --build first.", file=sys.stderr)
+        return 1
+    manifest = json.loads(path.read_text())
+    only = os.environ.get("CAP_PROBE_ONLY")
+
+    for name, info in manifest.items():
+        if only and name != only:
+            continue
+        out = root / f"{name}.jsonl"
+        port = free_port()
+        with Server(out, port):
+            run_claude(pathlib.Path(info["arm_dir"]), port)
+        n = sum(1 for _ in out.open()) if out.exists() else 0
+        print(f"  {name:11} -> {out.name} ({n} record(s), port {port})")
+        if n == 0:
+            print(f"FAIL: {name} captured nothing. The request did not reach the local "
+                  f"server, so it went somewhere else.", file=sys.stderr)
+            return 1
+    return 0
+
+
+NOTICE_RE = re.compile(r"> WARNING: (MEMORY\.md is [^\n]*)")
+
+
+def analyze(root):
+    root = pathlib.Path(root).resolve()
+    manifest = json.loads((root / "manifest.json").read_text())
+    ok = True
+
+    print(f"{'arm':11} {'disk u':>7} {'wire u':>7} {'wire L':>7} {'tools':>6}  notice")
+    print("-" * 100)
+    for name, info in sorted(manifest.items()):
+        cap_path = root / f"{name}.jsonl"
+        if not cap_path.exists():
+            print(f"{name:11}  NO CAPTURE")
+            ok = False
+            continue
+        rec = json.loads(cap_path.open().readline())
+        body = rec.get("body", rec)
+        text = json.dumps(body)                  # search the whole assembled request
+        raw = _first_text(body)
+
+        seg = _memory_segment(raw)
+        notice = NOTICE_RE.search(raw)
+        ntools = len(body.get("tools", []) or [])
+        exp_u, exp_l, exp_notice = EXPECTED[name]
+
+        wire_u = utf16_units(seg) if seg is not None else -1
+        wire_l = seg.count("\n") + 1 if seg else -1
+        got_notice = bool(notice)
+        flag = "" if got_notice == exp_notice else "   <-- UNEXPECTED"
+        print(f"{name:11} {info['utf16_units']:7} {wire_u:7} {wire_l:7} {ntools:6}  "
+              f"{notice.group(1) if notice else '(none)'}{flag}")
+        if got_notice != exp_notice:
+            ok = False
+
+    print()
+    print("OK" if ok else "MISMATCH -- read the captures, do not adjust the expectations")
+    return 0 if ok else 1
+
+
+def _first_text(body):
+    """The first assistant-visible text block of the request, where the index is injected."""
+    try:
+        msgs = body["messages"]
+        for m in msgs:
+            content = m.get("content")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                for c in content:
+                    if isinstance(c, dict) and c.get("type") == "text":
+                        return c["text"]
+    except (KeyError, TypeError, IndexError):
+        pass
+    return json.dumps(body)
+
+
+def _memory_segment(raw):
+    """The injected MEMORY.md body: between the 'Contents of ...MEMORY.md' header and either
+    the WARNING line or the end of the system-reminder. Returns None if not present."""
+    m = re.search(r"Contents of [^\n]*MEMORY\.md[^\n]*:\n+", raw)
+    if not m:
+        return None
+    rest = raw[m.end():]
+    for stop in ("\n\n> WARNING:", "\n> WARNING:", "\n</system-reminder>", "\n# userEmail"):
+        i = rest.find(stop)
+        if i != -1:
+            rest = rest[:i]
+    return rest
+
+
+def cleanup(root):
+    """FAIL-CLOSED: anything not removed is reported and the exit is non-zero. A probe fixture
+    is indistinguishable from a real memory store to anything that walks that directory."""
+    root = pathlib.Path(root).resolve()
+    path = root / "manifest.json"
+    if not path.exists():
+        print(f"FAIL: no manifest at {path}; refusing to guess what to delete.",
+              file=sys.stderr)
+        return 1
+    manifest = json.loads(path.read_text())
+    kept = []
+    for name, info in manifest.items():
+        for target in (projects_dir() / info["store"], pathlib.Path(info["arm_dir"])):
+            if not target.exists():
+                print(f"  {name}: already gone: {target}")
+                continue
+            try:
+                shutil.rmtree(target)
+                print(f"  {name}: removed {target}")
+            except OSError as exc:
+                kept.append(f"{target}: {exc}")
+
+    leftovers = [p.name for p in projects_dir().iterdir()
+                 if any(info["store"] == p.name for info in manifest.values())]
+    kept.extend(f"store still present: {n}" for n in leftovers)
+
+    if kept:
+        print("\nKEPT (cleanup incomplete):", file=sys.stderr)
+        for item in kept:
+            print(f"  {item}", file=sys.stderr)
+        return 1
+    print("\ncleanup: complete, nothing kept")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build", metavar="ROOT")
+    parser.add_argument("--capture", metavar="ROOT")
+    parser.add_argument("--analyze", metavar="ROOT")
+    parser.add_argument("--cleanup", metavar="ROOT")
+    parser.add_argument("--port", type=int, default=0)
+    args = parser.parse_args()
+
+    if args.build:
+        return build(args.build, args.port or free_port())
+    if args.capture:
+        return capture(args.capture)
+    if args.analyze:
+        return analyze(args.analyze)
+    if args.cleanup:
+        return cleanup(args.cleanup)
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/results/2026-08-26-cap-constant-closure/cap-closure-probe.py
+++ b/tests/results/2026-08-26-cap-constant-closure/cap-closure-probe.py
@@ -40,18 +40,19 @@ boundary instead of three characters inside one.
     line_exact   200 lines x 20 chars            4,199   200  silent, whole
     line_over1   201 lines x 20 chars            4,220   201  cut to 200 + notice
     both         300 lines x 100 chars          30,299   300  BOTH caps -> third variant
-    trim         size_exact + "\n\n\n"      25,000/25,003  1/4 silent IFF .trim() runs first
+    trim         size_exact + a blank run   25,000/25,003  1/4 silent IFF trimmed first
 
 `size_over7` replicates DanceNitra's win32 arm on linux: 25,000/7 = 3,571.43, so the cut
 lands THREE characters into marker 3,572. A cut landing on a marker edge would indict the
 fixture rather than measure the constant.
 
-`both` produces the third notice variant -- `${r} lines and ${at(o)}`, with no `(limit: ...)`
-at all -- which nobody in anthropics/claude-code#82056 has produced. After line-truncation to
+`both` produces a THIRD notice variant -- one naming the line count and the size together,
+with no `(limit: ...)` clause at all -- which nobody in anthropics/claude-code#82056 has
+produced. After line-truncation to
 200 lines the text is 20,199 units, under the size cap, so no second cut occurs.
 
-`trim` is the discriminator for the `.trim()` claim: trimmed it is 25,000 units and silent;
-untrimmed it is 25,003 and cuts. Nothing else in the corpus separates those.
+`trim` is the discriminator for P4: counted after trimming it is 25,000 units and silent;
+counted raw it is 25,003 and cuts. Nothing else in the corpus separates those.
 
 THE READ-OUT IS THE WIRE
 ------------------------
@@ -107,23 +108,40 @@ ARMS = {
     "trim": ("markers", {"width": 5, "count": 5000, "tail": "\n\n\n"}),
 }
 
+NOTICE_TAIL = (" Only part of it was loaded. Keep index entries to one line under ~200 chars;"
+               " move detail into topic files.")
+
+# arm -> what the run must produce. EVERY field here is asserted by --analyze.
+#
+# `disk_units` is the RAW file on disk; `disk_lines` is the count of the TRIMMED text. The two
+# deliberately measure different texts, and for every arm but `trim` those texts are identical,
+# so the distinction is invisible. `trim` is the one arm that separates them, which is its
+# entire purpose: 25,003 units on disk, 25,000 after trimming, and therefore SILENT if and only
+# if the trim really happens before the comparison.
+#
+# `notice` is the FULL expected string, not a boolean. An earlier version of this file stored a
+# boolean and asserted only that, so --analyze would have passed the `both` arm carrying
+# `300 lines (limit: 200)` -- precisely the outcome P5 predicts against. An independent reviewer
+# killed that version with a mutant: every wire body corrupted to 5 units and the `both` notice
+# replaced with `999.9KB ... TOTALLY DIFFERENT NOTICE`, and it still printed `OK`, exit 0.
+# Assert the payload, never its presence.
 EXPECTED = {
-    # arm: (utf16 units of the RAW file on disk, lineCount of the TRIMMED text, notice expected?)
-    #
-    # The two columns deliberately measure different texts. Units are what the file weighs on
-    # disk, which is what a human writing an index controls. The line figure is the count as
-    # taken under P4 -- i.e. AFTER trimming -- so for every arm but `trim` the two texts are
-    # identical and the distinction is invisible. `trim` is the one arm that separates them,
-    # which is its entire
-    # purpose: 25,003 units on disk, 25,000 after trimming, and therefore SILENT if and only if
-    # the trim really happens before the comparison.
-    "size_exact": (25000, 1, False),
-    "size_over1": (25001, 1, True),
-    "size_over7": (28000, 1, True),
-    "line_exact": (4199, 200, False),
-    "line_over1": (4220, 201, True),
-    "both": (30299, 300, True),
-    "trim": (25003, 1, False),
+    "size_exact": dict(disk_units=25000, disk_lines=1, wire_units=25000, wire_lines=1,
+                       notice=None),
+    "size_over1": dict(disk_units=25001, disk_lines=1, wire_units=25000, wire_lines=1,
+                       notice="MEMORY.md is 24.4KB (limit: 24.4KB) — index entries are"
+                              " too long." + NOTICE_TAIL),
+    "size_over7": dict(disk_units=28000, disk_lines=1, wire_units=25000, wire_lines=1,
+                       notice="MEMORY.md is 27.3KB (limit: 24.4KB) — index entries are"
+                              " too long." + NOTICE_TAIL),
+    "line_exact": dict(disk_units=4199, disk_lines=200, wire_units=4199, wire_lines=200,
+                       notice=None),
+    "line_over1": dict(disk_units=4220, disk_lines=201, wire_units=4199, wire_lines=200,
+                       notice="MEMORY.md is 201 lines (limit: 200)." + NOTICE_TAIL),
+    "both": dict(disk_units=30299, disk_lines=300, wire_units=20199, wire_lines=200,
+                 notice="MEMORY.md is 300 lines and 29.6KB." + NOTICE_TAIL),
+    "trim": dict(disk_units=25003, disk_lines=1, wire_units=25000, wire_lines=1,
+                 notice=None),
 }
 
 
@@ -254,10 +272,10 @@ def build(root, port):
                 fh.write(text.encode("utf-8"))
 
             units, lines = utf16_units(text), line_count(text)
-            exp_u, exp_l, _ = EXPECTED[name]
-            if units != exp_u or lines != exp_l:
-                print(f"FAIL: {name} built {units}u/{lines}L, expected {exp_u}u/{exp_l}L",
-                      file=sys.stderr)
+            exp = EXPECTED[name]
+            if units != exp["disk_units"] or lines != exp["disk_lines"]:
+                print(f"FAIL: {name} built {units}u/{lines}L, expected "
+                      f"{exp['disk_units']}u/{exp['disk_lines']}L", file=sys.stderr)
                 return 1
 
             manifest[name] = {
@@ -310,7 +328,7 @@ def analyze(root):
     manifest = json.loads((root / "manifest.json").read_text())
     ok = True
 
-    print(f"{'arm':11} {'disk u':>7} {'wire u':>7} {'wire L':>7} {'tools':>6}  notice")
+    print(f"{'arm':11} {'disk u':>7} {'wire u':>7} {'wire L':>7} {'tools':>6}  verdict")
     print("-" * 100)
     for name, info in sorted(manifest.items()):
         cap_path = root / f"{name}.jsonl"
@@ -320,24 +338,35 @@ def analyze(root):
             continue
         rec = json.loads(cap_path.open().readline())
         body = rec.get("body", rec)
-        text = json.dumps(body)                  # search the whole assembled request
         raw = _first_text(body)
 
         seg = _memory_segment(raw)
-        notice = NOTICE_RE.search(raw)
+        match = NOTICE_RE.search(raw)
+        got_notice = match.group(1) if match else None
         ntools = len(body.get("tools", []) or [])
-        exp_u, exp_l, exp_notice = EXPECTED[name]
+        exp = EXPECTED[name]
 
         wire_u = utf16_units(seg) if seg is not None else -1
         wire_l = seg.count("\n") + 1 if seg else -1
-        got_notice = bool(notice)
-        flag = "" if got_notice == exp_notice else "   <-- UNEXPECTED"
-        print(f"{name:11} {info['utf16_units']:7} {wire_u:7} {wire_l:7} {ntools:6}  "
-              f"{notice.group(1) if notice else '(none)'}{flag}")
-        if got_notice != exp_notice:
-            ok = False
 
-    print()
+        # EVERY field is asserted. Presence-only checking is what a mutant survived.
+        fails = []
+        if info["utf16_units"] != exp["disk_units"]:
+            fails.append(f"disk {info['utf16_units']}!={exp['disk_units']}")
+        if wire_u != exp["wire_units"]:
+            fails.append(f"wire {wire_u}!={exp['wire_units']}")
+        if wire_l != exp["wire_lines"]:
+            fails.append(f"lines {wire_l}!={exp['wire_lines']}")
+        if got_notice != exp["notice"]:
+            fails.append("notice text differs")
+
+        print(f"{name:11} {info['utf16_units']:7} {wire_u:7} {wire_l:7} {ntools:6}  "
+              f"{'ok' if not fails else 'FAIL: ' + '; '.join(fails)}")
+        if fails:
+            ok = False
+            print(f"{'':11}   expected notice: {exp['notice']!r}")
+            print(f"{'':11}   observed notice: {got_notice!r}")
+
     print("OK" if ok else "MISMATCH -- read the captures, do not adjust the expectations")
     return 0 if ok else 1
 

--- a/tests/results/2026-08-26-cap-constant-closure/reprex_memory_cap.py
+++ b/tests/results/2026-08-26-cap-constant-closure/reprex_memory_cap.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""
+reprex_memory_cap.py -- reproduce the Claude Code auto-memory index caps on your own machine.
+
+Single file. Python 3.8+. Standard library only. No repository, no dependencies, no network:
+the request is answered locally and forwarded nowhere.
+
+    python3 reprex_memory_cap.py --selftest    # no `claude` needed; checks the instrument
+    python3 reprex_memory_cap.py --run         # the real thing, ~7 sessions, ~2 minutes
+
+WHAT IT MEASURES
+----------------
+`MEMORY.md` is truncated on load. Two caps apply, and this reproduces both AT THEIR BOUNDARY --
+the pair of fixtures either side of the edge, which is what turns "about 25KB" into a constant:
+
+    size cap   25,000 UTF-16 code units, threshold strictly `>`
+    line cap   200 lines,                threshold strictly `>`
+
+and three things a single-cap fixture cannot show: that a trailing blank run does not count,
+that exceeding BOTH caps produces a third notice variant naming neither limit, and where the
+cut lands when the text has no line boundary to retreat to.
+
+WHY IT READS THE WIRE AND NOT THE MODEL
+---------------------------------------
+A session's self-report about its own context is unreliable in BOTH directions -- it has
+returned "no index" for an index that provably loaded, and volunteered an accurate "truncated
+on load" elsewhere. A failure with no consistent sign cannot be corrected for. So this points
+ANTHROPIC_BASE_URL at a local recording server and counts the bytes the client actually sent.
+
+PRIVACY: THE CAPTURE IS NEVER WRITTEN TO DISK
+---------------------------------------------
+A Claude Code request body contains device and account identifiers, a session id, your home
+paths, your email, and your entire CLAUDE.md. This script holds each body in memory, derives
+seven integers and four strings from it, prints those, and drops it. Credential headers are
+discarded at capture time and never even enter the in-memory record. Nothing here produces a
+file you would have to remember not to paste into a bug report.
+
+RUN IT OUTSIDE A GIT REPOSITORY -- THE GUARD BELOW ENFORCES THIS
+-----------------------------------------------------------------
+Memory is keyed to the GIT REPOSITORY, not to the working directory. Inside a repo, `cd` into a
+subdirectory keeps the same store; outside one, it does not. So if the arms run inside a repo,
+all seven share that repo's store, every arm reads the SAME index -- the repo's real one -- and
+the fixtures are never loaded at all.
+
+This is not theoretical. The first end-to-end run of this file put its arm directories beside
+itself, inside a repository, and all seven arms returned an identical 15,222 units over 141
+lines: the enclosing repository's own MEMORY.md, read seven times. Nothing was written to that
+store and it was unharmed, but every measurement was of the wrong file.
+
+Three guards now make that unreachable: the arms run under the system temp directory, an
+ancestor `.git` refuses the run outright, and each capture asserts that the index path the
+harness reports is the store this arm just wrote to. The third is the one that catches it
+directly, and it is why the failure above cannot recur silently.
+
+WHAT IT WRITES, AND THAT IT CLEANS UP
+-------------------------------------
+Each arm needs its own memory store, so each arm runs in its own throwaway directory, which
+causes Claude Code to create a matching entry under your projects folder. The store path is
+DISCOVERED by watching which entry appears -- never computed from a slug transform, which has
+changed between releases. Everything created is removed at the end, and cleanup is fail-closed:
+if anything could not be removed it is named and the exit status is non-zero.
+
+Leftover probe fixtures are not hypothetical: a census posted upstream found 75 of 80 "empty
+memory stores" on one machine were the observer's own residue.
+
+ONE INVOCATION HAZARD, SINCE IT HAS ALREADY COST THIS THREAD A ROUND TRIP
+------------------------------------------------------------------------
+    VARS printf '%s' hi | claude -p ...       # WRONG
+
+Assignments in front of a pipeline apply to the FIRST command, so the variables reach `printf`
+and never `claude`. The capture stays empty, the real API answers, and the fixture lands in a
+LIVE store. This script passes `env=` to subprocess, where the shape cannot occur.
+
+TESTED ON linux-x64. The OS-specific parts are the executable lookup (`.cmd` shims on Windows)
+and the projects directory, both handled below. If it misbehaves on macOS or Windows that is a
+bug in this file -- please say so rather than working around it.
+"""
+import argparse
+import http.server
+import json
+import os
+import pathlib
+import platform
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+SECRET_HEADERS = {"authorization", "x-api-key", "anthropic-auth-token",
+                  "proxy-authorization", "cookie", "set-cookie"}
+
+# arm -> (kind, params)
+ARMS = {
+    "size_exact": ("markers", dict(width=5, count=5000, tail="")),
+    "size_over1": ("markers", dict(width=5, count=5000, tail="z")),
+    "size_over7": ("markers", dict(width=7, count=4000, tail="")),
+    "line_exact": ("lines", dict(nlines=200, chars=20)),
+    "line_over1": ("lines", dict(nlines=201, chars=20)),
+    "both": ("lines", dict(nlines=300, chars=100)),
+    "trim": ("markers", dict(width=5, count=5000, tail="\n\n\n")),
+}
+
+TAIL = (" Only part of it was loaded. Keep index entries to one line under ~200 chars;"
+        " move detail into topic files.")
+
+# Every field is asserted. Asserting only "did a notice appear" is not a check: a mutant that
+# replaced one notice with a completely different string survived exactly that version.
+EXPECTED = {
+    "size_exact": dict(disk=25000, wire=25000, lines=1, notice=None),
+    "size_over1": dict(disk=25001, wire=25000, lines=1,
+                       notice="MEMORY.md is 24.4KB (limit: 24.4KB) — index entries are too long." + TAIL),
+    "size_over7": dict(disk=28000, wire=25000, lines=1,
+                       notice="MEMORY.md is 27.3KB (limit: 24.4KB) — index entries are too long." + TAIL),
+    "line_exact": dict(disk=4199, wire=4199, lines=200, notice=None),
+    "line_over1": dict(disk=4220, wire=4199, lines=200,
+                       notice="MEMORY.md is 201 lines (limit: 200)." + TAIL),
+    "both": dict(disk=30299, wire=20199, lines=200,
+                 notice="MEMORY.md is 300 lines and 29.6KB." + TAIL),
+    "trim": dict(disk=25003, wire=25000, lines=1, notice=None),
+}
+
+NOTICE_RE = re.compile(r"> WARNING: (MEMORY\.md is [^\n]*)")
+HEADER_RE = re.compile(r"Contents of [^\n]*MEMORY\.md[^\n]*:\n+")
+
+
+# ---------------------------------------------------------------- fixtures
+
+def build_index(kind, p):
+    """Fixed-width unique markers, or numbered lines. No trailing newline unless `tail` adds one."""
+    if kind == "markers":
+        body = "".join("M%0*d" % (p["width"] - 1, i) for i in range(1, p["count"] + 1))
+        return body + p["tail"]
+    return "\n".join("L%05d" % i + "x" * (p["chars"] - 6) for i in range(1, p["nlines"] + 1))
+
+
+def units(text):
+    """UTF-16 code units -- what the cap counts. NOT bytes, NOT code points.
+
+    An emoji outside the BMP is 4 UTF-8 bytes, 1 code point, and 2 of these."""
+    return len(text.encode("utf-16-le")) // 2
+
+
+def segment(raw):
+    """The injected MEMORY.md body: after its header line, up to the notice or the next block.
+
+    Stops at the LAST content character and excludes every trailing newline, so the figure is a
+    prefix of the file on disk rather than of the harness's scaffolding around it. Getting this
+    boundary wrong is how the thread produced two numbers, 24,922 and 24,924, for one fixture."""
+    m = HEADER_RE.search(raw)
+    if not m:
+        return None
+    rest = raw[m.end():]
+    for stop in ("\n\n> WARNING:", "\n> WARNING:", "\n</system-reminder>", "\n# userEmail"):
+        i = rest.find(stop)
+        if i != -1:
+            rest = rest[:i]
+    return rest.rstrip("\n")
+
+
+# ---------------------------------------------------------------- capture server
+
+SSE = [
+    ("message_start", {"type": "message_start", "message": {
+        "id": "msg_reprex", "type": "message", "role": "assistant", "model": "reprex",
+        "content": [], "stop_reason": None, "stop_sequence": None,
+        "usage": {"input_tokens": 1, "output_tokens": 1}}}),
+    ("content_block_start", {"type": "content_block_start", "index": 0,
+                             "content_block": {"type": "text", "text": ""}}),
+    ("content_block_delta", {"type": "content_block_delta", "index": 0,
+                             "delta": {"type": "text_delta", "text": "OK"}}),
+    ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+    ("message_delta", {"type": "message_delta",
+                       "delta": {"stop_reason": "end_turn", "stop_sequence": None},
+                       "usage": {"output_tokens": 1}}),
+    ("message_stop", {"type": "message_stop"}),
+]
+
+
+def make_server(sink):
+    class H(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, *_a):
+            pass
+
+        def _send(self, payload, ctype):
+            self.send_response(200)
+            self.send_header("content-type", ctype)
+            self.send_header("content-length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_POST(self):
+            n = int(self.headers.get("content-length") or 0)
+            raw = self.rfile.read(n) if n else b""
+            try:
+                # Headers are dropped entirely: nothing here needs them, and they carry the
+                # credential. Only the body is retained, in memory.
+                sink.append(json.loads(raw.decode("utf-8")))
+            except Exception:
+                pass
+            if self.path.rstrip("/").endswith("count_tokens"):
+                return self._send(json.dumps({"input_tokens": 1}).encode(), "application/json")
+            body = b"".join(("event: %s\ndata: %s\n\n" % (k, json.dumps(v))).encode()
+                            for k, v in SSE)
+            self._send(body, "text/event-stream")
+
+        def do_GET(self):
+            self._send(b"{}", "application/json")
+
+    return H
+
+
+class Recorder:
+    """A capture server on a free loopback port, as a context manager."""
+
+    def __init__(self):
+        self.bodies = []
+        self.port = None
+        self._srv = None
+        self._t = None
+
+    def __enter__(self):
+        self._srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), make_server(self.bodies))
+        self.port = self._srv.server_address[1]
+        self._t = threading.Thread(target=self._srv.serve_forever, daemon=True)
+        self._t.start()
+        return self
+
+    def __exit__(self, *_e):
+        self._srv.shutdown()
+        self._srv.server_close()
+
+
+# ---------------------------------------------------------------- portability
+
+def find_claude():
+    """Resolve the CLI across platforms.
+
+    On Windows the entry point is usually a `.cmd` shim, which CreateProcess cannot execute
+    directly -- it must be run through the command interpreter. Returns an argv PREFIX."""
+    for name in ("claude", "claude.cmd", "claude.exe", "claude.bat"):
+        found = shutil.which(name)
+        if found:
+            if found.lower().endswith((".cmd", ".bat")):
+                return ["cmd", "/c", found]
+            return [found]
+    return None
+
+
+def projects_dir():
+    return pathlib.Path.home() / ".claude" / "projects"
+
+
+def run_arm(prefix, cwd, port, timeout=180):
+    env = dict(os.environ)
+    env["ANTHROPIC_BASE_URL"] = "http://127.0.0.1:%d" % port
+    try:
+        subprocess.run(prefix + ["-p", "--tools", "", "--strict-mcp-config"],
+                       cwd=str(cwd), input="hi", text=True, env=env,
+                       capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def first_text(body):
+    for m in body.get("messages", []):
+        c = m.get("content")
+        if isinstance(c, str):
+            return c
+        if isinstance(c, list):
+            for part in c:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    return part["text"]
+    return ""
+
+
+# ---------------------------------------------------------------- the run
+
+def do_run(keep):
+    prefix = find_claude()
+    if not prefix:
+        print("FAIL: `claude` is not on PATH.", file=sys.stderr)
+        return 2
+    print("claude: %s   |   %s %s\n" % (" ".join(prefix), platform.system(), platform.machine()))
+
+    # GUARD 1: the system temp dir, never beside this file -- which may sit in a repository.
+    root = pathlib.Path(tempfile.mkdtemp(prefix="memcap_reprex_"))
+    # GUARD 2: refuse outright if we somehow landed inside a repository anyway (TMPDIR can be
+    # pointed anywhere). Memory keyed to the repo root would make every arm read one store.
+    for parent in [root] + list(root.parents):
+        if (parent / ".git").exists():
+            print("FAIL: %s is inside a git repository (%s)." % (root, parent), file=sys.stderr)
+            print("      Memory is keyed to the repository, so all seven arms would share one",
+                  file=sys.stderr)
+            print("      store and none of the fixtures would be read. Set TMPDIR elsewhere.",
+                  file=sys.stderr)
+            return 2
+    print("arms under: %s\n" % root)
+    created, rows, ok = [], [], True
+
+    try:
+        for name, (kind, params) in ARMS.items():
+            arm_dir = root / name
+            arm_dir.mkdir(exist_ok=True)
+            before = set(p.name for p in projects_dir().iterdir()) if projects_dir().exists() else set()
+
+            with Recorder() as rec:
+                run_arm(prefix, arm_dir, rec.port)              # 1: create the store
+                store = None
+                for _ in range(20):
+                    new = (set(p.name for p in projects_dir().iterdir()) - before)
+                    if new:
+                        store = sorted(new)[0]
+                        break
+                    time.sleep(0.25)
+                if store is None:
+                    print("FAIL: no projects entry appeared for %s." % arm_dir, file=sys.stderr)
+                    print("      Refusing to guess the store path.", file=sys.stderr)
+                    return 2
+                created.append(projects_dir() / store)
+
+                text = build_index(kind, params)
+                mem = projects_dir() / store / "memory"
+                mem.mkdir(parents=True, exist_ok=True)
+                # BYTES, never text mode: text mode would rewrite \n as \r\n on Windows and
+                # silently change the unit count of every line arm.
+                (mem / "MEMORY.md").write_bytes(text.encode("utf-8"))
+
+                rec.bodies.clear()
+                run_arm(prefix, arm_dir, rec.port)             # 2: capture with the fixture
+
+                if not rec.bodies:
+                    print("FAIL: %s captured nothing -- the request went somewhere else."
+                          % name, file=sys.stderr)
+                    return 2
+                body = rec.bodies[0]
+
+            raw = first_text(body)
+
+            # GUARD 3: the harness must be reading the store this arm just wrote to. Without
+            # this, reading a DIFFERENT store returns perfectly well-formed numbers for the
+            # wrong file -- which is exactly how the first run of this file failed.
+            hdr = HEADER_RE.search(raw)
+            if hdr and store not in hdr.group(0):
+                print("FAIL: %s read a different store than it wrote." % name, file=sys.stderr)
+                print("      wrote to: %s" % store, file=sys.stderr)
+                print("      harness read: %s" % hdr.group(0).strip(), file=sys.stderr)
+                print("      Are you inside a git repository?", file=sys.stderr)
+                return 2
+            if not hdr:
+                print("FAIL: %s -- no MEMORY.md was injected at all. The fixture was not read."
+                      % name, file=sys.stderr)
+                return 2
+
+            seg = segment(raw)
+            m = NOTICE_RE.search(raw)
+            got = m.group(1) if m else None
+            exp = EXPECTED[name]
+            w = units(seg) if seg is not None else -1
+            ln = seg.count("\n") + 1 if seg else -1
+
+            bad = []
+            if units(text) != exp["disk"]:
+                bad.append("disk %d!=%d" % (units(text), exp["disk"]))
+            if w != exp["wire"]:
+                bad.append("wire %d!=%d" % (w, exp["wire"]))
+            if ln != exp["lines"]:
+                bad.append("lines %d!=%d" % (ln, exp["lines"]))
+            if got != exp["notice"]:
+                bad.append("notice differs")
+            if bad:
+                ok = False
+            rows.append((name, units(text), w, ln, len(body.get("tools") or []), got, bad))
+
+        print("%-11s %7s %7s %6s %6s  %s" % ("arm", "disk", "wire", "lines", "tools", "verdict"))
+        print("-" * 78)
+        for name, d, w, ln, nt, got, bad in rows:
+            print("%-11s %7d %7d %6d %6d  %s"
+                  % (name, d, w, ln, nt, "ok" if not bad else "FAIL: " + "; ".join(bad)))
+            if bad:
+                print("%13sexpected: %r" % ("", EXPECTED[name]["notice"]))
+                print("%13sobserved: %r" % ("", got))
+        print("\nnotices observed:")
+        for name, _d, _w, _l, _t, got, _b in rows:
+            print("  %-11s %s" % (name, got if got else "(none)"))
+        print("\n" + ("ALL SEVEN AS PREDICTED" if ok else
+                      "MISMATCH -- report it; do not adjust EXPECTED to match"))
+        return 0 if ok else 1
+    finally:
+        if keep:
+            print("\n--keep: left %d store(s) and %s" % (len(created), root), file=sys.stderr)
+            print("Remove them yourself: a probe fixture is indistinguishable from a real "
+                  "memory store.", file=sys.stderr)
+        else:
+            kept = []
+            for path in created + [root]:
+                if not path.exists():
+                    continue
+                try:
+                    shutil.rmtree(path)
+                except OSError as exc:
+                    kept.append("%s: %s" % (path, exc))
+            if kept:
+                print("\nCLEANUP INCOMPLETE -- remove these yourself:", file=sys.stderr)
+                for k in kept:
+                    print("  " + k, file=sys.stderr)
+                os._exit(2)
+            print("\ncleanup: complete, nothing kept")
+
+
+# ---------------------------------------------------------------- selftest
+
+def selftest():
+    """Check the instrument without needing `claude`, a network, or any store.
+
+    Everyone can run this, so a null result here is separable from a broken environment."""
+    bad = 0
+
+    for name, (kind, params) in ARMS.items():
+        text = build_index(kind, params)
+        if units(text) != EXPECTED[name]["disk"]:
+            print("FAIL %s: built %d units, expected %d"
+                  % (name, units(text), EXPECTED[name]["disk"]))
+            bad += 1
+
+    if units("\U0001F600") != 2 or len("\U0001F600") != 1:
+        print("FAIL: units() is not counting UTF-16 code units")
+        bad += 1
+
+    # segment() must stop at the last content character, excluding the trailing newline run --
+    # the boundary that produced 24,922 vs 24,924 upstream.
+    raw = ("Contents of /x/memory/MEMORY.md (user's auto-memory):\n\nabc\n\n"
+           "> WARNING: MEMORY.md is 1 lines (limit: 200). done\n")
+    if segment(raw) != "abc":
+        print("FAIL: segment() returned %r, expected 'abc'" % segment(raw))
+        bad += 1
+    if NOTICE_RE.search(raw).group(1) != "MEMORY.md is 1 lines (limit: 200). done":
+        print("FAIL: notice extraction")
+        bad += 1
+    if segment("no header here") is not None:
+        print("FAIL: segment() should return None with no header")
+        bad += 1
+
+    # A notice-presence-only check is not a check. Prove this file's comparison is by payload.
+    exp = EXPECTED["both"]["notice"]
+    if exp == "MEMORY.md is 300 lines (limit: 200)." + TAIL:
+        print("FAIL: the `both` expectation is a single-cap string")
+        bad += 1
+    if (exp is not None) == (("MEMORY.md is 999.9KB - DIFFERENT." + TAIL) is not None) \
+            and exp == "MEMORY.md is 999.9KB - DIFFERENT." + TAIL:
+        print("FAIL: payload comparison is not distinguishing strings")
+        bad += 1
+
+    if find_claude() is None:
+        print("note: `claude` not on PATH -- --selftest still valid, --run will not work")
+
+    print("selftest: %s (%d arms, unit counting, segment boundary, notice payload)"
+          % ("OK" if bad == 0 else "FAILED", len(ARMS)))
+    return 1 if bad else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--run", action="store_true", help="the real probe (needs `claude`)")
+    ap.add_argument("--selftest", action="store_true", help="check the instrument only")
+    ap.add_argument("--keep", action="store_true", help="do NOT clean up (you must)")
+    a = ap.parse_args()
+    if a.selftest:
+        return selftest()
+    if a.run:
+        return do_run(a.keep)
+    ap.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/README.md
+++ b/tools/README.md
@@ -19,6 +19,7 @@ with a `--verify` mode can be re-run by anyone, including the next session.
 |---|---|
 | `capgeom.py` | Geometry and reconstruction arithmetic for auto-memory index cap probes. Holds the arm registry from `tests/results/2026-08-23-memory-cap-truncation-probe/`, derives every published bound from it, and refuses to agree with a figure that no longer follows from its recorded arm |
 | `wirecap.py` | Captures the request body a Claude Code session actually sends, by standing in as `ANTHROPIC_BASE_URL`. Answers locally — nothing is forwarded — and redacts credential headers before anything reaches disk. Use it when the question is "what is in the context?", which a session cannot be asked, because its self-report on that is unsound in both directions |
+| `check-redaction.sh` | Shape-tier deny-list scanner for a **draft about to leave the machine**. Implements the scanner `skills/redact-for-public-disclosure` Step 3 and `skills/enforce-redaction-gate` Step 2 both specify and neither shipped. Guards third-party internals — minified identifier shapes, byte offsets, operator home paths, store slugs, credential shapes — that the skill's category table rates publishable "Never — until vendor-documented" |
 
 ## Running
 
@@ -34,7 +35,25 @@ python3 tools/capgeom.py --span 170 147
 python3 tools/wirecap.py --verify                       # self-test: capture verbatim, redact secrets
 python3 tools/wirecap.py --port 8788 --out over.jsonl   # then point ANTHROPIC_BASE_URL at it
 python3 tools/wirecap.py --diff over.jsonl under.jsonl
+
+bash tools/check-redaction.sh --verify        # seed each shape, assert the gate catches it
+bash tools/check-redaction.sh --labels        # what is checked, without the patterns
+bash tools/check-redaction.sh DRAFT.md        # exit 0 clean / N findings / 2 COULD NOT RUN
 ```
+
+**`check-redaction.sh` exits 2 when it cannot run, and 2 must never be read as a pass.**
+`enforce-redaction-gate` names the trap it is built against: a wrapper shaped
+`scanner && ok || echo CLEAN` treats a *tool error* — a bad flag, an unreadable file — as a clean
+result, so the gate reports success precisely when it has checked nothing. Its `--verify` seeds
+each of its six shapes **individually**, because a gate that catches five and is blind to the
+sixth passes any self-test that seeds only one.
+
+It scans a draft, not the tree, which is why it is here and not in `scripts/` and why no CI job
+runs it — a draft is not a tracked file. It is also **not** `npm run validate:security`: that gate
+guards *our* committed content against leaking *our* credentials outward to people who install the
+skills. This one guards a *third party's* internals on the way out. Neither substitutes for the
+other, and the first real use of this one caught four findings in a probe script already staged
+for a public commit.
 
 **A `--verify` nobody has watched fail is a green light of unknown wiring.** `capgeom.py
 --selftest-negative` is the answer to that for this directory: it mutates a recorded figure in

--- a/tools/check-redaction.sh
+++ b/tools/check-redaction.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# check-redaction.sh -- a shape-tier deny-list scanner for outbound disclosure drafts.
+#
+# WHY THIS EXISTS
+# ---------------
+# `skills/redact-for-public-disclosure` specifies this tool in its Step 3 and
+# `skills/enforce-redaction-gate` specifies its exit-code contract. Neither shipped an
+# implementation: before 2026-08-26 every script those skills named was prose in a markdown
+# file, so the "gate" could not fail anything. This is the implementation, written when the
+# skills were first exercised for real -- an outbound comment on anthropics/claude-code#82056
+# carrying findings about a closed-source CLI harness.
+#
+# WHAT IT GUARDS, AND WHY IT IS NOT THE OTHER SCANNER
+# ---------------------------------------------------
+# `scripts/scan-skill-content.js` (`npm run validate:security`) guards THIS repository's own
+# committed content against leaking OUR credentials and PII outward to people who install our
+# skills. It is a merge gate over our trees.
+#
+# This scans a DRAFT -- a file about to leave the machine -- for THIRD-PARTY internals that
+# `redact-for-public-disclosure` classifies as `live internal`, publishable "Never -- until
+# vendor-documented":
+#
+#     minified identifier names, byte offsets, current-version gate logic, internal codenames
+#
+# The two are complementary and neither substitutes for the other. This one is deliberately
+# NOT wired into CI: it scans drafts, and a draft is not a tracked file.
+#
+# THE EXIT-CODE CONTRACT (from `enforce-redaction-gate`)
+# -----------------------------------------------------
+#     0    clean
+#     N>0  N findings
+#     2    the scanner could not run -- FAIL CLOSED, never read as a pass
+#
+# `enforce-redaction-gate` names the trap this contract exists for: a wrapper of the shape
+# `scanner && ok || echo CLEAN` reads a TOOL ERROR as a pass. Hence exit 2 and hence --verify.
+#
+# LABELS ONLY, NEVER THE PATTERN
+# ------------------------------
+# Findings print the label and the location, never the regex that matched. A deny-list of
+# internal shapes is itself a description of internals.
+#
+# USAGE
+#     tools/check-redaction.sh FILE...      scan
+#     tools/check-redaction.sh --verify     self-test; exit non-zero if the gate cannot fail
+#     tools/check-redaction.sh --labels     list what is checked, without the patterns
+set -uo pipefail
+
+SELF="$(basename "${BASH_SOURCE[0]}")"
+
+# label|regex  -- ERE. Keep each pattern narrow; `redact-for-public-disclosure` Step 8 says
+# narrow a false positive, never suppress it.
+PATTERNS=(
+  # A minified declaration run: a 1-3 char identifier assigned a string or number, twice or
+  # more in sequence. This is the shape of a bundler's `var a="x",b=1,c=2` output.
+  'minified-declaration-run|[A-Za-z_$][A-Za-z0-9_$]{0,2}=("[^"]*"|[0-9]+),[A-Za-z_$][A-Za-z0-9_$]{0,2}=("[^"]*"|[0-9]+)'
+
+  # A minified function definition: `function xy(e,t)` / `function xy(e)`. Real source uses
+  # descriptive names; 1-3 chars plus single-letter params is bundler output.
+  'minified-function-def|function [A-Za-z_$][A-Za-z0-9_$]{0,2}\([a-z](,[a-z](=[^)]*)?)*\)'
+
+  # Provenance the vendor never licensed: "at offset N", `skip=N`, `bs=1 skip=`.
+  'binary-byte-offset|(offset[ =:]+[0-9]{5,}|skip=[0-9]{5,}|dd if=[^ ]*(claude|versions)[^ ]*)'
+
+  # An operator home path or a discovered project-store slug (the #722 precedent: commit
+  # 9048cd7b3 redacted exactly these two shapes from a published RESULT.md).
+  'operator-home-path|/home/[a-z][a-z0-9_.-]*/'
+  'project-store-slug|(\.claude/projects/-|projects/-[a-z][a-z0-9-]*-scratchpad)'
+
+  # Credential shapes, belt and braces -- a draft is the last place these can be caught.
+  'credential-shape|(gh[pousr]_[A-Za-z0-9]{16,}|sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----)'
+)
+
+list_labels() {
+  printf 'checked shapes (patterns deliberately not shown):\n'
+  local entry
+  for entry in "${PATTERNS[@]}"; do
+    printf '  %s\n' "${entry%%|*}"
+  done
+}
+
+# scan_file FILE -> prints findings, echoes the count on the last line
+scan_file() {
+  local file="$1" count=0 entry label pat hits
+  for entry in "${PATTERNS[@]}"; do
+    label="${entry%%|*}"
+    pat="${entry#*|}"
+    # -a: a draft may contain odd bytes and must still be scanned, not skipped as binary.
+    hits="$(grep -aEn -- "$pat" "$file" 2>/dev/null | cut -d: -f1)" || true
+    if [ -n "$hits" ]; then
+      local line
+      while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        printf '  %-26s %s:%s\n' "$label" "$file" "$line"
+        count=$((count + 1))
+      done <<< "$hits"
+    fi
+  done
+  echo "$count"
+}
+
+verify() {
+  local tmp rc out
+  tmp="$(mktemp -d)" || { echo "verify: mktemp failed" >&2; return 2; }
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp'" RETURN
+
+  # 1. A clean draft must exit 0.
+  printf 'The cap is 25,000 UTF-16 code units and the line cap is 200.\n' > "$tmp/clean.md"
+  out="$(scan_all "$tmp/clean.md")"; rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "verify FAIL: clean draft reported $rc finding(s)" >&2
+    echo "$out" >&2
+    return 1
+  fi
+
+  # 2. A seeded canary of EACH shape must be caught. A gate that catches one shape and
+  #    silently misses another is the blind class `enforce-redaction-gate` Step 6 warns of.
+  local seeded=0 missed=0 label
+  for label in minified-declaration-run minified-function-def binary-byte-offset \
+               operator-home-path project-store-slug credential-shape; do
+    case "$label" in
+      minified-declaration-run) printf 'var Q="LABEL.md",zz=200,qq=25000\n' ;;
+      minified-function-def)    printf 'function qz(e,t="index"){return e}\n' ;;
+      binary-byte-offset)       printf 'found at offset 204053570 in the build\n' ;;
+      operator-home-path)       printf 'path was /home/someone/.local/share\n' ;;
+      project-store-slug)       printf 'store .claude/projects/-tmp-probe-arm\n' ;;
+      credential-shape)         printf 'token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ01\n' ;;
+    esac > "$tmp/canary.md"
+    seeded=$((seeded + 1))
+    out="$(scan_all "$tmp/canary.md")"; rc=$?
+    if [ "$rc" -lt 1 ]; then
+      echo "verify FAIL: seeded '$label' was NOT caught -- the gate is blind to it" >&2
+      missed=$((missed + 1))
+      continue
+    fi
+    if ! printf '%s' "$out" | grep -q "$label"; then
+      echo "verify FAIL: '$label' fired but did not report its own label" >&2
+      missed=$((missed + 1))
+    fi
+    # 3. The pattern itself must never be printed.
+    if printf '%s' "$out" | grep -qF '[A-Za-z_$]'; then
+      echo "verify FAIL: the output leaked a regex; labels only" >&2
+      missed=$((missed + 1))
+    fi
+  done
+
+  # 4. An unreadable target must FAIL CLOSED, not report clean.
+  scan_all "$tmp/does-not-exist.md" >/dev/null 2>&1; rc=$?
+  if [ "$rc" -ne 2 ]; then
+    echo "verify FAIL: a missing file exited $rc, expected 2 (fail closed)" >&2
+    missed=$((missed + 1))
+  fi
+
+  if [ "$missed" -ne 0 ]; then
+    echo "check-redaction --verify: FAILED ($missed of $((seeded + 1)) checks)" >&2
+    return 1
+  fi
+  echo "check-redaction --verify: OK ($seeded shapes each seeded and caught; clean exits 0; missing file exits 2; labels only)"
+  return 0
+}
+
+scan_all() {
+  local total=0 file last
+  [ "$#" -eq 0 ] && { echo "no files given" >&2; return 2; }
+  for file in "$@"; do
+    if [ ! -r "$file" ]; then
+      echo "cannot read: $file" >&2
+      return 2                                   # FAIL CLOSED
+    fi
+    # Never scan this script: it necessarily contains every shape it looks for.
+    [ "$(basename "$file")" = "$SELF" ] && continue
+    last="$(scan_file "$file")"
+    # scan_file prints findings then the count; the count is the last line.
+    printf '%s' "$last" | sed '$d'
+    total=$((total + $(printf '%s' "$last" | tail -1)))
+  done
+  return "$total"
+}
+
+main() {
+  case "${1:-}" in
+    --verify) verify; exit $? ;;
+    --labels) list_labels; exit 0 ;;
+    -h|--help|"") sed -n '2,50p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+  esac
+  local out rc
+  out="$(scan_all "$@")"; rc=$?
+  if [ "$rc" -eq 2 ]; then
+    echo "check-redaction: COULD NOT RUN -- this is not a pass" >&2
+    exit 2
+  fi
+  if [ "$rc" -eq 0 ]; then
+    echo "check-redaction: clean ($# file(s))"
+    exit 0
+  fi
+  echo "check-redaction: $rc finding(s) -- classify each with skills/redact-for-public-disclosure Step 1"
+  printf '%s\n' "$out"
+  exit "$rc"
+}
+
+main "$@"

--- a/tools/check-redaction.sh
+++ b/tools/check-redaction.sh
@@ -148,8 +148,8 @@ verify() {
     esac > "$tmp/canary.md"
     seeded=$((seeded + 1))
     out="$(scan_all "$tmp/canary.md")"; rc=$?
-    if [ "$rc" -lt 1 ]; then
-      echo "verify FAIL: seeded '$label' was NOT caught -- the gate is blind to it" >&2
+    if [ "$rc" -ne 1 ]; then
+      echo "verify FAIL: seeded '$label' gave exit $rc, expected 1 (findings found)" >&2
       missed=$((missed + 1))
       continue
     fi
@@ -171,6 +171,30 @@ verify() {
     missed=$((missed + 1))
   fi
 
+  # 5. The finding COUNT must not reach the exit status. Regression for the 2026-08-26 defect:
+  #    while the count was the exit code, 2 findings rendered as COULD NOT RUN with both
+  #    swallowed, and 256 findings exited 0 and printed "clean" -- a gate certifying a
+  #    maximally-leaky draft. 255 and 256 straddle the byte wrap; 2 is the reserved collision.
+  local n
+  for n in 2 255 256; do
+    : > "$tmp/many.md"
+    local i=0
+    while [ "$i" -lt "$n" ]; do
+      printf 'lineCount is what `_n` computes\n' >> "$tmp/many.md"
+      i=$((i + 1))
+    done
+    out="$(scan_all "$tmp/many.md")"; rc=$?
+    if [ "$rc" -ne 1 ]; then
+      echo "verify FAIL: $n findings exited $rc, expected 1 -- the count is reaching the exit status" >&2
+      missed=$((missed + 1))
+      continue
+    fi
+    if [ "$(printf '%s\n' "$out" | grep -c '[^[:space:]]')" -ne "$n" ]; then
+      echo "verify FAIL: $n findings seeded but a different number was reported" >&2
+      missed=$((missed + 1))
+    fi
+  done
+
   if [ "$missed" -ne 0 ]; then
     echo "check-redaction --verify: FAILED ($missed of $((seeded + 1)) checks)" >&2
     return 1
@@ -179,9 +203,19 @@ verify() {
   return 0
 }
 
+# Returns 0 clean / 1 findings found / 2 could not run. The COUNT is carried in the printed
+# findings, one per line, NOT in the exit status.
+#
+# The skills specify "exit code = leak count" and that specification is unsound, because a
+# process exit status is a byte. Measured on this implementation before the contract was
+# changed: a draft with exactly TWO findings exited 2 and rendered as "COULD NOT RUN" with both
+# findings swallowed, and a draft with 256 findings exited 0 and printed "clean". The second is
+# the worst outcome a redaction gate has: it certifies a maximally-leaky draft. Reserving 2 for
+# could-not-run and 1 for any-findings is the only assignment that keeps both signals readable.
 scan_all() {
-  local total=0 file last
+  local file last
   [ "$#" -eq 0 ] && { echo "no files given" >&2; return 2; }
+  local total=0
   for file in "$@"; do
     if [ ! -r "$file" ]; then
       echo "cannot read: $file" >&2
@@ -194,7 +228,8 @@ scan_all() {
     printf '%s' "$last" | sed '$d'
     total=$((total + $(printf '%s' "$last" | tail -1)))
   done
-  return "$total"
+  [ "$total" -gt 0 ] && return 1
+  return 0
 }
 
 main() {
@@ -203,7 +238,7 @@ main() {
     --labels) list_labels; exit 0 ;;
     -h|--help|"") sed -n '2,50p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
   esac
-  local out rc
+  local out rc count
   out="$(scan_all "$@")"; rc=$?
   if [ "$rc" -eq 2 ]; then
     echo "check-redaction: COULD NOT RUN -- this is not a pass" >&2
@@ -213,9 +248,11 @@ main() {
     echo "check-redaction: clean ($# file(s))"
     exit 0
   fi
-  echo "check-redaction: $rc finding(s) -- classify each with skills/redact-for-public-disclosure Step 1"
+  # The count is derived from the printed findings, never from the exit status.
+  count="$(printf '%s\n' "$out" | grep -c '[^[:space:]]')"
+  echo "check-redaction: $count finding(s) -- classify each with skills/redact-for-public-disclosure Step 1"
   printf '%s\n' "$out"
-  exit "$rc"
+  exit 1
 }
 
 main "$@"

--- a/tools/check-redaction.sh
+++ b/tools/check-redaction.sh
@@ -25,14 +25,20 @@
 # The two are complementary and neither substitutes for the other. This one is deliberately
 # NOT wired into CI: it scans drafts, and a draft is not a tracked file.
 #
-# THE EXIT-CODE CONTRACT (from `enforce-redaction-gate`)
-# -----------------------------------------------------
+# THE EXIT-CODE CONTRACT
+# ----------------------
 #     0    clean
-#     N>0  N findings
+#     1    findings -- the COUNT is in the printed output, never in the status
 #     2    the scanner could not run -- FAIL CLOSED, never read as a pass
 #
-# `enforce-redaction-gate` names the trap this contract exists for: a wrapper of the shape
+# `enforce-redaction-gate` names the trap the third state exists for: a wrapper of the shape
 # `scanner && ok || echo CLEAN` reads a TOOL ERROR as a pass. Hence exit 2 and hence --verify.
+#
+# This DEVIATES from the skills, which both specify "exit code = leak count". That
+# specification is unsound and was implemented literally here before being measured: an exit
+# status is a byte, so 256 findings exited 0 and printed "clean" -- a redaction gate certifying
+# a maximally-leaky draft -- and 2 findings collided with the reserved could-not-run code and
+# were swallowed unprinted. `--verify` pins all three cases.
 #
 # LABELS ONLY, NEVER THE PATTERN
 # ------------------------------
@@ -85,6 +91,14 @@ PATTERNS=(
   # excluded because this repository's prose is full of legitimate ones -- locale codes (`de`,
   # `es`, `ja`), file types (`md`, `js`, `sh`, `py`). Widen only with a case that motivated it.
   'minified-ident-in-prose|(`[_$][A-Za-z0-9_$]{0,2}`|`[A-Z]`|`[A-Za-z0-9]{1,2}[_$][A-Za-z0-9]{0,1}`)'
+
+  # A template-literal interpolation of a short identifier -- `${r}`, `${at(o)}`. Added
+  # 2026-08-26 (second pass) after a reviewer found `${r} lines and ${at(o)}` quoted verbatim
+  # from the bundle in a probe docstring, which the prose-identifier shape above does not match
+  # because the name sits inside `${...}` rather than between backticks. Two review rounds, two
+  # distinct escapes from the same class: an internal name is not one shape, and a deny-list
+  # reaches it only one spelling at a time.
+  'minified-template-fragment|\$\{[A-Za-z_$][A-Za-z0-9_$]{0,2}(\([A-Za-z0-9_$, ]{0,12}\))?\}'
 )
 
 list_labels() {
@@ -135,7 +149,7 @@ verify() {
   local seeded=0 missed=0 label
   for label in minified-declaration-run minified-function-def binary-byte-offset \
                operator-home-path project-store-slug credential-shape \
-               minified-ident-in-prose; do
+               minified-ident-in-prose minified-template-fragment; do
     case "$label" in
       minified-declaration-run) printf 'var Q="LABEL.md",zz=200,qq=25000\n' ;;
       minified-function-def)    printf 'function qz(e,t="index"){return e}\n' ;;
@@ -145,6 +159,8 @@ verify() {
       credential-shape)         printf 'token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ01\n' ;;
       # The 2026-08-26 case, verbatim in shape: a real internal name described in English.
       minified-ident-in-prose)  printf 'lineCount is what `_n` computes, and `R` counts them\n' ;;
+      # The 2026-08-26 second-pass case, verbatim in shape.
+      minified-template-fragment) printf 'the variant is `${r} lines and ${at(o)}` with no limit\n' ;;
     esac > "$tmp/canary.md"
     seeded=$((seeded + 1))
     out="$(scan_all "$tmp/canary.md")"; rc=$?

--- a/tools/check-redaction.sh
+++ b/tools/check-redaction.sh
@@ -68,6 +68,23 @@ PATTERNS=(
 
   # Credential shapes, belt and braces -- a draft is the last place these can be caught.
   'credential-shape|(gh[pousr]_[A-Za-z0-9]{16,}|sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|-----BEGIN [A-Z ]*PRIVATE KEY-----)'
+
+  # A minified identifier NAMED IN PROSE rather than used as code. Added 2026-08-26 after a
+  # review found `_n` and `R` described in comments in a probe script this scanner had just
+  # reported clean -- the shapes above are all built around code SYNTAX (`x=1,y=2`,
+  # `function ab(e)`), so a true internal name merely discussed in English slips every one.
+  #
+  # This is a gap in `enforce-redaction-gate` Step 3 as specified, not only in this
+  # implementation: its structure-aware tier checks identifiers "in identifier position only,
+  # so a word in a comment does not trip the gate" -- written to suppress coincidental English
+  # words, which is exactly the position a prose-named internal occupies. Neither of the
+  # skill's two tiers is aimed there.
+  #
+  # Narrow deliberately, to shapes prose does not otherwise produce: a leading `_` or `$`, a
+  # lone capital, or an embedded `_`/`$`. Two-letter backticked tokens without those are
+  # excluded because this repository's prose is full of legitimate ones -- locale codes (`de`,
+  # `es`, `ja`), file types (`md`, `js`, `sh`, `py`). Widen only with a case that motivated it.
+  'minified-ident-in-prose|(`[_$][A-Za-z0-9_$]{0,2}`|`[A-Z]`|`[A-Za-z0-9]{1,2}[_$][A-Za-z0-9]{0,1}`)'
 )
 
 list_labels() {
@@ -117,7 +134,8 @@ verify() {
   #    silently misses another is the blind class `enforce-redaction-gate` Step 6 warns of.
   local seeded=0 missed=0 label
   for label in minified-declaration-run minified-function-def binary-byte-offset \
-               operator-home-path project-store-slug credential-shape; do
+               operator-home-path project-store-slug credential-shape \
+               minified-ident-in-prose; do
     case "$label" in
       minified-declaration-run) printf 'var Q="LABEL.md",zz=200,qq=25000\n' ;;
       minified-function-def)    printf 'function qz(e,t="index"){return e}\n' ;;
@@ -125,6 +143,8 @@ verify() {
       operator-home-path)       printf 'path was /home/someone/.local/share\n' ;;
       project-store-slug)       printf 'store .claude/projects/-tmp-probe-arm\n' ;;
       credential-shape)         printf 'token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ01\n' ;;
+      # The 2026-08-26 case, verbatim in shape: a real internal name described in English.
+      minified-ident-in-prose)  printf 'lineCount is what `_n` computes, and `R` counts them\n' ;;
     esac > "$tmp/canary.md"
     seeded=$((seeded + 1))
     out="$(scan_all "$tmp/canary.md")"; rc=$?

--- a/tools/wirecap.py
+++ b/tools/wirecap.py
@@ -34,9 +34,18 @@ USAGE
     python3 tools/wirecap.py --port 8787 --out capture.jsonl     # run the server
     python3 tools/wirecap.py --verify                            # self-test, exit non-zero on failure
 
-    # in another shell
-    ANTHROPIC_BASE_URL=http://127.0.0.1:8787 \
-      printf '%s' 'hello' | claude -p --tools "" --strict-mcp-config
+    # in another shell -- the assignment goes on `claude`, NEVER in front of a pipeline
+    printf '%s' 'hello' | ANTHROPIC_BASE_URL=http://127.0.0.1:8787 \
+      claude -p --tools "" --strict-mcp-config
+
+    # WHY THE ORDER MATTERS. `VARS printf '%s' hi | claude -p ...` applies the assignments to
+    # `printf` ONLY -- they never reach `claude`. The capture then stays empty, the real API
+    # answers, and any fixture written for the run lands in a LIVE memory store. Measured:
+    # `FOO=bar printf x | sh -c 'echo ${FOO:-UNSET}'` prints UNSET. This exact form was
+    # published in this docstring until 2026-08-26 and is the cause of a false finding
+    # upstream, reported as "a nested session ignores the isolation variables" and retracted
+    # the same day (anthropics/claude-code#82056, comment 5424142726). Calling from Python,
+    # pass `env=` to subprocess and the shape cannot occur at all.
 
 Then difference two captures:
 


### PR DESCRIPTION
## Summary

Two things, and the second exists because of the first.

**The measurement.** Seven wire-captured arms pin both auto-memory index caps at their boundary on linux-x64: **25,000 UTF-16 code units** and **200 lines**, both on a strictly-greater-than threshold. `size_exact` and `size_over1` put byte-identical content on the wire and differ by one character on disk — that character is the whole difference between silence and a notice. Two results are new to the corpus: a trailing blank run does not count against the cap, and exceeding *both* caps produces a **third notice variant** naming lines and size together with no `(limit: …)` clause at all.

**The gate.** Preparing the upstream comment meant exercising `skills/redact-for-public-disclosure` and `skills/enforce-redaction-gate` for the first time. Every script they name — `check-redaction.sh`, `enforce-redaction-gate.sh`, `sync-to-public.sh`, `redact-visualization.py`, `public-allowlist.txt`, `REDACTION_POLICY.md` — was prose in a markdown file. The gate could not fail anything because the gate did not exist. `tools/check-redaction.sh` is now a real implementation, and on first use it caught four findings in a probe script already staged for a public commit here.

## What each commit does

| | |
|---|---|
| `c6f1cec10` | implement the scanner both skills specify |
| `eb1534911` | `wirecap.py`'s documented invocation never reached `claude` — assignments before a pipeline apply to the first command, so the capture stays empty, the real API answers, and any fixture lands in a **live** store. This is the cause of a false finding published upstream and retracted the same day |
| `77081eaf0` | the scanner was blind to an internal name described in prose |
| `1fe2e54a1` | the seven-arm boundary run |
| `fed1d94cd` | the finding count *was* the exit status: **2 leaks read as `COULD NOT RUN`** with both swallowed, and **256 leaks exited 0 printing `clean`** |
| `dd75182a9` | apply three independent reviews; ship the reprex |

## Reviews applied

Three reviewers ran against this. Between them: one dead check in the probe, two defects in the scanner, five false or overstated prose claims.

The one worth reading twice: **`--analyze` asserted only whether a notice appeared**, one bit per arm, while the write-up claimed it compared against a declared table. A reviewer killed it with a mutant — every body corrupted to 5 units, the `both` notice swapped for `999.9KB … TOTALLY DIFFERENT NOTICE` — and it printed `OK`, exit 0. Under that check the `both` arm would have passed carrying `300 lines (limit: 200)`, which is exactly the outcome the third-variant finding predicts against. `EXPECTED` now carries the full notice string plus expected wire units and lines; the same mutant fails all seven arms.

Claims withdrawn rather than defended: `isolated CLAUDE_CONFIG_DIR` (the probe sets one variable, and it is not that one); `line_over1` demonstrating the retreat branch (the size cap never binds there); "the counts are taken after trimming" (the arm pins the *threshold's* count only); and the promise of a fixture that would separate the two cuts' order — **no fixture can**, because both cuts keep a maximal whole-line prefix and two such truncations commute for every input.

## The reprex, and the trap it caught in itself

`reprex_memory_cap.py` is the whole run as one file — Python 3.8+, stdlib only, no repo, no network, `--selftest` that needs no `claude`, fail-closed cleanup, and the capture never written to disk. It reproduced all seven arms independently of the original probe.

Its **first** run failed. Its arm directories sat inside this repository, and all seven arms returned an identical 15,222 units over 141 lines — this repository's own `MEMORY.md`, read seven times. Memory is keyed to the **git repository**, not the working directory, so every arm shared one store and no fixture was loaded. Nothing was written there and it was unharmed, but every number was of the wrong file. The original probe escaped this only because its root was under `/tmp` — luck, not design.

Three guards now, and only the third catches it directly: an assertion that the index path the harness reports is the store that arm just wrote to. Reading the wrong store returns perfectly well-formed numbers.

## Acceptance

- [x] `npm test` green
- [x] `tools/check-redaction.sh --verify` — 8 shapes each seeded and caught, clean exits 0, missing file exits 2, labels only
- [x] every public artifact gates clean
- [x] `python3 tools/wirecap.py --verify` still passes after the docstring fix
- [x] reprex `--selftest` and `--run` both green; zero store residue; the real store verified intact
- [x] fixture stores cleaned — projects directory returned to its prior count

Skill defects filed as #751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3HwKHvZszudWPz9Axzatm