### PR TITLE
Record in the tool's own README that its approach is second-best (#751)

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -55,6 +55,21 @@ skills. This one guards a *third party's* internals on the way out. Neither subs
 other, and the first real use of this one caught four findings in a probe script already staged
 for a public commit.
 
+**Know what it is second-best to before you extend it (#751).** A shape-tier deny-list reaches an
+internal name one spelling at a time: this one cleared `_n` described in prose, then — a round
+later, after a shape was added for that — cleared a verbatim bundle span quoted as `${…}`. Same
+class, two escapes. The better question is **provenance over spans**: does this published text
+appear verbatim in the artifact being audited? That needs no list and cannot be escaped by
+respelling. It also needs a measured false-positive rate first, because a shipped binary is full
+of ordinary English.
+
+Two consequences for anyone touching this file. **Widening the identifier shapes to catch more
+minified names is not worth doing** — those rotate every release and carry nothing attributable;
+they are belt-and-braces against a careless paste, not the control. And a provenance tool is not
+automatically safe here either: one that tokenizes before asking provenance never asks about a
+span containing no identifier-shaped token, which is a shape dependency hiding inside a
+provenance design.
+
 **A `--verify` nobody has watched fail is a green light of unknown wiring.** `capgeom.py
 --selftest-negative` is the answer to that for this directory: it mutates a recorded figure in
 memory — never the file on disk, so there is no mutant to strand — and asserts `--verify` exits


### PR DESCRIPTION
## Summary

`tools/check-redaction.sh` described itself as the implementation of the contract `redact-for-public-disclosure` and `enforce-redaction-gate` specify. A peer audit has since shown the whole shape-tier approach is second-best to asking **provenance about spans** — and that correction lived only in #751. The tracker is read by whoever searches; the README by whoever extends.

## What it records

- **A deny-list reaches an internal name one spelling at a time.** This scanner cleared `_n` described in prose, then — a round later, after a shape was added for exactly that — cleared a verbatim bundle span quoted as a `${…}` fragment. Same class, two escapes.
- **Widening the identifier shapes is not worth doing.** Minified names rotate every release and carry nothing attributable; those patterns are belt-and-braces against a careless paste, not the control. The verbatim span is the half with a victim.
- **A provenance design is not automatically safe either.** One that tokenizes before asking provenance never asks about a span containing no identifier-shaped token — a shape dependency hiding inside a provenance tool, measured by the peer against their own scanner.

Also notes that provenance-over-spans needs a measured false-positive rate before it can block: a shipped binary is full of ordinary English, and a naive sweep produces a gate people learn to ignore.

## Acceptance

- [x] Documentation only; no behaviour change
- [x] `tools/check-redaction.sh --verify` unaffected
- [ ] CI green

Follows #752. Corrects the direction set in #751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3HwKHvZszudWPz9Axzatm