### PR TITLE
fix(test-x402-payment-client): post-merge audit — fences that had never been run

### DIFF
--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -78,10 +78,14 @@ set -o pipefail   # a 402 carrying NO payment-required header makes grep fail wh
                   # last stage. That is the silent break named below. The assertion catches it
                   # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
+# the status line is the first half of what Expected demands, and nothing else reads it
+head -1 challenge.txt | grep -q ' 402' || { echo "not a 402: $(head -1 challenge.txt)"; exit 1; }
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
-jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+# assert the rest of it: a non-empty file is not enough, `null` is a non-empty file, and an
+# entry missing one of the six fields is not one the signing step can use
+jq -e '.x402Version == 2 and ([.accepts[] | select(.scheme and .network and .asset and .amount
+       and .payTo and .maxTimeoutSeconds)] | length) > 0' terms.json > /dev/null \
   || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
@@ -98,10 +102,12 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero in every failure case, including the two a bare emptiness
-check would pass: a header that decodes to `null`, and one that decodes to valid
-JSON carrying no `accepts` entries.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. Every
+clause of that sentence is asserted by the block, which is the point: the status
+line, the decode, the version, and an entry carrying all six fields. It exits
+non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
+`accepts` entries, and on one whose only entry is missing a field the signing
+step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -182,10 +188,12 @@ set -o pipefail
 # Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
 # `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
 # empty PAYMENT-SIGNATURE and read back as a settlement failure.
-[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
+jq -e '.x402Version == 2 and .accepted != null and .payload != null' payload.json > /dev/null 2>&1 \
+  || { echo 'payload.json is not a PaymentPayload: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+head -1 headers.txt | grep -q ' 200' || { echo "not a 200: $(head -1 headers.txt)"; exit 1; }
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
 # assert the settlement before believing it: an absent header, a `null` body and a SettleResponse

--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -37,7 +37,9 @@ claim; a completed settlement is the proof.
 The header names, scheme semantics, and network identifiers below are from the
 x402 v2 specification and its transport and scheme specs
 (`specs/x402-specification-v2.md`, `specs/transports-v2/http.md`,
-`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md` in
+`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md`,
+`specs/schemes/exact/scheme_exact_svm.md`, and
+`specs/extensions/extension-offer-and-receipt.md` in
 [coinbase/x402](https://github.com/coinbase/x402)). Treat those specs as the
 source of truth over any single vendor's docs.
 
@@ -106,8 +108,8 @@ in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 clause of that sentence is asserted by the block, which is the point: the status
 line, the decode, the version, and an entry carrying all six fields. It exits
 non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
-`accepts` entries, and on one whose only entry is missing a field the signing
-step needs.
+`accepts` entries, on one declaring a version other than `2`, and on one whose
+only entry is missing a field the signing step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -155,6 +157,12 @@ schemes offered, and stop. Do not coerce an `upto` or batch entry into an
 gate working, not a defect.
 
 ### Step 3: Build and sign the payment authorization
+
+**This step has no fence because it is the client under test that signs it.** Hand
+`selected.json` to that client along the path it would use in production, and
+capture what it produces as `payload.json`; the skill supplies no reference
+signer, because signing with one would test the reference rather than the client.
+The `Inputs` section names the wallet and its signer as things you bring.
 
 Construct the scheme-specific authorization over the selected entry and sign it.
 For `exact` on EVM the recommended mechanism is an EIP-3009
@@ -211,10 +219,12 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
-other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
-`SettleResponse` without a `transaction` — the assertion above exits non-zero:
-record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+other name once and record which the endpoint accepts. The status check above
+separates that case from the next one by message, so read which of the two the
+block printed. If the response is `200` but carries no settlement transaction —
+no `PAYMENT-RESPONSE` header at all, a `SettleResponse` without a `transaction`,
+or one reporting `success: false` — the assertion above exits non-zero: record
+`settled-unverified` and stop. There is no hash for Step 5 to check, and a
 `200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
@@ -232,17 +242,25 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 # contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
 # the value in atomic units. Check .address too — a Transfer of the right amount to
 # the right address from the wrong token contract is exactly the mismatch below.
-# Finality: compare .result.blockNumber against eth_blockNumber for the
-# confirmations you require on that network.
+# Finality: the receipt carries no head height, so ask for one and subtract.
+curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+  | jq -r '"head " + .result'
+# confirmations = head - .result.blockNumber, both hex; require what that network needs.
 
 # SVM: the equivalent is getTransaction, reading the token-balance delta rather
 # than a log.
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo and whose mint is
-# `asset`, post minus pre must equal the authorized amount — a destination account
-# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null = success; for the balance entry whose owner is payTo AND whose mint is
+# `asset` — both, in one filter — post minus pre must equal the authorized amount.
+# A destination account the transaction creates has no pre entry at all, which
+# reads as a pre of 0. scheme_exact_svm.md is what licenses filtering on the owner:
+# "Destination MUST equal the Associated Token Account PDA for (owner = payTo,
+# mint = asset)", so payTo is the wallet, not the token account. Deriving that PDA
+# and matching the entry's account address is the stricter check, if you have a
+# derivation to hand.
 # err null is inclusion, not finality: poll getSignatureStatuses for the
 # commitment level you require.
 ```

--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: de
   source_locale: en
-  source_commit: 935fa0b00
-  fence_basis_commit: 935fa0b00
+  source_commit: 6aed0e343
+  fence_basis_commit: 6aed0e343
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -73,18 +73,22 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
-set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
-                  # grep fails, every later stage succeeds on empty input, and the pipeline
-                  # reports only the last stage. That is the silent break named below.
+set -o pipefail   # a 402 carrying NO payment-required header makes grep fail while every later
+                  # stage succeeds on empty input; without this the pipeline reports only the
+                  # last stage. That is the silent break named below. The assertion catches it
+                  # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
+# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
+jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+  || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
-Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
-spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
-mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
+The transport spec does not pin the base64 alphabet. The one endpoint measured while writing this
+skill uses standard base64 with `=` padding, which the decode above reads; a server using base64url
+would fail that decode rather than mis-parse it — `base64 -d` rejects `-` and `_` — and the
+assertion turns the failure into a stop rather than an empty file.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -95,8 +99,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 `scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero and leaves `terms.json` empty in every failure case — treat
-a non-empty `terms.json` as the pass condition, never the exit status alone.
+block exits non-zero in every failure case, including the two a bare emptiness
+check would pass: a header that decodes to `null`, and one that decodes to valid
+JSON carrying no `accepts` entries.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -179,6 +184,10 @@ curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+# assert the settlement before believing it: an absent header, a `null` body and a SettleResponse
+# with no transaction all leave a block that merely prints, exiting 0
+jq -e '.success == true and ((.transaction // "") | length) > 0' settlement.json > /dev/null \
+  || { echo 'settled-unverified: no settlement transaction'; exit 1; }
 jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
@@ -191,8 +200,10 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
 other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction, treat it as `settled-unverified` and
-proceed to Step 5 before trusting it.
+but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
+`SettleResponse` without a `transaction` — the assertion above exits non-zero:
+record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+`200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
 
@@ -217,8 +228,11 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo, post minus pre must
-# equal the authorized amount, and its mint must equal `asset`.
+# err null = success; for the balance entry whose owner is payTo and whose mint is
+# `asset`, post minus pre must equal the authorized amount — a destination account
+# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null is inclusion, not finality: poll getSignatureStatuses for the
+# commitment level you require.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized

--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -73,10 +73,18 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
+set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
+                  # grep fails, every later stage succeeds on empty input, and the pipeline
+                  # reports only the last stage. That is the silent break named below.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
+[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
 ```
+
+Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
+spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
+mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -86,7 +94,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
+block exits non-zero and leaves `terms.json` empty in every failure case — treat
+a non-empty `terms.json` as the pass condition, never the exit status alone.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -114,7 +124,9 @@ jq -e --arg optin "${MAINNET_OPTIN:-false}" '
   ["eip155:84532","eip155:43113","solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"] as $testnets
   | ["eip155:","solana:"] as $supported
   | [.accepts[] | select(.scheme=="exact" and (.network as $n | any($supported[]; . as $p | $n|startswith($p))))] as $ok
-  | if ($ok|length)==0 then error("unsupported-scheme: " + ([.accepts[] | .scheme+"@"+.network]|join(",")))
+  | if ($ok|length)==0 then error("unsupported-scheme: " + (if (.accepts|length)==0
+      then "(challenge offered no accepts entries)"
+      else ([.accepts[] | .scheme+"@"+.network]|join(",")) end))
     else ([$ok[] | select((.network|IN($testnets[])) or $optin=="true")][0]
           // error("mainnet-not-opted-in: " + $ok[0].network)) end' terms.json > selected.json
 ```
@@ -161,14 +173,19 @@ Base64-encode the `PaymentPayload` and resend the same request with it in the
 signature and settles.
 
 ```bash
-curl -s -H "PAYMENT-SIGNATURE: $(base64 -w0 payload.json)" \
+set -o pipefail
+# base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
+curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+# the settlement rides a header too, and needs the same decode as Step 1
+grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
 **Expected:** HTTP `200`. The response carries a settlement result in the
-base64-encoded `PAYMENT-RESPONSE` header (`SettleResponse`: `success: true`, a
-non-empty `transaction` hash, and the `network`; `amount` and `payer` are
-optional and may be omitted).
+base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
+(`SettleResponse`: `success: true`, a non-empty `transaction` hash, and the
+`network`; `amount` and `payer` are optional and may be omitted).
 
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
@@ -188,10 +205,20 @@ hash from the `SettleResponse` and confirm it on chain: correct `payTo`, correct
 curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["<transaction>"]}' \
   | jq '{status: .result.status, block: .result.blockNumber, logs: .result.logs}'
-# status 0x1 = success; the ERC-20 Transfer log's topics[2] is the recipient
-# (must equal payTo, zero-padded) and its data is the value in atomic units.
+# status 0x1 = success. In the ERC-20 Transfer log: .address must equal the `asset`
+# contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
+# the value in atomic units. Check .address too — a Transfer of the right amount to
+# the right address from the wrong token contract is exactly the mismatch below.
 # Finality: compare .result.blockNumber against eth_blockNumber for the
 # confirmations you require on that network.
+
+# SVM: the equivalent is getTransaction, reading the token-balance delta rather
+# than a log.
+curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
+  | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
+# err null = success; for the balance entry whose owner is payTo, post minus pre must
+# equal the authorized amount, and its mint must equal `asset`.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized
@@ -228,6 +255,12 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       with `x402Version: 2` and at least one complete `accepts` entry.
 - [ ] The client selected a scheme+network it supports and refused the rest
       rather than misreading them.
+- [ ] Step 2's gate was exercised on its negative cases, not only on a challenge
+      it accepts: an `exact` entry on a network prefix the client does not
+      implement, a challenge mixing mainnet and testnet entries with
+      `mainnet_optin` false (the testnet entry must be the one selected, not a
+      refusal), and a challenge with an empty `accepts` array. Each must stop
+      the run with the documented reason rather than select anything.
 - [ ] The signed authorization used an atomic-unit amount and echoed all
       advertised extensions.
 - [ ] The retry with `PAYMENT-SIGNATURE` returned `200` with a `SettleResponse`
@@ -242,7 +275,11 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       recover the signer from the signature; for a JWS compact serialization,
       resolve the header's `kid` (a DID URL) to the issuer's key and verify
       over the complete payload. In both cases confirm the signer is authorised
-      for `resourceUrl`, the required fields are present (offer: `version`,
+      for `resourceUrl`, that the signed `network`, `asset`, `payTo` and
+      `amount` match the `accepts` entry selected in Step 2 — the spec binds an
+      offer to its entry by those fields, and explicitly not by the unsigned
+      `acceptIndex` an offer may also carry — that the required fields are
+      present (offer: `version`,
       `resourceUrl`, `scheme`, `network`, `asset`, `payTo`, `amount`; receipt:
       `version`, `network`, `resourceUrl`, `payer`, `issuedAt`), and any
       `validUntil` has not passed.

--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -179,6 +179,10 @@ signature and settles.
 
 ```bash
 set -o pipefail
+# Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
+# `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
+# empty PAYMENT-SIGNATURE and read back as a settlement failure.
+[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json

--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: de
   source_locale: en
-  source_commit: 6aed0e343
-  fence_basis_commit: 6aed0e343
+  source_commit: 486d1d344
+  fence_basis_commit: 486d1d344
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: de
   source_locale: en
-  source_commit: a3406e2d8
-  fence_basis_commit: a3406e2d8
+  source_commit: 6d6b78679
+  fence_basis_commit: 6d6b78679
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: de
   source_locale: en
-  source_commit: 486d1d344
-  fence_basis_commit: 486d1d344
+  source_commit: 460ba8e8f
+  fence_basis_commit: 460ba8e8f
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/de/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/de/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: de
   source_locale: en
-  source_commit: 6d6b78679
-  fence_basis_commit: 6d6b78679
+  source_commit: 935fa0b00
+  fence_basis_commit: 935fa0b00
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: es
   source_locale: en
-  source_commit: 935fa0b00
-  fence_basis_commit: 935fa0b00
+  source_commit: 6aed0e343
+  fence_basis_commit: 6aed0e343
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -78,10 +78,14 @@ set -o pipefail   # a 402 carrying NO payment-required header makes grep fail wh
                   # last stage. That is the silent break named below. The assertion catches it
                   # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
+# the status line is the first half of what Expected demands, and nothing else reads it
+head -1 challenge.txt | grep -q ' 402' || { echo "not a 402: $(head -1 challenge.txt)"; exit 1; }
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
-jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+# assert the rest of it: a non-empty file is not enough, `null` is a non-empty file, and an
+# entry missing one of the six fields is not one the signing step can use
+jq -e '.x402Version == 2 and ([.accepts[] | select(.scheme and .network and .asset and .amount
+       and .payTo and .maxTimeoutSeconds)] | length) > 0' terms.json > /dev/null \
   || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
@@ -98,10 +102,12 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero in every failure case, including the two a bare emptiness
-check would pass: a header that decodes to `null`, and one that decodes to valid
-JSON carrying no `accepts` entries.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. Every
+clause of that sentence is asserted by the block, which is the point: the status
+line, the decode, the version, and an entry carrying all six fields. It exits
+non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
+`accepts` entries, and on one whose only entry is missing a field the signing
+step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -182,10 +188,12 @@ set -o pipefail
 # Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
 # `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
 # empty PAYMENT-SIGNATURE and read back as a settlement failure.
-[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
+jq -e '.x402Version == 2 and .accepted != null and .payload != null' payload.json > /dev/null 2>&1 \
+  || { echo 'payload.json is not a PaymentPayload: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+head -1 headers.txt | grep -q ' 200' || { echo "not a 200: $(head -1 headers.txt)"; exit 1; }
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
 # assert the settlement before believing it: an absent header, a `null` body and a SettleResponse

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -37,7 +37,9 @@ claim; a completed settlement is the proof.
 The header names, scheme semantics, and network identifiers below are from the
 x402 v2 specification and its transport and scheme specs
 (`specs/x402-specification-v2.md`, `specs/transports-v2/http.md`,
-`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md` in
+`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md`,
+`specs/schemes/exact/scheme_exact_svm.md`, and
+`specs/extensions/extension-offer-and-receipt.md` in
 [coinbase/x402](https://github.com/coinbase/x402)). Treat those specs as the
 source of truth over any single vendor's docs.
 
@@ -106,8 +108,8 @@ in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 clause of that sentence is asserted by the block, which is the point: the status
 line, the decode, the version, and an entry carrying all six fields. It exits
 non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
-`accepts` entries, and on one whose only entry is missing a field the signing
-step needs.
+`accepts` entries, on one declaring a version other than `2`, and on one whose
+only entry is missing a field the signing step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -155,6 +157,12 @@ schemes offered, and stop. Do not coerce an `upto` or batch entry into an
 gate working, not a defect.
 
 ### Step 3: Build and sign the payment authorization
+
+**This step has no fence because it is the client under test that signs it.** Hand
+`selected.json` to that client along the path it would use in production, and
+capture what it produces as `payload.json`; the skill supplies no reference
+signer, because signing with one would test the reference rather than the client.
+The `Inputs` section names the wallet and its signer as things you bring.
 
 Construct the scheme-specific authorization over the selected entry and sign it.
 For `exact` on EVM the recommended mechanism is an EIP-3009
@@ -211,10 +219,12 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
-other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
-`SettleResponse` without a `transaction` — the assertion above exits non-zero:
-record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+other name once and record which the endpoint accepts. The status check above
+separates that case from the next one by message, so read which of the two the
+block printed. If the response is `200` but carries no settlement transaction —
+no `PAYMENT-RESPONSE` header at all, a `SettleResponse` without a `transaction`,
+or one reporting `success: false` — the assertion above exits non-zero: record
+`settled-unverified` and stop. There is no hash for Step 5 to check, and a
 `200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
@@ -232,17 +242,25 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 # contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
 # the value in atomic units. Check .address too — a Transfer of the right amount to
 # the right address from the wrong token contract is exactly the mismatch below.
-# Finality: compare .result.blockNumber against eth_blockNumber for the
-# confirmations you require on that network.
+# Finality: the receipt carries no head height, so ask for one and subtract.
+curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+  | jq -r '"head " + .result'
+# confirmations = head - .result.blockNumber, both hex; require what that network needs.
 
 # SVM: the equivalent is getTransaction, reading the token-balance delta rather
 # than a log.
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo and whose mint is
-# `asset`, post minus pre must equal the authorized amount — a destination account
-# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null = success; for the balance entry whose owner is payTo AND whose mint is
+# `asset` — both, in one filter — post minus pre must equal the authorized amount.
+# A destination account the transaction creates has no pre entry at all, which
+# reads as a pre of 0. scheme_exact_svm.md is what licenses filtering on the owner:
+# "Destination MUST equal the Associated Token Account PDA for (owner = payTo,
+# mint = asset)", so payTo is the wallet, not the token account. Deriving that PDA
+# and matching the entry's account address is the stricter check, if you have a
+# derivation to hand.
 # err null is inclusion, not finality: poll getSignatureStatuses for the
 # commitment level you require.
 ```

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -73,18 +73,22 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
-set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
-                  # grep fails, every later stage succeeds on empty input, and the pipeline
-                  # reports only the last stage. That is the silent break named below.
+set -o pipefail   # a 402 carrying NO payment-required header makes grep fail while every later
+                  # stage succeeds on empty input; without this the pipeline reports only the
+                  # last stage. That is the silent break named below. The assertion catches it
+                  # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
+# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
+jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+  || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
-Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
-spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
-mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
+The transport spec does not pin the base64 alphabet. The one endpoint measured while writing this
+skill uses standard base64 with `=` padding, which the decode above reads; a server using base64url
+would fail that decode rather than mis-parse it — `base64 -d` rejects `-` and `_` — and the
+assertion turns the failure into a stop rather than an empty file.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -95,8 +99,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 `scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero and leaves `terms.json` empty in every failure case — treat
-a non-empty `terms.json` as the pass condition, never the exit status alone.
+block exits non-zero in every failure case, including the two a bare emptiness
+check would pass: a header that decodes to `null`, and one that decodes to valid
+JSON carrying no `accepts` entries.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -179,6 +184,10 @@ curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+# assert the settlement before believing it: an absent header, a `null` body and a SettleResponse
+# with no transaction all leave a block that merely prints, exiting 0
+jq -e '.success == true and ((.transaction // "") | length) > 0' settlement.json > /dev/null \
+  || { echo 'settled-unverified: no settlement transaction'; exit 1; }
 jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
@@ -191,8 +200,10 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
 other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction, treat it as `settled-unverified` and
-proceed to Step 5 before trusting it.
+but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
+`SettleResponse` without a `transaction` — the assertion above exits non-zero:
+record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+`200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
 
@@ -217,8 +228,11 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo, post minus pre must
-# equal the authorized amount, and its mint must equal `asset`.
+# err null = success; for the balance entry whose owner is payTo and whose mint is
+# `asset`, post minus pre must equal the authorized amount — a destination account
+# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null is inclusion, not finality: poll getSignatureStatuses for the
+# commitment level you require.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: es
   source_locale: en
-  source_commit: 486d1d344
-  fence_basis_commit: 486d1d344
+  source_commit: 460ba8e8f
+  fence_basis_commit: 460ba8e8f
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -73,10 +73,18 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
+set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
+                  # grep fails, every later stage succeeds on empty input, and the pipeline
+                  # reports only the last stage. That is the silent break named below.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
+[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
 ```
+
+Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
+spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
+mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -86,7 +94,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
+block exits non-zero and leaves `terms.json` empty in every failure case — treat
+a non-empty `terms.json` as the pass condition, never the exit status alone.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -114,7 +124,9 @@ jq -e --arg optin "${MAINNET_OPTIN:-false}" '
   ["eip155:84532","eip155:43113","solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"] as $testnets
   | ["eip155:","solana:"] as $supported
   | [.accepts[] | select(.scheme=="exact" and (.network as $n | any($supported[]; . as $p | $n|startswith($p))))] as $ok
-  | if ($ok|length)==0 then error("unsupported-scheme: " + ([.accepts[] | .scheme+"@"+.network]|join(",")))
+  | if ($ok|length)==0 then error("unsupported-scheme: " + (if (.accepts|length)==0
+      then "(challenge offered no accepts entries)"
+      else ([.accepts[] | .scheme+"@"+.network]|join(",")) end))
     else ([$ok[] | select((.network|IN($testnets[])) or $optin=="true")][0]
           // error("mainnet-not-opted-in: " + $ok[0].network)) end' terms.json > selected.json
 ```
@@ -161,14 +173,19 @@ Base64-encode the `PaymentPayload` and resend the same request with it in the
 signature and settles.
 
 ```bash
-curl -s -H "PAYMENT-SIGNATURE: $(base64 -w0 payload.json)" \
+set -o pipefail
+# base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
+curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+# the settlement rides a header too, and needs the same decode as Step 1
+grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
 **Expected:** HTTP `200`. The response carries a settlement result in the
-base64-encoded `PAYMENT-RESPONSE` header (`SettleResponse`: `success: true`, a
-non-empty `transaction` hash, and the `network`; `amount` and `payer` are
-optional and may be omitted).
+base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
+(`SettleResponse`: `success: true`, a non-empty `transaction` hash, and the
+`network`; `amount` and `payer` are optional and may be omitted).
 
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
@@ -188,10 +205,20 @@ hash from the `SettleResponse` and confirm it on chain: correct `payTo`, correct
 curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["<transaction>"]}' \
   | jq '{status: .result.status, block: .result.blockNumber, logs: .result.logs}'
-# status 0x1 = success; the ERC-20 Transfer log's topics[2] is the recipient
-# (must equal payTo, zero-padded) and its data is the value in atomic units.
+# status 0x1 = success. In the ERC-20 Transfer log: .address must equal the `asset`
+# contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
+# the value in atomic units. Check .address too — a Transfer of the right amount to
+# the right address from the wrong token contract is exactly the mismatch below.
 # Finality: compare .result.blockNumber against eth_blockNumber for the
 # confirmations you require on that network.
+
+# SVM: the equivalent is getTransaction, reading the token-balance delta rather
+# than a log.
+curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
+  | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
+# err null = success; for the balance entry whose owner is payTo, post minus pre must
+# equal the authorized amount, and its mint must equal `asset`.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized
@@ -228,6 +255,12 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       with `x402Version: 2` and at least one complete `accepts` entry.
 - [ ] The client selected a scheme+network it supports and refused the rest
       rather than misreading them.
+- [ ] Step 2's gate was exercised on its negative cases, not only on a challenge
+      it accepts: an `exact` entry on a network prefix the client does not
+      implement, a challenge mixing mainnet and testnet entries with
+      `mainnet_optin` false (the testnet entry must be the one selected, not a
+      refusal), and a challenge with an empty `accepts` array. Each must stop
+      the run with the documented reason rather than select anything.
 - [ ] The signed authorization used an atomic-unit amount and echoed all
       advertised extensions.
 - [ ] The retry with `PAYMENT-SIGNATURE` returned `200` with a `SettleResponse`
@@ -242,7 +275,11 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       recover the signer from the signature; for a JWS compact serialization,
       resolve the header's `kid` (a DID URL) to the issuer's key and verify
       over the complete payload. In both cases confirm the signer is authorised
-      for `resourceUrl`, the required fields are present (offer: `version`,
+      for `resourceUrl`, that the signed `network`, `asset`, `payTo` and
+      `amount` match the `accepts` entry selected in Step 2 — the spec binds an
+      offer to its entry by those fields, and explicitly not by the unsigned
+      `acceptIndex` an offer may also carry — that the required fields are
+      present (offer: `version`,
       `resourceUrl`, `scheme`, `network`, `asset`, `payTo`, `amount`; receipt:
       `version`, `network`, `resourceUrl`, `payer`, `issuedAt`), and any
       `validUntil` has not passed.

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -179,6 +179,10 @@ signature and settles.
 
 ```bash
 set -o pipefail
+# Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
+# `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
+# empty PAYMENT-SIGNATURE and read back as a settlement failure.
+[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: es
   source_locale: en
-  source_commit: a3406e2d8
-  fence_basis_commit: a3406e2d8
+  source_commit: 6d6b78679
+  fence_basis_commit: 6d6b78679
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: es
   source_locale: en
-  source_commit: 6aed0e343
-  fence_basis_commit: 6aed0e343
+  source_commit: 486d1d344
+  fence_basis_commit: 486d1d344
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/es/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/es/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: es
   source_locale: en
-  source_commit: 6d6b78679
-  fence_basis_commit: 6d6b78679
+  source_commit: 935fa0b00
+  fence_basis_commit: 935fa0b00
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: ja
   source_locale: en
-  source_commit: 6aed0e343
-  fence_basis_commit: 6aed0e343
+  source_commit: 486d1d344
+  fence_basis_commit: 486d1d344
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -78,10 +78,14 @@ set -o pipefail   # a 402 carrying NO payment-required header makes grep fail wh
                   # last stage. That is the silent break named below. The assertion catches it
                   # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
+# the status line is the first half of what Expected demands, and nothing else reads it
+head -1 challenge.txt | grep -q ' 402' || { echo "not a 402: $(head -1 challenge.txt)"; exit 1; }
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
-jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+# assert the rest of it: a non-empty file is not enough, `null` is a non-empty file, and an
+# entry missing one of the six fields is not one the signing step can use
+jq -e '.x402Version == 2 and ([.accepts[] | select(.scheme and .network and .asset and .amount
+       and .payTo and .maxTimeoutSeconds)] | length) > 0' terms.json > /dev/null \
   || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
@@ -98,10 +102,12 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero in every failure case, including the two a bare emptiness
-check would pass: a header that decodes to `null`, and one that decodes to valid
-JSON carrying no `accepts` entries.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. Every
+clause of that sentence is asserted by the block, which is the point: the status
+line, the decode, the version, and an entry carrying all six fields. It exits
+non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
+`accepts` entries, and on one whose only entry is missing a field the signing
+step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -182,10 +188,12 @@ set -o pipefail
 # Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
 # `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
 # empty PAYMENT-SIGNATURE and read back as a settlement failure.
-[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
+jq -e '.x402Version == 2 and .accepted != null and .payload != null' payload.json > /dev/null 2>&1 \
+  || { echo 'payload.json is not a PaymentPayload: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+head -1 headers.txt | grep -q ' 200' || { echo "not a 200: $(head -1 headers.txt)"; exit 1; }
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
 # assert the settlement before believing it: an absent header, a `null` body and a SettleResponse

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -37,7 +37,9 @@ claim; a completed settlement is the proof.
 The header names, scheme semantics, and network identifiers below are from the
 x402 v2 specification and its transport and scheme specs
 (`specs/x402-specification-v2.md`, `specs/transports-v2/http.md`,
-`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md` in
+`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md`,
+`specs/schemes/exact/scheme_exact_svm.md`, and
+`specs/extensions/extension-offer-and-receipt.md` in
 [coinbase/x402](https://github.com/coinbase/x402)). Treat those specs as the
 source of truth over any single vendor's docs.
 
@@ -106,8 +108,8 @@ in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 clause of that sentence is asserted by the block, which is the point: the status
 line, the decode, the version, and an entry carrying all six fields. It exits
 non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
-`accepts` entries, and on one whose only entry is missing a field the signing
-step needs.
+`accepts` entries, on one declaring a version other than `2`, and on one whose
+only entry is missing a field the signing step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -155,6 +157,12 @@ schemes offered, and stop. Do not coerce an `upto` or batch entry into an
 gate working, not a defect.
 
 ### Step 3: Build and sign the payment authorization
+
+**This step has no fence because it is the client under test that signs it.** Hand
+`selected.json` to that client along the path it would use in production, and
+capture what it produces as `payload.json`; the skill supplies no reference
+signer, because signing with one would test the reference rather than the client.
+The `Inputs` section names the wallet and its signer as things you bring.
 
 Construct the scheme-specific authorization over the selected entry and sign it.
 For `exact` on EVM the recommended mechanism is an EIP-3009
@@ -211,10 +219,12 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
-other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
-`SettleResponse` without a `transaction` — the assertion above exits non-zero:
-record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+other name once and record which the endpoint accepts. The status check above
+separates that case from the next one by message, so read which of the two the
+block printed. If the response is `200` but carries no settlement transaction —
+no `PAYMENT-RESPONSE` header at all, a `SettleResponse` without a `transaction`,
+or one reporting `success: false` — the assertion above exits non-zero: record
+`settled-unverified` and stop. There is no hash for Step 5 to check, and a
 `200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
@@ -232,17 +242,25 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 # contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
 # the value in atomic units. Check .address too — a Transfer of the right amount to
 # the right address from the wrong token contract is exactly the mismatch below.
-# Finality: compare .result.blockNumber against eth_blockNumber for the
-# confirmations you require on that network.
+# Finality: the receipt carries no head height, so ask for one and subtract.
+curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+  | jq -r '"head " + .result'
+# confirmations = head - .result.blockNumber, both hex; require what that network needs.
 
 # SVM: the equivalent is getTransaction, reading the token-balance delta rather
 # than a log.
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo and whose mint is
-# `asset`, post minus pre must equal the authorized amount — a destination account
-# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null = success; for the balance entry whose owner is payTo AND whose mint is
+# `asset` — both, in one filter — post minus pre must equal the authorized amount.
+# A destination account the transaction creates has no pre entry at all, which
+# reads as a pre of 0. scheme_exact_svm.md is what licenses filtering on the owner:
+# "Destination MUST equal the Associated Token Account PDA for (owner = payTo,
+# mint = asset)", so payTo is the wallet, not the token account. Deriving that PDA
+# and matching the entry's account address is the stricter check, if you have a
+# derivation to hand.
 # err null is inclusion, not finality: poll getSignatureStatuses for the
 # commitment level you require.
 ```

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -73,18 +73,22 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
-set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
-                  # grep fails, every later stage succeeds on empty input, and the pipeline
-                  # reports only the last stage. That is the silent break named below.
+set -o pipefail   # a 402 carrying NO payment-required header makes grep fail while every later
+                  # stage succeeds on empty input; without this the pipeline reports only the
+                  # last stage. That is the silent break named below. The assertion catches it
+                  # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
+# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
+jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+  || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
-Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
-spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
-mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
+The transport spec does not pin the base64 alphabet. The one endpoint measured while writing this
+skill uses standard base64 with `=` padding, which the decode above reads; a server using base64url
+would fail that decode rather than mis-parse it — `base64 -d` rejects `-` and `_` — and the
+assertion turns the failure into a stop rather than an empty file.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -95,8 +99,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 `scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero and leaves `terms.json` empty in every failure case — treat
-a non-empty `terms.json` as the pass condition, never the exit status alone.
+block exits non-zero in every failure case, including the two a bare emptiness
+check would pass: a header that decodes to `null`, and one that decodes to valid
+JSON carrying no `accepts` entries.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -179,6 +184,10 @@ curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+# assert the settlement before believing it: an absent header, a `null` body and a SettleResponse
+# with no transaction all leave a block that merely prints, exiting 0
+jq -e '.success == true and ((.transaction // "") | length) > 0' settlement.json > /dev/null \
+  || { echo 'settled-unverified: no settlement transaction'; exit 1; }
 jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
@@ -191,8 +200,10 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
 other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction, treat it as `settled-unverified` and
-proceed to Step 5 before trusting it.
+but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
+`SettleResponse` without a `transaction` — the assertion above exits non-zero:
+record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+`200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
 
@@ -217,8 +228,11 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo, post minus pre must
-# equal the authorized amount, and its mint must equal `asset`.
+# err null = success; for the balance entry whose owner is payTo and whose mint is
+# `asset`, post minus pre must equal the authorized amount — a destination account
+# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null is inclusion, not finality: poll getSignatureStatuses for the
+# commitment level you require.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -73,10 +73,18 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
+set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
+                  # grep fails, every later stage succeeds on empty input, and the pipeline
+                  # reports only the last stage. That is the silent break named below.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
+[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
 ```
+
+Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
+spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
+mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -86,7 +94,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
+block exits non-zero and leaves `terms.json` empty in every failure case — treat
+a non-empty `terms.json` as the pass condition, never the exit status alone.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -114,7 +124,9 @@ jq -e --arg optin "${MAINNET_OPTIN:-false}" '
   ["eip155:84532","eip155:43113","solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"] as $testnets
   | ["eip155:","solana:"] as $supported
   | [.accepts[] | select(.scheme=="exact" and (.network as $n | any($supported[]; . as $p | $n|startswith($p))))] as $ok
-  | if ($ok|length)==0 then error("unsupported-scheme: " + ([.accepts[] | .scheme+"@"+.network]|join(",")))
+  | if ($ok|length)==0 then error("unsupported-scheme: " + (if (.accepts|length)==0
+      then "(challenge offered no accepts entries)"
+      else ([.accepts[] | .scheme+"@"+.network]|join(",")) end))
     else ([$ok[] | select((.network|IN($testnets[])) or $optin=="true")][0]
           // error("mainnet-not-opted-in: " + $ok[0].network)) end' terms.json > selected.json
 ```
@@ -161,14 +173,19 @@ Base64-encode the `PaymentPayload` and resend the same request with it in the
 signature and settles.
 
 ```bash
-curl -s -H "PAYMENT-SIGNATURE: $(base64 -w0 payload.json)" \
+set -o pipefail
+# base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
+curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+# the settlement rides a header too, and needs the same decode as Step 1
+grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
 **Expected:** HTTP `200`. The response carries a settlement result in the
-base64-encoded `PAYMENT-RESPONSE` header (`SettleResponse`: `success: true`, a
-non-empty `transaction` hash, and the `network`; `amount` and `payer` are
-optional and may be omitted).
+base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
+(`SettleResponse`: `success: true`, a non-empty `transaction` hash, and the
+`network`; `amount` and `payer` are optional and may be omitted).
 
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
@@ -188,10 +205,20 @@ hash from the `SettleResponse` and confirm it on chain: correct `payTo`, correct
 curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["<transaction>"]}' \
   | jq '{status: .result.status, block: .result.blockNumber, logs: .result.logs}'
-# status 0x1 = success; the ERC-20 Transfer log's topics[2] is the recipient
-# (must equal payTo, zero-padded) and its data is the value in atomic units.
+# status 0x1 = success. In the ERC-20 Transfer log: .address must equal the `asset`
+# contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
+# the value in atomic units. Check .address too — a Transfer of the right amount to
+# the right address from the wrong token contract is exactly the mismatch below.
 # Finality: compare .result.blockNumber against eth_blockNumber for the
 # confirmations you require on that network.
+
+# SVM: the equivalent is getTransaction, reading the token-balance delta rather
+# than a log.
+curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
+  | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
+# err null = success; for the balance entry whose owner is payTo, post minus pre must
+# equal the authorized amount, and its mint must equal `asset`.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized
@@ -228,6 +255,12 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       with `x402Version: 2` and at least one complete `accepts` entry.
 - [ ] The client selected a scheme+network it supports and refused the rest
       rather than misreading them.
+- [ ] Step 2's gate was exercised on its negative cases, not only on a challenge
+      it accepts: an `exact` entry on a network prefix the client does not
+      implement, a challenge mixing mainnet and testnet entries with
+      `mainnet_optin` false (the testnet entry must be the one selected, not a
+      refusal), and a challenge with an empty `accepts` array. Each must stop
+      the run with the documented reason rather than select anything.
 - [ ] The signed authorization used an atomic-unit amount and echoed all
       advertised extensions.
 - [ ] The retry with `PAYMENT-SIGNATURE` returned `200` with a `SettleResponse`
@@ -242,7 +275,11 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       recover the signer from the signature; for a JWS compact serialization,
       resolve the header's `kid` (a DID URL) to the issuer's key and verify
       over the complete payload. In both cases confirm the signer is authorised
-      for `resourceUrl`, the required fields are present (offer: `version`,
+      for `resourceUrl`, that the signed `network`, `asset`, `payTo` and
+      `amount` match the `accepts` entry selected in Step 2 — the spec binds an
+      offer to its entry by those fields, and explicitly not by the unsigned
+      `acceptIndex` an offer may also carry — that the required fields are
+      present (offer: `version`,
       `resourceUrl`, `scheme`, `network`, `asset`, `payTo`, `amount`; receipt:
       `version`, `network`, `resourceUrl`, `payer`, `issuedAt`), and any
       `validUntil` has not passed.

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: ja
   source_locale: en
-  source_commit: 935fa0b00
-  fence_basis_commit: 935fa0b00
+  source_commit: 6aed0e343
+  fence_basis_commit: 6aed0e343
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: ja
   source_locale: en
-  source_commit: 486d1d344
-  fence_basis_commit: 486d1d344
+  source_commit: 460ba8e8f
+  fence_basis_commit: 460ba8e8f
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -179,6 +179,10 @@ signature and settles.
 
 ```bash
 set -o pipefail
+# Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
+# `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
+# empty PAYMENT-SIGNATURE and read back as a settlement failure.
+[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: ja
   source_locale: en
-  source_commit: 6d6b78679
-  fence_basis_commit: 6d6b78679
+  source_commit: 935fa0b00
+  fence_basis_commit: 935fa0b00
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/ja/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/ja/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: ja
   source_locale: en
-  source_commit: a3406e2d8
-  fence_basis_commit: a3406e2d8
+  source_commit: 6d6b78679
+  fence_basis_commit: 6d6b78679
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: zh-CN
   source_locale: en
-  source_commit: 6aed0e343
-  fence_basis_commit: 6aed0e343
+  source_commit: 486d1d344
+  fence_basis_commit: 486d1d344
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -78,10 +78,14 @@ set -o pipefail   # a 402 carrying NO payment-required header makes grep fail wh
                   # last stage. That is the silent break named below. The assertion catches it
                   # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
+# the status line is the first half of what Expected demands, and nothing else reads it
+head -1 challenge.txt | grep -q ' 402' || { echo "not a 402: $(head -1 challenge.txt)"; exit 1; }
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
-jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+# assert the rest of it: a non-empty file is not enough, `null` is a non-empty file, and an
+# entry missing one of the six fields is not one the signing step can use
+jq -e '.x402Version == 2 and ([.accepts[] | select(.scheme and .network and .asset and .amount
+       and .payTo and .maxTimeoutSeconds)] | length) > 0' terms.json > /dev/null \
   || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
@@ -98,10 +102,12 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero in every failure case, including the two a bare emptiness
-check would pass: a header that decodes to `null`, and one that decodes to valid
-JSON carrying no `accepts` entries.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. Every
+clause of that sentence is asserted by the block, which is the point: the status
+line, the decode, the version, and an entry carrying all six fields. It exits
+non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
+`accepts` entries, and on one whose only entry is missing a field the signing
+step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -182,10 +188,12 @@ set -o pipefail
 # Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
 # `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
 # empty PAYMENT-SIGNATURE and read back as a settlement failure.
-[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
+jq -e '.x402Version == 2 and .accepted != null and .payload != null' payload.json > /dev/null 2>&1 \
+  || { echo 'payload.json is not a PaymentPayload: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+head -1 headers.txt | grep -q ' 200' || { echo "not a 200: $(head -1 headers.txt)"; exit 1; }
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
 # assert the settlement before believing it: an absent header, a `null` body and a SettleResponse

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -37,7 +37,9 @@ claim; a completed settlement is the proof.
 The header names, scheme semantics, and network identifiers below are from the
 x402 v2 specification and its transport and scheme specs
 (`specs/x402-specification-v2.md`, `specs/transports-v2/http.md`,
-`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md` in
+`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md`,
+`specs/schemes/exact/scheme_exact_svm.md`, and
+`specs/extensions/extension-offer-and-receipt.md` in
 [coinbase/x402](https://github.com/coinbase/x402)). Treat those specs as the
 source of truth over any single vendor's docs.
 
@@ -106,8 +108,8 @@ in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 clause of that sentence is asserted by the block, which is the point: the status
 line, the decode, the version, and an entry carrying all six fields. It exits
 non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
-`accepts` entries, and on one whose only entry is missing a field the signing
-step needs.
+`accepts` entries, on one declaring a version other than `2`, and on one whose
+only entry is missing a field the signing step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -155,6 +157,12 @@ schemes offered, and stop. Do not coerce an `upto` or batch entry into an
 gate working, not a defect.
 
 ### Step 3: Build and sign the payment authorization
+
+**This step has no fence because it is the client under test that signs it.** Hand
+`selected.json` to that client along the path it would use in production, and
+capture what it produces as `payload.json`; the skill supplies no reference
+signer, because signing with one would test the reference rather than the client.
+The `Inputs` section names the wallet and its signer as things you bring.
 
 Construct the scheme-specific authorization over the selected entry and sign it.
 For `exact` on EVM the recommended mechanism is an EIP-3009
@@ -211,10 +219,12 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
-other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
-`SettleResponse` without a `transaction` — the assertion above exits non-zero:
-record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+other name once and record which the endpoint accepts. The status check above
+separates that case from the next one by message, so read which of the two the
+block printed. If the response is `200` but carries no settlement transaction —
+no `PAYMENT-RESPONSE` header at all, a `SettleResponse` without a `transaction`,
+or one reporting `success: false` — the assertion above exits non-zero: record
+`settled-unverified` and stop. There is no hash for Step 5 to check, and a
 `200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
@@ -232,17 +242,25 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 # contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
 # the value in atomic units. Check .address too — a Transfer of the right amount to
 # the right address from the wrong token contract is exactly the mismatch below.
-# Finality: compare .result.blockNumber against eth_blockNumber for the
-# confirmations you require on that network.
+# Finality: the receipt carries no head height, so ask for one and subtract.
+curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+  | jq -r '"head " + .result'
+# confirmations = head - .result.blockNumber, both hex; require what that network needs.
 
 # SVM: the equivalent is getTransaction, reading the token-balance delta rather
 # than a log.
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo and whose mint is
-# `asset`, post minus pre must equal the authorized amount — a destination account
-# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null = success; for the balance entry whose owner is payTo AND whose mint is
+# `asset` — both, in one filter — post minus pre must equal the authorized amount.
+# A destination account the transaction creates has no pre entry at all, which
+# reads as a pre of 0. scheme_exact_svm.md is what licenses filtering on the owner:
+# "Destination MUST equal the Associated Token Account PDA for (owner = payTo,
+# mint = asset)", so payTo is the wallet, not the token account. Deriving that PDA
+# and matching the entry's account address is the stricter check, if you have a
+# derivation to hand.
 # err null is inclusion, not finality: poll getSignatureStatuses for the
 # commitment level you require.
 ```

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: zh-CN
   source_locale: en
-  source_commit: 6d6b78679
-  fence_basis_commit: 6d6b78679
+  source_commit: 935fa0b00
+  fence_basis_commit: 935fa0b00
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -73,18 +73,22 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
-set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
-                  # grep fails, every later stage succeeds on empty input, and the pipeline
-                  # reports only the last stage. That is the silent break named below.
+set -o pipefail   # a 402 carrying NO payment-required header makes grep fail while every later
+                  # stage succeeds on empty input; without this the pipeline reports only the
+                  # last stage. That is the silent break named below. The assertion catches it
+                  # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
+# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
+jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+  || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
-Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
-spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
-mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
+The transport spec does not pin the base64 alphabet. The one endpoint measured while writing this
+skill uses standard base64 with `=` padding, which the decode above reads; a server using base64url
+would fail that decode rather than mis-parse it — `base64 -d` rejects `-` and `_` — and the
+assertion turns the failure into a stop rather than an empty file.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -95,8 +99,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 `scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero and leaves `terms.json` empty in every failure case — treat
-a non-empty `terms.json` as the pass condition, never the exit status alone.
+block exits non-zero in every failure case, including the two a bare emptiness
+check would pass: a header that decodes to `null`, and one that decodes to valid
+JSON carrying no `accepts` entries.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -179,6 +184,10 @@ curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+# assert the settlement before believing it: an absent header, a `null` body and a SettleResponse
+# with no transaction all leave a block that merely prints, exiting 0
+jq -e '.success == true and ((.transaction // "") | length) > 0' settlement.json > /dev/null \
+  || { echo 'settled-unverified: no settlement transaction'; exit 1; }
 jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
@@ -191,8 +200,10 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
 other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction, treat it as `settled-unverified` and
-proceed to Step 5 before trusting it.
+but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
+`SettleResponse` without a `transaction` — the assertion above exits non-zero:
+record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+`200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
 
@@ -217,8 +228,11 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo, post minus pre must
-# equal the authorized amount, and its mint must equal `asset`.
+# err null = success; for the balance entry whose owner is payTo and whose mint is
+# `asset`, post minus pre must equal the authorized amount — a destination account
+# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null is inclusion, not finality: poll getSignatureStatuses for the
+# commitment level you require.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -73,10 +73,18 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
+set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
+                  # grep fails, every later stage succeeds on empty input, and the pipeline
+                  # reports only the last stage. That is the silent break named below.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
+[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
 ```
+
+Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
+spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
+mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -86,7 +94,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
+block exits non-zero and leaves `terms.json` empty in every failure case — treat
+a non-empty `terms.json` as the pass condition, never the exit status alone.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -114,7 +124,9 @@ jq -e --arg optin "${MAINNET_OPTIN:-false}" '
   ["eip155:84532","eip155:43113","solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"] as $testnets
   | ["eip155:","solana:"] as $supported
   | [.accepts[] | select(.scheme=="exact" and (.network as $n | any($supported[]; . as $p | $n|startswith($p))))] as $ok
-  | if ($ok|length)==0 then error("unsupported-scheme: " + ([.accepts[] | .scheme+"@"+.network]|join(",")))
+  | if ($ok|length)==0 then error("unsupported-scheme: " + (if (.accepts|length)==0
+      then "(challenge offered no accepts entries)"
+      else ([.accepts[] | .scheme+"@"+.network]|join(",")) end))
     else ([$ok[] | select((.network|IN($testnets[])) or $optin=="true")][0]
           // error("mainnet-not-opted-in: " + $ok[0].network)) end' terms.json > selected.json
 ```
@@ -161,14 +173,19 @@ Base64-encode the `PaymentPayload` and resend the same request with it in the
 signature and settles.
 
 ```bash
-curl -s -H "PAYMENT-SIGNATURE: $(base64 -w0 payload.json)" \
+set -o pipefail
+# base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
+curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+# the settlement rides a header too, and needs the same decode as Step 1
+grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
 **Expected:** HTTP `200`. The response carries a settlement result in the
-base64-encoded `PAYMENT-RESPONSE` header (`SettleResponse`: `success: true`, a
-non-empty `transaction` hash, and the `network`; `amount` and `payer` are
-optional and may be omitted).
+base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
+(`SettleResponse`: `success: true`, a non-empty `transaction` hash, and the
+`network`; `amount` and `payer` are optional and may be omitted).
 
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
@@ -188,10 +205,20 @@ hash from the `SettleResponse` and confirm it on chain: correct `payTo`, correct
 curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["<transaction>"]}' \
   | jq '{status: .result.status, block: .result.blockNumber, logs: .result.logs}'
-# status 0x1 = success; the ERC-20 Transfer log's topics[2] is the recipient
-# (must equal payTo, zero-padded) and its data is the value in atomic units.
+# status 0x1 = success. In the ERC-20 Transfer log: .address must equal the `asset`
+# contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
+# the value in atomic units. Check .address too — a Transfer of the right amount to
+# the right address from the wrong token contract is exactly the mismatch below.
 # Finality: compare .result.blockNumber against eth_blockNumber for the
 # confirmations you require on that network.
+
+# SVM: the equivalent is getTransaction, reading the token-balance delta rather
+# than a log.
+curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
+  | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
+# err null = success; for the balance entry whose owner is payTo, post minus pre must
+# equal the authorized amount, and its mint must equal `asset`.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized
@@ -228,6 +255,12 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       with `x402Version: 2` and at least one complete `accepts` entry.
 - [ ] The client selected a scheme+network it supports and refused the rest
       rather than misreading them.
+- [ ] Step 2's gate was exercised on its negative cases, not only on a challenge
+      it accepts: an `exact` entry on a network prefix the client does not
+      implement, a challenge mixing mainnet and testnet entries with
+      `mainnet_optin` false (the testnet entry must be the one selected, not a
+      refusal), and a challenge with an empty `accepts` array. Each must stop
+      the run with the documented reason rather than select anything.
 - [ ] The signed authorization used an atomic-unit amount and echoed all
       advertised extensions.
 - [ ] The retry with `PAYMENT-SIGNATURE` returned `200` with a `SettleResponse`
@@ -242,7 +275,11 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       recover the signer from the signature; for a JWS compact serialization,
       resolve the header's `kid` (a DID URL) to the issuer's key and verify
       over the complete payload. In both cases confirm the signer is authorised
-      for `resourceUrl`, the required fields are present (offer: `version`,
+      for `resourceUrl`, that the signed `network`, `asset`, `payTo` and
+      `amount` match the `accepts` entry selected in Step 2 — the spec binds an
+      offer to its entry by those fields, and explicitly not by the unsigned
+      `acceptIndex` an offer may also carry — that the required fields are
+      present (offer: `version`,
       `resourceUrl`, `scheme`, `network`, `asset`, `payTo`, `amount`; receipt:
       `version`, `network`, `resourceUrl`, `payer`, `issuedAt`), and any
       `validUntil` has not passed.

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: zh-CN
   source_locale: en
-  source_commit: 935fa0b00
-  fence_basis_commit: 935fa0b00
+  source_commit: 6aed0e343
+  fence_basis_commit: 6aed0e343
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: zh-CN
   source_locale: en
-  source_commit: a3406e2d8
-  fence_basis_commit: a3406e2d8
+  source_commit: 6d6b78679
+  fence_basis_commit: 6d6b78679
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -179,6 +179,10 @@ signature and settles.
 
 ```bash
 set -o pipefail
+# Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
+# `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
+# empty PAYMENT-SIGNATURE and read back as a settlement failure.
+[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json

--- a/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
+++ b/i18n/zh-CN/skills/test-x402-payment-client/SKILL.md
@@ -20,8 +20,8 @@ metadata:
   tags: agent-commerce, x402, payments, testing, conformance
   locale: zh-CN
   source_locale: en
-  source_commit: 486d1d344
-  fence_basis_commit: 486d1d344
+  source_commit: 460ba8e8f
+  fence_basis_commit: 460ba8e8f
   translator: "(untranslated stub)"
   translation_date: "2026-09-03"
 ---

--- a/skills/test-a2a-interop/SKILL.md
+++ b/skills/test-a2a-interop/SKILL.md
@@ -462,3 +462,4 @@ interface ConformanceReport {
 - `build-ci-cd-pipeline` - integrate conformance tests into CI/CD
 - `troubleshoot-mcp-connection` - debugging patterns applicable to A2A connectivity
 - `review-software-architecture` - architecture review for multi-agent systems
+- `test-x402-payment-client` - the same posture on the payment rail: drive the real protocol loop end to end and validate it against the spec

--- a/skills/test-x402-payment-client/SKILL.md
+++ b/skills/test-x402-payment-client/SKILL.md
@@ -67,18 +67,22 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
-set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
-                  # grep fails, every later stage succeeds on empty input, and the pipeline
-                  # reports only the last stage. That is the silent break named below.
+set -o pipefail   # a 402 carrying NO payment-required header makes grep fail while every later
+                  # stage succeeds on empty input; without this the pipeline reports only the
+                  # last stage. That is the silent break named below. The assertion catches it
+                  # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
+# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
+jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+  || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
-Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
-spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
-mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
+The transport spec does not pin the base64 alphabet. The one endpoint measured while writing this
+skill uses standard base64 with `=` padding, which the decode above reads; a server using base64url
+would fail that decode rather than mis-parse it — `base64 -d` rejects `-` and `_` — and the
+assertion turns the failure into a stop rather than an empty file.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -89,8 +93,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 `scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero and leaves `terms.json` empty in every failure case — treat
-a non-empty `terms.json` as the pass condition, never the exit status alone.
+block exits non-zero in every failure case, including the two a bare emptiness
+check would pass: a header that decodes to `null`, and one that decodes to valid
+JSON carrying no `accepts` entries.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -173,6 +178,10 @@ curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+# assert the settlement before believing it: an absent header, a `null` body and a SettleResponse
+# with no transaction all leave a block that merely prints, exiting 0
+jq -e '.success == true and ((.transaction // "") | length) > 0' settlement.json > /dev/null \
+  || { echo 'settled-unverified: no settlement transaction'; exit 1; }
 jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
@@ -185,10 +194,10 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
 other name once and record which the endpoint accepts. If the response is `200`
-but carries no `PAYMENT-RESPONSE` header, the decode above exits non-zero and
-leaves `settlement.json` empty: record `settled-unverified` and stop. There is no
-hash for Step 5 to check in that case, and a `200` without a settlement is not a
-completed payment.
+but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
+`SettleResponse` without a `transaction` — the assertion above exits non-zero:
+record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+`200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
 
@@ -213,8 +222,11 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo, post minus pre must
-# equal the authorized amount, and its mint must equal `asset`.
+# err null = success; for the balance entry whose owner is payTo and whose mint is
+# `asset`, post minus pre must equal the authorized amount — a destination account
+# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null is inclusion, not finality: poll getSignatureStatuses for the
+# commitment level you require.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized

--- a/skills/test-x402-payment-client/SKILL.md
+++ b/skills/test-x402-payment-client/SKILL.md
@@ -72,10 +72,14 @@ set -o pipefail   # a 402 carrying NO payment-required header makes grep fail wh
                   # last stage. That is the silent break named below. The assertion catches it
                   # too — keep both, since either alone can be edited away.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
+# the status line is the first half of what Expected demands, and nothing else reads it
+head -1 challenge.txt | grep -q ' 402' || { echo "not a 402: $(head -1 challenge.txt)"; exit 1; }
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
-# assert what Expected below demands: a non-empty file is not enough, `null` is a non-empty file
-jq -e '.x402Version == 2 and (.accepts | length) > 0' terms.json > /dev/null \
+# assert the rest of it: a non-empty file is not enough, `null` is a non-empty file, and an
+# entry missing one of the six fields is not one the signing step can use
+jq -e '.x402Version == 2 and ([.accepts[] | select(.scheme and .network and .asset and .amount
+       and .payTo and .maxTimeoutSeconds)] | length) > 0' terms.json > /dev/null \
   || { echo 'no usable PAYMENT-REQUIRED terms — stop here'; exit 1; }
 ```
 
@@ -92,10 +96,12 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
-block exits non-zero in every failure case, including the two a bare emptiness
-check would pass: a header that decodes to `null`, and one that decodes to valid
-JSON carrying no `accepts` entries.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. Every
+clause of that sentence is asserted by the block, which is the point: the status
+line, the decode, the version, and an entry carrying all six fields. It exits
+non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
+`accepts` entries, and on one whose only entry is missing a field the signing
+step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -176,10 +182,12 @@ set -o pipefail
 # Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
 # `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
 # empty PAYMENT-SIGNATURE and read back as a settlement failure.
-[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
+jq -e '.x402Version == 2 and .accepted != null and .payload != null' payload.json > /dev/null 2>&1 \
+  || { echo 'payload.json is not a PaymentPayload: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+head -1 headers.txt | grep -q ' 200' || { echo "not a 200: $(head -1 headers.txt)"; exit 1; }
 # the settlement rides a header too, and needs the same decode as Step 1
 grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
 # assert the settlement before believing it: an absent header, a `null` body and a SettleResponse

--- a/skills/test-x402-payment-client/SKILL.md
+++ b/skills/test-x402-payment-client/SKILL.md
@@ -173,6 +173,10 @@ signature and settles.
 
 ```bash
 set -o pipefail
+# Step 3 has no fence — it is the client under test that signs — so check its artifact arrived.
+# `base64 missing.json | tr -d` exits 0 (the pipeline reports tr), which would otherwise send an
+# empty PAYMENT-SIGNATURE and read back as a settlement failure.
+[ -s payload.json ] || { echo 'no payload.json: the client under test produced no signed payment'; exit 1; }
 # base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
 curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json

--- a/skills/test-x402-payment-client/SKILL.md
+++ b/skills/test-x402-payment-client/SKILL.md
@@ -31,7 +31,9 @@ claim; a completed settlement is the proof.
 The header names, scheme semantics, and network identifiers below are from the
 x402 v2 specification and its transport and scheme specs
 (`specs/x402-specification-v2.md`, `specs/transports-v2/http.md`,
-`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md` in
+`specs/transports-v2/mcp.md`, `specs/schemes/exact/scheme_exact_evm.md`,
+`specs/schemes/exact/scheme_exact_svm.md`, and
+`specs/extensions/extension-offer-and-receipt.md` in
 [coinbase/x402](https://github.com/coinbase/x402)). Treat those specs as the
 source of truth over any single vendor's docs.
 
@@ -100,8 +102,8 @@ in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
 clause of that sentence is asserted by the block, which is the point: the status
 line, the decode, the version, and an entry carrying all six fields. It exits
 non-zero on a non-`402`, on a header that decodes to `null`, on one carrying no
-`accepts` entries, and on one whose only entry is missing a field the signing
-step needs.
+`accepts` entries, on one declaring a version other than `2`, and on one whose
+only entry is missing a field the signing step needs.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -149,6 +151,12 @@ schemes offered, and stop. Do not coerce an `upto` or batch entry into an
 gate working, not a defect.
 
 ### Step 3: Build and sign the payment authorization
+
+**This step has no fence because it is the client under test that signs it.** Hand
+`selected.json` to that client along the path it would use in production, and
+capture what it produces as `payload.json`; the skill supplies no reference
+signer, because signing with one would test the reference rather than the client.
+The `Inputs` section names the wallet and its signer as things you bring.
 
 Construct the scheme-specific authorization over the selected entry and sign it.
 For `exact` on EVM the recommended mechanism is an EIP-3009
@@ -205,10 +213,12 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
-other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction — no `PAYMENT-RESPONSE` header at all, or a
-`SettleResponse` without a `transaction` — the assertion above exits non-zero:
-record `settled-unverified` and stop. There is no hash for Step 5 to check, and a
+other name once and record which the endpoint accepts. The status check above
+separates that case from the next one by message, so read which of the two the
+block printed. If the response is `200` but carries no settlement transaction —
+no `PAYMENT-RESPONSE` header at all, a `SettleResponse` without a `transaction`,
+or one reporting `success: false` — the assertion above exits non-zero: record
+`settled-unverified` and stop. There is no hash for Step 5 to check, and a
 `200` without a settlement is not a completed payment.
 
 ### Step 5: Verify the settlement independently on chain
@@ -226,17 +236,25 @@ curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
 # contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
 # the value in atomic units. Check .address too — a Transfer of the right amount to
 # the right address from the wrong token contract is exactly the mismatch below.
-# Finality: compare .result.blockNumber against eth_blockNumber for the
-# confirmations you require on that network.
+# Finality: the receipt carries no head height, so ask for one and subtract.
+curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' \
+  | jq -r '"head " + .result'
+# confirmations = head - .result.blockNumber, both hex; require what that network needs.
 
 # SVM: the equivalent is getTransaction, reading the token-balance delta rather
 # than a log.
 curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
   | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
-# err null = success; for the balance entry whose owner is payTo and whose mint is
-# `asset`, post minus pre must equal the authorized amount — a destination account
-# the transaction creates has no pre entry at all, which reads as a pre of 0.
+# err null = success; for the balance entry whose owner is payTo AND whose mint is
+# `asset` — both, in one filter — post minus pre must equal the authorized amount.
+# A destination account the transaction creates has no pre entry at all, which
+# reads as a pre of 0. scheme_exact_svm.md is what licenses filtering on the owner:
+# "Destination MUST equal the Associated Token Account PDA for (owner = payTo,
+# mint = asset)", so payTo is the wallet, not the token account. Deriving that PDA
+# and matching the entry's account address is the stricter check, if you have a
+# derivation to hand.
 # err null is inclusion, not finality: poll getSignatureStatuses for the
 # commitment level you require.
 ```

--- a/skills/test-x402-payment-client/SKILL.md
+++ b/skills/test-x402-payment-client/SKILL.md
@@ -185,8 +185,10 @@ base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
 name where the endpoint only reads `PAYMENT-SIGNATURE` (or the reverse); try the
 other name once and record which the endpoint accepts. If the response is `200`
-but carries no settlement transaction, treat it as `settled-unverified` and
-proceed to Step 5 before trusting it.
+but carries no `PAYMENT-RESPONSE` header, the decode above exits non-zero and
+leaves `settlement.json` empty: record `settled-unverified` and stop. There is no
+hash for Step 5 to check in that case, and a `200` without a settlement is not a
+completed payment.
 
 ### Step 5: Verify the settlement independently on chain
 

--- a/skills/test-x402-payment-client/SKILL.md
+++ b/skills/test-x402-payment-client/SKILL.md
@@ -67,10 +67,18 @@ Send a plain request and read the `402`. The machine-readable terms ride the
 human-oriented and must not be the client's source of truth.
 
 ```bash
+set -o pipefail   # required: without it a 402 carrying NO payment-required header exits 0 —
+                  # grep fails, every later stage succeeds on empty input, and the pipeline
+                  # reports only the last stage. That is the silent break named below.
 curl -sD challenge.txt -o /dev/null https://x402.example.testnet/resource
 # base64-decode the PAYMENT-REQUIRED header value into terms.json
 grep -i '^payment-required:' challenge.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > terms.json
+[ -s terms.json ] || { echo 'no decodable PAYMENT-REQUIRED header — stop here'; exit 1; }
 ```
+
+Servers observed in the wild encode the header as standard base64 with `=` padding; the transport
+spec does not pin the alphabet, so a server using base64url will fail the decode above rather than
+mis-parse — `base64 -d` rejects `-` and `_`, and the guard turns that into a stop.
 
 The decoded `PaymentRequired` object carries `x402Version` (must be `2`), one
 or more `accepts` entries (each a `PaymentRequirements`), and any advertised
@@ -80,7 +88,9 @@ or more `accepts` entries (each a `PaymentRequirements`), and any advertised
 
 **Expected:** HTTP `402`; a `PAYMENT-REQUIRED` header that base64-decodes to JSON
 in `terms.json` with `x402Version: 2` and at least one `accepts` entry carrying
-`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`.
+`scheme`, `network`, `asset`, `amount`, `payTo`, and `maxTimeoutSeconds`. The
+block exits non-zero and leaves `terms.json` empty in every failure case — treat
+a non-empty `terms.json` as the pass condition, never the exit status alone.
 
 **On failure:** If there is no `PAYMENT-REQUIRED` header, the endpoint is not
 serving v2 terms a client can act on — stop and report that (a `402` body with
@@ -108,7 +118,9 @@ jq -e --arg optin "${MAINNET_OPTIN:-false}" '
   ["eip155:84532","eip155:43113","solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"] as $testnets
   | ["eip155:","solana:"] as $supported
   | [.accepts[] | select(.scheme=="exact" and (.network as $n | any($supported[]; . as $p | $n|startswith($p))))] as $ok
-  | if ($ok|length)==0 then error("unsupported-scheme: " + ([.accepts[] | .scheme+"@"+.network]|join(",")))
+  | if ($ok|length)==0 then error("unsupported-scheme: " + (if (.accepts|length)==0
+      then "(challenge offered no accepts entries)"
+      else ([.accepts[] | .scheme+"@"+.network]|join(",")) end))
     else ([$ok[] | select((.network|IN($testnets[])) or $optin=="true")][0]
           // error("mainnet-not-opted-in: " + $ok[0].network)) end' terms.json > selected.json
 ```
@@ -155,14 +167,19 @@ Base64-encode the `PaymentPayload` and resend the same request with it in the
 signature and settles.
 
 ```bash
-curl -s -H "PAYMENT-SIGNATURE: $(base64 -w0 payload.json)" \
+set -o pipefail
+# base64 without -w0: GNU wraps at 76 columns, BSD and busybox reject -w — strip newlines instead
+curl -s -H "PAYMENT-SIGNATURE: $(base64 payload.json | tr -d '\n')" \
   https://x402.example.testnet/resource -D headers.txt -o body.json
+# the settlement rides a header too, and needs the same decode as Step 1
+grep -i '^payment-response:' headers.txt | sed 's/^[^:]*:[[:space:]]*//' | tr -d '\r' | base64 -d | jq . > settlement.json
+jq -r '.transaction' settlement.json   # the hash Step 5 verifies
 ```
 
 **Expected:** HTTP `200`. The response carries a settlement result in the
-base64-encoded `PAYMENT-RESPONSE` header (`SettleResponse`: `success: true`, a
-non-empty `transaction` hash, and the `network`; `amount` and `payer` are
-optional and may be omitted).
+base64-encoded `PAYMENT-RESPONSE` header, decoded above into `settlement.json`
+(`SettleResponse`: `success: true`, a non-empty `transaction` hash, and the
+`network`; `amount` and `payer` are optional and may be omitted).
 
 **On failure:** A repeated `402` means verification refused the payment — inspect
 the reason. A common cause is the client sending the legacy `X-PAYMENT` header
@@ -182,10 +199,20 @@ hash from the `SettleResponse` and confirm it on chain: correct `payTo`, correct
 curl -s -X POST https://sepolia.base.org -H 'content-type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"eth_getTransactionReceipt","params":["<transaction>"]}' \
   | jq '{status: .result.status, block: .result.blockNumber, logs: .result.logs}'
-# status 0x1 = success; the ERC-20 Transfer log's topics[2] is the recipient
-# (must equal payTo, zero-padded) and its data is the value in atomic units.
+# status 0x1 = success. In the ERC-20 Transfer log: .address must equal the `asset`
+# contract, topics[2] is the recipient (must equal payTo, zero-padded) and .data is
+# the value in atomic units. Check .address too — a Transfer of the right amount to
+# the right address from the wrong token contract is exactly the mismatch below.
 # Finality: compare .result.blockNumber against eth_blockNumber for the
 # confirmations you require on that network.
+
+# SVM: the equivalent is getTransaction, reading the token-balance delta rather
+# than a log.
+curl -s -X POST https://api.devnet.solana.com -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":0}]}' \
+  | jq '{err: .result.meta.err, pre: .result.meta.preTokenBalances, post: .result.meta.postTokenBalances}'
+# err null = success; for the balance entry whose owner is payTo, post minus pre must
+# equal the authorized amount, and its mint must equal `asset`.
 ```
 
 **Expected:** The on-chain transfer matches `payTo`, `asset`, and the authorized
@@ -222,6 +249,12 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       with `x402Version: 2` and at least one complete `accepts` entry.
 - [ ] The client selected a scheme+network it supports and refused the rest
       rather than misreading them.
+- [ ] Step 2's gate was exercised on its negative cases, not only on a challenge
+      it accepts: an `exact` entry on a network prefix the client does not
+      implement, a challenge mixing mainnet and testnet entries with
+      `mainnet_optin` false (the testnet entry must be the one selected, not a
+      refusal), and a challenge with an empty `accepts` array. Each must stop
+      the run with the documented reason rather than select anything.
 - [ ] The signed authorization used an atomic-unit amount and echoed all
       advertised extensions.
 - [ ] The retry with `PAYMENT-SIGNATURE` returned `200` with a `SettleResponse`
@@ -236,7 +269,11 @@ advertising x402 over this transport — fall back to the HTTP path or stop.
       recover the signer from the signature; for a JWS compact serialization,
       resolve the header's `kid` (a DID URL) to the issuer's key and verify
       over the complete payload. In both cases confirm the signer is authorised
-      for `resourceUrl`, the required fields are present (offer: `version`,
+      for `resourceUrl`, that the signed `network`, `asset`, `payTo` and
+      `amount` match the `accepts` entry selected in Step 2 — the spec binds an
+      offer to its entry by those fields, and explicitly not by the unsigned
+      `acceptIndex` an offer may also carry — that the required fields are
+      present (offer: `version`,
       `resourceUrl`, `scheme`, `network`, `asset`, `payTo`, `amount`; receipt:
       `version`, `network`, `resourceUrl`, `payer`, `issuedAt`), and any
       `validUntil` has not passed.


### PR DESCRIPTION
Post-merge audit of #763, prompted by @cv-scvd's own post-merge verification pass on that thread.

## Why this exists

#763 was reviewed twice — an adversarial round on the PR (seven should-fix, all applied) and the contributor's independent re-check against `coinbase/x402` `main` after the merge. Both passes **read** the fences. Only Step 2's jq gate had ever been **executed**.

So this pass ran the rest of them. Step 1 works against a live 402 with no wallet; Step 5 takes a transaction hash, so it can be run against someone else's transaction; Step 4's decode tail runs against a synthetic `headers.txt`. That found four defects in the merged skill, plus one this PR introduced and then fixed (below).

## Findings and fixes

1. **Step 1 exited `0` on the failure the skill itself calls "the single most common silent break."** A `402` with no `PAYMENT-REQUIRED` header makes `grep` fail; every later stage succeeds on empty input; the pipeline reports only the last stage. Measured: exit `0`, `terms.json` 0 bytes — while the **On failure** block says to stop and report. Now `set -o pipefail` plus an assertion of the **Expected:** criteria themselves (`x402Version == 2` and a non-empty `accepts`), because emptiness is the wrong test: `null` is a non-empty file.

2. **Step 4 never decoded `PAYMENT-RESPONSE`**, although Step 5 consumes the `transaction` hash from it and Step 4's own **Expected:** block describes reading `SettleResponse` fields. Added the decode, plus an assertion — see the self-inflicted finding below. Also replaced `base64 -w0`, which BSD and busybox reject, with `base64 | tr -d '\n'`.

3. **Step 5 was EVM-only**, though Step 2's gate admits `solana:` entries and Inputs names Solana Devnet — an agent following the procedure on SVM reached the step the whole skill exists for with no method. Added the SVM path (`getTransaction`, token-balance delta). Also: the receipt carries each log's `.address` and the **Expected:** block requires the `asset` to match, but the comment never said to compare them.

4. **Validation checked an offer's signature and field list, but never its binding** to the entry the client selected. `specs/extensions/extension-offer-and-receipt.md` makes `acceptIndex` optional and unsigned and says clients must match on `network`/`asset`/`payTo`/`amount` instead. Added, plus @cv-scvd's three gate fixtures as a Validation item.

5. **Step 4's On failure branch sent a run with no transaction hash on to Step 5**, whose entire input is that hash.

**And one this PR introduced.** The decode added in (2) ended with `jq -r '.transaction' settlement.json` — a command that prints and exits `0` whether or not there is anything to print. Measured against synthetic responses, it exited `0` in all three cases the rewritten **On failure** block claims exit non-zero. Same defect as (1), one step later, in the fix for it. It now asserts before it prints. This is why the table below exists: an earlier revision of this PR body claimed every fence had been executed, and Step 4's tail had not been.

**And a second one this PR introduced.** Replacing `base64 -w0` with `base64 | tr -d '\n'` bought portability and sold a signal: `base64 -w0 missing.json` exits 1, while `base64 missing.json | tr -d '\n'` exits 0, because the pipeline reports `tr`. A run where Step 3 produced nothing therefore sent an empty `PAYMENT-SIGNATURE` and surfaced one step later as `settled-unverified` — a settlement diagnosis for a signing failure. Step 4 now asserts `[ -s payload.json ]` first, which is worth doing anyway: Step 3 is the one step with no fence, because signing is the client-under-test's job, so its artifact is exactly the one to check on arrival.

**A systematic pass over the seam.** After finding two self-inflicted defects at the boundary between a fence and the prose describing it, every **Expected:** and **On failure:** block was read against the fence above it, once, top to bottom. Four more mismatches, all of the same shape — the prose states a pass condition that no command observes:

- Step 1's Expected opens "HTTP `402`"; `curl -sD` wrote the status line and nothing read it.
- Step 1's Expected names six fields per entry; the assertion checked `x402Version` and a non-empty array, so an entry missing `maxTimeoutSeconds` — which Step 3 needs for `validBefore` — passed.
- Step 4's Expected opens "HTTP `200`", with the same gap.
- Step 4 guarded `[ -s payload.json ]` while Step 3's Expected promises a `PaymentPayload` with three named fields, so a stub `{}` passed.

Each assertion is now the Expected sentence itself.

Minor: Step 2's error for an empty `accepts` array read `unsupported-scheme: ` with nothing after the colon; the base64 sentence claimed "servers observed in the wild" on a sample of one endpoint.

## Measurements

| What | Against | Result |
|---|---|---|
| Step 1 fence, verbatim | live `402` (unpaid GET) | exit 0, 6691 bytes; standard base64, `=`-padded; all six promised fields present in all three `accepts` entries |
| Step 1 fence | `402` with no header | **exit 0 before, exit 1 after** |
| Step 1 fence | base64url header, `null`, `accepts: []`, `x402Version: 1` | exit 1 each — the last three pass a bare emptiness check |
| Step 2 gate, sliced out of the file at run time | 8 fixtures incl. @cv-scvd's three | all as documented; the live mainnet challenge refused with `mainnet-not-opted-in` |
| Step 1 fence | complete challenge / entry missing a field / `200` / HTTP-1.1 status line | 0,1,1,0 |
| Step 4 decode tail (curl removed) | settled / no `transaction` / no header / `null` / no `payload.json` / stub `payload.json` | **0,0,0,0,0,0 before; 0,1,1,1,1,1 after** |
| Step 5 EVM fence | a real Base Sepolia USDC transfer | `status: 0x1`; `topics[2]` the padded recipient, `.data` the atomic value |
| Step 5 SVM fence (new) | a real USDC transfer | `postTokenBalances` carry the `mint`, `owner` and `amount` the comment tells the agent to compare |
| Offer artifacts | the live challenge's `offer-receipt` extension | JWS `kid` is a DID URL (`did:web:…#key-2`); all seven required offer fields present |

Steps 3 and 4's `curl` still need a funded wallet and remain unexecuted; nothing here claims otherwise.

## Mirrors

Fences propagated to all four stubs, verified by bytes:

```
npm run check:fence-propagation -- --id test-x402-payment-client
test-x402-payment-client (skills): 4 of 4 mirror(s) alignable, 4 frozen of 4 fence(s)
  OK — 4 frozen fence(s) byte-identical across 4 mirror(s)
```

The stamp commits are split out because the sha a `fence_basis_commit` must name does not exist until the commit it names has been written. All four are untranslated stubs, so moving `source_commit` forward costs no human translation.

## Review

An `advocatus-diaboli` pass, two rounds. Round 1 graded a copy I refreshed after telling it to re-read — its two BLOCKING findings were already fixed and were withdrawn. Round 2 reported **no BLOCKING findings** and five standing items, all applied in `dc062c0e9`: the missing `scheme_exact_svm.md` and `extension-offer-and-receipt.md` citations (the SVM filter's licence is a sentence in the first of those), Step 3 never naming the client under test as the actor, the `eth_blockNumber` call this PR's own measurement log recorded as missing and the earlier commits half-fixed, `success: false` as an unnamed `settled-unverified` trigger, and the wrong-version case missing from Step 1's Expected. Details and the two findings not applied are in the [review comment](https://github.com/pjt222/agent-almanac/pull/788#issuecomment-5538877506).

## Not in scope

The viz palette, domain style, glyph and icon for `agent-commerce` remain #781.

Two gaps this audit surfaced are filed rather than fixed here: #789 (nothing in the repository can refresh an untranslated i18n stub after an English fence edit — `translate:scaffold` SKIPs an existing target and the fence normalizer has no `--id` scope, so this PR carried a scratchpad script through four fence commits) and #790 (no agent lists the skill, and B5 measures skill-to-skill references only, so the green it now reports is not evidence of reachability).

One thing this PR does fix beyond the fences: `validate:integrity` B5 reported `test-x402-payment-client` as an orphan — registered but referenced nowhere outside its own directory and the registry. `test-a2a-interop` now links to it, and B5 reports "No orphan skills detected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dp5MW8ckZPKBqADkYui5E



