### PR TITLE
chore(gitignore): cover CONTINUE_HERE.draft.md, not only the installed file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,12 @@ Thumbs.db
 *.bak
 *.backup
 
-# Local continuation markers
-CONTINUE_HERE.md
+# Local continuation markers.
+# The glob, not the bare name: `write-continue-here` 1.1 drafts to CONTINUE_HERE.draft.md and
+# renames it only after the verification round, so the bare name left every draft
+# untracked-but-visible — and a draft is the one edition most likely to be swept into an
+# unrelated commit by a `git add -A`.
+CONTINUE_HERE*.md
 
 # Campfire state (local, not shared)
 .agent-almanac/


### PR DESCRIPTION
`write-continue-here` 1.1 drafts to `CONTINUE_HERE.draft.md` and renames it to `CONTINUE_HERE.md` only after the adversarial verification round. The ignore rule named the installed file exactly, so **every draft was untracked-but-visible for the length of a verification round** — and a draft is the edition most likely to be swept into an unrelated commit by a `git add -A`, which is how a peer session's dream reached a PR once already.

Measured both ways:

```
$ git check-ignore -v CONTINUE_HERE.draft.md          # before
(no match)

$ git check-ignore -v CONTINUE_HERE.draft.md          # after
.gitignore:26:CONTINUE_HERE*.md	CONTINUE_HERE.draft.md
$ git check-ignore -v CONTINUE_HERE.md
.gitignore:26:CONTINUE_HERE*.md	CONTINUE_HERE.md
```

Carried as Next Step 7 of the 2026-09-02 handoff, which recorded it as deferred "to avoid a review round for one line". Taken now because this session is about to create the exact file the rule failed to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQmckPNYHQjSkFzFLYhMjd
