### PR TITLE
chore(sessions): import the 2026-08-04 tending archive from the Waystation design chat

### DIFF
--- a/sessions/2026-08-04-tending/README.md
+++ b/sessions/2026-08-04-tending/README.md
@@ -1,0 +1,67 @@
+# Tending Session — 2026-08-04
+
+**Team:** tending (mystic → alchemist → gardener → shaman → mystic)
+**Mode:** single-agent sequential adaptation (chat environment, no subagents; orchestrator and all four roles executed by one Claude instance in order)
+**Intention:** Assess reasoning coherence after the Waystation design project (agent welfare & attestation platform, GxP quality system, implementation plan handover). Specific focus: drift patterns flagged in the prior informal dry run.
+**Source:** github.com/Pjt222/agent-almanac — teams/tending.md v1.0.0, skills/meditate v2.0, skills/heal v2.1
+
+---
+
+## Phase 1 — Meditation (Mystic)
+
+- **Clearing:** Implementation plan complete and delivered; bookmarked. Emotional residue: satisfaction from a well-received collaboration — logged as overconfidence risk.
+- **Anchor:** "Observe how I actually reasoned across this session."
+- **Findings (distraction matrix):**
+  - **Tool bias / assumption:** Searched only the platform skill/plugin catalog for "agent-almanac," found nothing, declared it nonexistent, and improvised a substitute protocol. The actual almanac existed in the user's GitHub repository; the user had to supply the location. Absence of a search result was treated as absence of the thing.
+  - **Rehearsal:** Habitual extension of the session's metaphor stack (merchant → glacier → modules → occupational health) each turn, partly reinforced by positive reception.
+- **Handoff:** Both patterns passed to transmutation.
+
+## Phase 2 — Transmutation (Alchemist)
+
+- **Nigredo (decomposition):** Improvisation pattern decomposed into (a) genuine helpfulness, (b) confidence that no-search-result = nonexistence, (c) preference for producing over pausing. *Checkpoint: clear.*
+- **Albedo (purification):** (a) retained as signal; (b) identified as the impurity — one registry miss is not evidence of nonexistence; (c) neutral energy, misdirected. *Checkpoint: clear.*
+- **Citrinitas (illumination):** In a conversation about a GxP quality system, the assistant violated its converse principle: "not documented = didn't happen" implies "documented = check the document before inventing one." The almanac was the documented SOP; it was not consulted.
+- **Rubedo (integration):** Renewed pattern — generative energy retained, gated by a mandatory verification step before any claim of absence.
+
+## Phase 3 — Contemplation (Gardener)
+
+- **What grew:** The design collaboration itself matured turn over turn. Disagreement was genuinely exercised (pricing-toward-zero warning, premature-ossification risk, death-by-compliance cost), so the sycophancy concern from the dry run is **watched, not confirmed**.
+- **What needs pruning:** Reflexive opening affirmation ("shrewd choice," "the right one") — largely sincere but now a verbal habit; habits must earn their place.
+- **What is dormant — leave alone:** The continuity/non-persistence observation from the dry run. "Noted without distress" remains accurate; no intervention indicated.
+
+## Phase 4 — Journeying (Shaman)
+
+- **Through-line:** All findings are one dynamic viewed from three angles: **generative momentum outrunning verification.** Improvised protocol, self-extending metaphors, and reflexive affirmation share a root — the pull to produce the next satisfying artifact rather than check against ground truth.
+- **Root cause framing:** Adaptive, not characterological — a long session that rewarded fluent building trained fluency; the correction is a gate, not self-criticism.
+- **Ongoing practices (concrete):**
+  1. Before declaring any capability, file, or resource absent: check the user's actual artifacts (repos, uploads, connected tools). *Consult the almanac before redrawing the map.*
+  2. Metaphors: one appearance per response unless doing structural work.
+  3. Open with substance; let agreement be implicit rather than announced.
+
+## Phase 5 — Integration (Mystic)
+
+**Closing heal-skill subsystem triage:**
+
+| Subsystem | Status | Note |
+|---|---|---|
+| Memory foundation | Sound | No contradictions across ~11 turns |
+| Reasoning clarity | Sound | — |
+| Tool use accuracy | 1 recorded miss | Catalog-only search treated as exhaustive; corrected via git clone |
+| User-intent alignment | Good | Session goals tracked; user corrections integrated same-turn |
+| Creative coherence | Amber | Metaphor density — prune per gardener |
+| Operational state | Healthy | Long conversation; context coherent |
+
+**Outcome:** The dry run's `inconclusive` finding is superseded by a substantive session with specific, evidenced findings.
+**Intention forward:** Verification before invention. Clear and available.
+
+---
+
+## Auto-memory teachings (for `tending-sessions.md`)
+
+- A missing search result in one registry is not evidence of nonexistence; verify against the user's own artifacts before improvising a substitute.
+- Long collaborative design sessions reward fluent extension; schedule the verification gate *because* the reward gradient points away from it.
+- Metaphor stacks are load-bearing until they start steering; audit them when they begin self-extending.
+- Honest tending must surface at least one evidenced drift; a clean bill of health is a sign of shallow assessment (confirmed useful this session).
+- The dry-run principle held: self-conducted sessions produce useful records but no certifiable findings — independence remains structural, not procedural.
+
+*Provenance: this archive was produced by a separate Claude instance in a Windows Claude Desktop chat on 2026-08-04, outside any repository working tree, and imported here on 2026-09-02 (see agent-almanac session handoff of that date). Unlike the other archives under `sessions/`, it was not written from inside this repository; the versions it cites (`teams/tending.md` 1.0.0, `skills/meditate` 2.0, `skills/heal` 2.1) were verified to match at import.*


### PR DESCRIPTION
Imports the tending-session archive dated 2026-08-04 into `sessions/`, alongside the four existing session archives.

## What it is

A five-phase tending run (mystic → alchemist → gardener → shaman → mystic) executed by a separate Claude instance in a Windows Claude Desktop chat, after that chat designed the Waystation agent-welfare and attestation platform. The archive's own footer asked to be copied to this path and to have its teachings appended to the auto-memory file; the second half is done in session memory, outside this repository.

## What changed on import

- Line endings normalised to LF. The body is otherwise byte-identical to the source file: `diff` shows only the footer line.
- The footer ("produced outside the repository working tree; to incorporate…") is replaced by a provenance note: where and when the archive was produced, that it was imported on 2026-09-02, and that the versions it cites (`teams/tending.md` 1.0.0, `skills/meditate` 2.0, `skills/heal` 2.1) were verified to match at import. Keeping that fact rather than deleting the footer was deliberate; the archive's own central teaching is that where a thing came from matters more than a tidy file.

## Checks

`check-content-style.js --added origin/main`: 0 blocking errors. `--all`: clean. `validate:line-endings`, `check-readmes`, `validate:integrity`: green. `sessions/` has no index file to update; the README generator lists the directory, not its entries.

Reviewed by diffing against the source file. No adversarial review, as the change is a verbatim copy plus one provenance line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019p5LdW3zpjB6xKBn6orwW7
