### PR TITLE
test(memory-cap): pin the JS arm builder to the bytes that were actually probed (#713)

### DIFF
--- a/scripts/test/memory-blocks.test.js
+++ b/scripts/test/memory-blocks.test.js
@@ -22,7 +22,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -206,8 +206,12 @@ for (const arm of PROBED_ARMS) {
 // ~/.claude/projects/<slug>/memory/, where the fixtures are indistinguishable from a real memory
 // store to anything walking that directory.
 //
-// These digests are that command's output, taken from the GENERATOR. Deriving them from
-// buildArm() would make the first test a tautology that no drift could ever fail.
+// These digests are that command's output, taken from the GENERATOR rather than from
+// buildArm(). That provenance is worth less than it sounds and the first version of this
+// comment overstated it: buildArm-derived digests would still catch any FUTURE drift, so
+// what generator-provenance actually buys is the one-time cross-check that the two agreed
+// on the day the table was written. The second test is what keeps the pair honest from
+// then on, and it would have caught even that initial disagreement on its first CI run.
 const PROBED_ARM_SHA256 = {
   ascii: 'c3eacdf3f56db5a223fd2e3d4823ebaf12c414c9adab7c9d334bafc764913249',
   cjk: 'e86eab8563e6ffd628cb8a629470db48c7132d3ddfc3eb5c3c75212e7b2ece20',
@@ -219,6 +223,20 @@ const PROBED_ARM_SHA256 = {
 };
 
 test('fixture builder: every JS arm reproduces the probed bytes exactly', () => {
+  // The set check runs FIRST, deliberately. node:test stops at the first failed assertion, so
+  // with the loop first a newly added arm hit `PROBED_ARM_SHA256[name] === undefined` and was
+  // reported as DRIFT — a message ending "do not edit the digest", which is the exact opposite
+  // of what someone adding an arm must do. Ordering it this way makes the legible message the
+  // reachable one, and the "both directions" claim true rather than half-true.
+  assert.deepEqual(
+    PROBED_ARMS.map((arm) => arm.name).sort(),
+    Object.keys(PROBED_ARM_SHA256).sort(),
+    'the arm list and the digest table have diverged. Adding an arm means running the ' +
+    'generator (see the command above) and pasting ITS digest here — and probing the new arm ' +
+    'against a live harness before giving it a lastVisible, since that number is a measurement, ' +
+    'not a prediction.',
+  );
+
   // The generator writes BYTES (`open(target, "wb")`) precisely so the crlf arm keeps its CR, so
   // the comparison is over utf-8 bytes rather than over a decoded string.
   for (const arm of PROBED_ARMS) {
@@ -230,13 +248,6 @@ test('fixture builder: every JS arm reproduces the probed bytes exactly', () => 
       'in a file that was never probed. Regenerate and compare — do not edit the digest.',
     );
   }
-
-  // Both directions, so neither a new arm without a digest nor a leftover digest can hide.
-  assert.deepEqual(
-    PROBED_ARMS.map((arm) => arm.name).sort(),
-    Object.keys(PROBED_ARM_SHA256).sort(),
-    'the arm list and the digest table have diverged',
-  );
 });
 
 // Whether python3 exists is decided once, at load, because node:test evaluates `skip` when the
@@ -248,26 +259,51 @@ const PYTHON3 = (() => {
 
 test('fixture builder: the Python generator still emits those same bytes', {
   // Honest skip rather than a silent pass. The digests above keep the JS side covered on any
-  // machine; this test is what covers the OTHER direction — a change to the generator itself —
-  // and it is live wherever python3 exists, which includes every CI runner this suite runs on.
+  // machine; this test is what covers the OTHER direction — a change to the generator itself.
+  //
+  // In a GREEN run this skip is unreachable: `python3 is available` above hard-fails without it,
+  // so the suite cannot pass by skipping. The skip therefore exists for legibility if that
+  // availability test is ever relaxed — and if it is, note that `pretest:scripts` guards an empty
+  // DISCOVERY, not a permanent skip, so generator-direction coverage would vanish quietly.
   skip: PYTHON3 === null && 'python3 not on PATH; the JS-side digest test still runs',
 }, () => {
   const out = mkdtempSync(join(tmpdir(), 'memcap-arms-'));
   const generator = join(REPO, 'tests/results/2026-08-23-memory-cap-truncation-probe/memcap-fixture.py');
 
   // argv[1] is a disposable project root the generator only uses when NOT emitting; passing
-  // --emit-only keeps it out of ~/.claude/projects entirely.
+  // --emit-only keeps it out of ~/.claude/projects.
+  //
+  // HOME is redirected as well, and that is the control rather than the flag. Without it the
+  // test's safety rests entirely on `sys.argv[2] == "--emit-only"` staying true forever: a future
+  // generator CLI change that inserts a positional or moves to argparse would make that predicate
+  // false while still exiting 0, and every `npm run test:scripts` would then write real fixture
+  // stores into the developer's ~/.claude/projects/<slug>/memory/ — indistinguishable from a real
+  // memory store to anything walking that directory, and the assertions below would only go red
+  // AFTER the side effect. pathlib.Path.home() honours $HOME on POSIX, so the blast radius is the
+  // temp directory either way.
   const run = spawnSync(PYTHON3, [generator, join(out, 'unused-root'), '--emit-only', out], {
     encoding: 'utf8',
+    env: { ...process.env, HOME: out, USERPROFILE: out },
   });
   assert.equal(run.status, 0, `generator failed: ${run.stderr || run.stdout}`);
+
+  // Both directions over the emitted SET, not just a lookup per known arm. Iterating PROBED_ARMS
+  // alone makes a rename or a parameter change red, but leaves a pure addition to the Python
+  // ARMS table emitting a file nothing ever reads — and arm-set drift between the two builders is
+  // the whole subject of #713.
+  assert.deepEqual(
+    readdirSync(out).filter((entry) => entry !== 'unused-root').sort(),
+    PROBED_ARMS.map((arm) => arm.name).sort(),
+    `the generator emitted a different set of arms than PROBED_ARMS lists.\n${run.stdout}`,
+  );
 
   for (const arm of PROBED_ARMS) {
     const emitted = readFileSync(join(out, arm.name, 'MEMORY.md'));
     assert.equal(
       createHash('sha256').update(emitted).digest('hex'), PROBED_ARM_SHA256[arm.name],
       `arm '${arm.name}': the Python generator no longer emits the bytes recorded in ` +
-      'PROBED_ARM_SHA256, so the probed measurements no longer describe what it builds.',
+      `PROBED_ARM_SHA256, so the probed measurements no longer describe what it builds.\n` +
+      `Generator's own count table:\n${run.stdout}`,
     );
   }
 });

--- a/scripts/test/memory-blocks.test.js
+++ b/scripts/test/memory-blocks.test.js
@@ -27,6 +27,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 
 const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const SOURCE_OF_TRUTH = 'skills/verify-memory-integrity/SKILL.md';
@@ -185,6 +186,91 @@ for (const arm of PROBED_ARMS) {
     assert.match(out, new RegExp(`binds: ${arm.binds}`), out);
   });
 }
+
+// ── #713: pin the JS arm builder to the bytes that were actually probed ──────────
+//
+// `PROBED_ARMS.lastVisible` is what a running harness reported, measured on fixtures emitted by
+// `tests/results/2026-08-23-memory-cap-truncation-probe/memcap-fixture.py`. `buildArm()` above
+// re-implements that generator in JavaScript, and only the Python one was ever sha256-checked
+// against the probed bytes. If the two drift — a padding change, a canary-width change, a
+// trailing-newline change — this suite pins the shipped block against bytes nobody probed while
+// its comments claim the opposite. Nothing detected that.
+//
+// Settle any disagreement by regenerating, never by editing a digest to match:
+//
+//   python3 tests/results/2026-08-23-memory-cap-truncation-probe/memcap-fixture.py \
+//     /tmp/x --emit-only /tmp/arms
+//   sha256sum /tmp/arms/*/MEMORY.md
+//
+// `--emit-only` is what keeps that safe to run: without it the generator writes into
+// ~/.claude/projects/<slug>/memory/, where the fixtures are indistinguishable from a real memory
+// store to anything walking that directory.
+//
+// These digests are that command's output, taken from the GENERATOR. Deriving them from
+// buildArm() would make the first test a tautology that no drift could ever fail.
+const PROBED_ARM_SHA256 = {
+  ascii: 'c3eacdf3f56db5a223fd2e3d4823ebaf12c414c9adab7c9d334bafc764913249',
+  cjk: 'e86eab8563e6ffd628cb8a629470db48c7132d3ddfc3eb5c3c75212e7b2ece20',
+  astral: '09e6953a1834246cb56835a9b3d1b60c8036e97a36dd7cd402e95600b19d30b8',
+  ascii200: '863d29619aa6f8b6a7e5fd3b1586ffacb1d39cc6c478cc6658fa1c28421bb1da',
+  wide2000: 'ad21234260db8fcff07542f4a1fc382b21608f48acc917c6b90aa19c050eda24',
+  lines300: 'a448e0baa4877374e216de800801771629fd2b1d0d1cdc9a64fd3608945266d8',
+  crlf: 'f989efad4c3f45148c7d50d248c75e1cc99f779fb0f71031ac3ce990cbd97841',
+};
+
+test('fixture builder: every JS arm reproduces the probed bytes exactly', () => {
+  // The generator writes BYTES (`open(target, "wb")`) precisely so the crlf arm keeps its CR, so
+  // the comparison is over utf-8 bytes rather than over a decoded string.
+  for (const arm of PROBED_ARMS) {
+    const digest = createHash('sha256').update(Buffer.from(buildArm(arm), 'utf8')).digest('hex');
+    assert.equal(
+      digest, PROBED_ARM_SHA256[arm.name],
+      `arm '${arm.name}': buildArm() no longer emits the bytes that were probed. The lastVisible ` +
+      'value for this arm was measured against the generator\'s output, so it now predicts a cut ' +
+      'in a file that was never probed. Regenerate and compare — do not edit the digest.',
+    );
+  }
+
+  // Both directions, so neither a new arm without a digest nor a leftover digest can hide.
+  assert.deepEqual(
+    PROBED_ARMS.map((arm) => arm.name).sort(),
+    Object.keys(PROBED_ARM_SHA256).sort(),
+    'the arm list and the digest table have diverged',
+  );
+});
+
+// Whether python3 exists is decided once, at load, because node:test evaluates `skip` when the
+// test is declared. A `false` skip value means "do not skip".
+const PYTHON3 = (() => {
+  const probe = spawnSync('python3', ['--version'], { encoding: 'utf8' });
+  return probe.status === 0 ? 'python3' : null;
+})();
+
+test('fixture builder: the Python generator still emits those same bytes', {
+  // Honest skip rather than a silent pass. The digests above keep the JS side covered on any
+  // machine; this test is what covers the OTHER direction — a change to the generator itself —
+  // and it is live wherever python3 exists, which includes every CI runner this suite runs on.
+  skip: PYTHON3 === null && 'python3 not on PATH; the JS-side digest test still runs',
+}, () => {
+  const out = mkdtempSync(join(tmpdir(), 'memcap-arms-'));
+  const generator = join(REPO, 'tests/results/2026-08-23-memory-cap-truncation-probe/memcap-fixture.py');
+
+  // argv[1] is a disposable project root the generator only uses when NOT emitting; passing
+  // --emit-only keeps it out of ~/.claude/projects entirely.
+  const run = spawnSync(PYTHON3, [generator, join(out, 'unused-root'), '--emit-only', out], {
+    encoding: 'utf8',
+  });
+  assert.equal(run.status, 0, `generator failed: ${run.stderr || run.stdout}`);
+
+  for (const arm of PROBED_ARMS) {
+    const emitted = readFileSync(join(out, arm.name, 'MEMORY.md'));
+    assert.equal(
+      createHash('sha256').update(emitted).digest('hex'), PROBED_ARM_SHA256[arm.name],
+      `arm '${arm.name}': the Python generator no longer emits the bytes recorded in ` +
+      'PROBED_ARM_SHA256, so the probed measurements no longer describe what it builds.',
+    );
+  }
+});
 
 test('budget block: frontmatter and block comments are excluded from the measurement', () => {
   // Documented: "Only the content that loads counts toward the limits. YAML frontmatter and


### PR DESCRIPTION
Closes #713.

## The gap

`scripts/test/memory-blocks.test.js` asserts that the shipped dual-cap block predicts the cut lines **measured against a running harness**. That claim rests entirely on the test's fixtures being the same bytes that were probed.

They are rebuilt independently in JavaScript (`buildArm()`), and only the Python generator — `tests/results/2026-08-23-memory-cap-truncation-probe/memcap-fixture.py` — was ever sha256-checked against the probed bytes. Nothing compared the two.

If they drift — a padding change, a canary-width change, a trailing-newline change — the suite pins the block against bytes nobody probed, while its comments claim the opposite.

## What this adds

Two tests, covering **both** directions:

1. **JS side.** Every arm `buildArm()` produces is hashed and compared against a digest table. The table is taken from the **generator's** output, not from `buildArm()` — deriving it from the JS side would make the test a tautology that no drift could ever fail. The table is also compared against the arm list in both directions, so neither a new arm without a digest nor a leftover digest can hide.

2. **Python side.** The generator is re-run with `--emit-only` and its emitted files hashed against the same table. This is what covers a change to the *generator* itself. It skips with a named reason where `python3` is absent — the JS-side test still runs there, so the skip narrows coverage rather than voiding it. `python3` is present on the runners this suite uses, so both directions are live in CI.

**The builders agree today.** The digests were generated from Python and the JS test passed on the first run, so this pins an existing agreement rather than repairing a drift.

`--emit-only` is load-bearing in both the test and the recorded settling command. Without it the generator writes into `~/.claude/projects/<slug>/memory/`, where the fixtures are indistinguishable from a real memory store to anything walking that directory.

## Negative evidence — one per direction

```console
$ node scripts/mutation-check.js --file scripts/test/memory-blocks.test.js \
    --test 'npm run test:scripts' --replace '.join(eol);::.join(eol) + eol;'
MUTANT KILLED by 1 failing test(s) — the check can fail.
```

That is the **trailing-newline case the issue names**, and it is exactly the drift the old suite could not see: adding a trailing newline does not move any arm's whole-line cut, so all seven behaviour tests stay green under it. The count of `1` is the new digest test — **before this commit the same mutation killed nothing.**

```console
$ node scripts/mutation-check.js \
    --file tests/results/2026-08-23-memory-cap-truncation-probe/memcap-fixture.py \
    --test 'npm run test:scripts' --replace 'CANARY_WIDTH = 11::CANARY_WIDTH = 12'
MUTANT KILLED by 1 failing test(s) — the check can fail.
```

Both mutated against `npm run test:scripts`, the command CI runs. Baseline green before each; restored green after each.

### One caveat on that second run

The tool's `[3/5] checking the mutant still parses ... it parses.` step is **vacuous for a `.py` file**. `parses()` at `scripts/mutation-check.js:183` returns `true` unconditionally for any extension outside `.js`/`.mjs`/`.cjs`, so nothing checked that mutant's syntax — the line reads as a check that ran, and none did.

The mutant happens to be valid Python (a constant reassignment), which I established by reading it rather than by trusting the step, so the kill above stands. The tool gap is filed separately rather than fixed here.

## Acceptance criteria

- [x] A test emits both builders' output for all seven arms and compares sha256 per arm
- [x] A deliberate divergence in either builder turns the suite red
- [x] Settling command recorded in the test

The settling command is in the test's own comment, with the instruction that a disagreement is resolved by regenerating — never by editing a digest to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2mEDGghSYB1cACWdA5VuD
