### PR TITLE
test(integrity): assert the pinned A7c examples cover every prefix

### DIFF
--- a/scripts/test/skill-path-refs.test.js
+++ b/scripts/test/skill-path-refs.test.js
@@ -18,7 +18,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
-import { ALLOWLIST, checkSkill, extractRefs, isFileUnder, listSkills, main } from '../check-skill-path-refs.js';
+import { ALLOWLIST, PATH_PREFIXES, checkSkill, extractRefs, isFileUnder, listSkills, main } from '../check-skill-path-refs.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const SCRIPT = join(ROOT, 'scripts', 'check-skill-path-refs.js');
@@ -110,12 +110,33 @@ test('the corpus is clean, and three named skills extract exactly the sets they 
     extracted[id] = extractRefs(text).map((r) => r.path);
     assert.deepEqual(checkSkill({ id, text, exists: existsInRepo }), [], id);
   }
-  // Exact sets for three skills the predicate must keep seeing; a threshold over the whole
-  // corpus could lose half of it and stay green (review finding 6).
-  assert.deepEqual(extracted['write-continue-here'], ['workflows/verify-handoff.mjs']);
-  assert.deepEqual(extracted['coordinate-peer-sessions'], ['scripts/repo-guard.js']);
-  assert.deepEqual([...new Set(extracted['redact-for-public-disclosure'])].sort(),
-    ['tools/check-redaction.sh', 'tools/public-allowlist.txt', 'tools/sync-to-public.sh']);
+  // Exact sets for three named skills, plus a FLOOR on the corpus total — deliberately not an
+  // exact total. A total pinned over a whole tree is a specification of today's corpus and
+  // reddens on an author who edits any skill; the question "what does the predicate accept" is
+  // answered deterministically by the token tests above, against constructed input. The floor
+  // is a backstop for the fuzzier question of mass loss, and a floor is the right shape for it.
+  //
+  // What makes the slack between the floor and the real total safe is that these three skills
+  // cover ONE reference under EACH of the three prefixes, so an entire prefix falling out of
+  // the predicate cannot hide in it. That property is asserted below rather than left to the
+  // choice of examples, because a later author swapping one example for another could drop the
+  // coverage to two prefixes and leave every assertion here green.
+  const PINNED = {
+    'write-continue-here': ['workflows/verify-handoff.mjs'],
+    'coordinate-peer-sessions': ['scripts/repo-guard.js'],
+    'redact-for-public-disclosure': [
+      'tools/check-redaction.sh', 'tools/public-allowlist.txt', 'tools/sync-to-public.sh',
+    ],
+  };
+  for (const [id, expected] of Object.entries(PINNED)) {
+    assert.deepEqual([...new Set(extracted[id])].sort(), expected, id);
+  }
+  const coveredPrefixes = new Set(
+    Object.values(PINNED).flat().map((path) => path.slice(0, path.indexOf('/'))),
+  );
+  assert.deepEqual([...coveredPrefixes].sort(), [...PATH_PREFIXES].sort(),
+    'the pinned examples must cover every prefix the predicate accepts, or a whole prefix could be dropped silently');
+
   const total = Object.values(extracted).reduce((n, refs) => n + refs.length, 0);
   assert.ok(total >= 20, `expected a real population of references, saw ${total}`);
 });


### PR DESCRIPTION
A7c's corpus test pins three named skills exactly and puts a **floor** on the corpus total rather than an exact count. That shape is deliberate, and this PR keeps it: an exact total is a specification of today's corpus and would redden on an author who edits any skill, while "what does the predicate accept" is already answered deterministically by the token tests against constructed input. The floor is a backstop for mass loss, and a floor is the right shape for a fuzzy backstop.

What made the slack between the floor and the real total safe was **unstated and accidental**: the three chosen skills happen to cover one reference under each of the three prefixes — `workflows/` in `write-continue-here`, `scripts/` in `coordinate-peer-sessions`, `tools/` in `redact-for-public-disclosure` — so an entire prefix falling out of the predicate could not hide in the slack. Nothing said so. A later author swapping one example for another could have dropped the coverage to two prefixes with every assertion still green.

The property is now **derived from the pinned sets** and compared against the module's own `PATH_PREFIXES`, so the examples cannot silently narrow.

## Proven

Replacing the `tools/` example with a second `workflows/` one:

```
ℹ pass 9
ℹ fail 1
  the pinned examples must cover every prefix the predicate accepts, or a whole
  prefix could be dropped silently
```

Restoring it: `pass 10, fail 0`.

## Provenance

Raised by the adversarial reviewer of #784 after that PR merged — it was the one change it would still make. It suggested a comment; an assertion is the durable form, since a comment cannot fail. Related: #785, which tracks A7c's remaining scope (the ten i18n mirrors and every prefix but these three).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQmckPNYHQjSkFzFLYhMjd
