### PR TITLE
docs(contributing): incoming-contribution policy, PR template, and the contributor/maintainer split (#765)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
-<!-- Paired with CONTRIBUTING.md § Adding a skill. The checklist below mirrors that section's
-     contributor steps, item for item; change both or neither. -->
+<!-- Paired with CONTRIBUTING.md. The checklist below carries § Adding a skill — its four
+     contributor steps and its four one-line checks — plus the acceptance rules from § What the
+     library accepts and the not-yours line from § Maintainer steps. Change both or neither. -->
 
 ## Why
 
@@ -18,6 +19,7 @@
 - [ ] Symlink `.claude/skills/<skill-name>` → `../../skills/<skill-name>`, committed
 - [ ] Local checks run and clean (CONTRIBUTING.md § Local checks)
 - [ ] `description` is mine, not the template's; `allowed-tools` matches what the procedure invokes; every fence has been run, not only read
+- [ ] No file or directory in the skill carries a name from `USER_OWNED_EXCLUDE` or `EXCLUDED_SKILL_DIRS` (`scripts/build-hermes-distribution.js`), no directory starts with `_` or `.`, nothing in it is a symlink
 - [ ] Vendor-neutral: works against any conforming target, one vendor location at most, no attribution parameters, sandbox first with the live path opt-in
 - [ ] I did **not** scaffold translations or regenerate READMEs — those are maintainer steps at merge, and CONTRIBUTING.md says why
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- Paired with CONTRIBUTING.md § Adding a skill. The checklist below mirrors that section's
+     contributor steps, item for item; change both or neither. -->
+
+## Why
+
+<!-- The gap this fills or the defect it fixes, in a paragraph. Link the issue if one exists. -->
+
+## What
+
+<!-- What changed, in the order a reviewer should read it. -->
+
+## Checklist for a new skill
+
+<!-- Delete this section if the PR adds no skill. -->
+
+- [ ] `skills/<skill-name>/SKILL.md` from `skills/_template/SKILL.md`, with all six sections — When to Use, Inputs, Procedure, Validation, Common Pitfalls, Related Skills — under 500 lines, every code fence tagged
+- [ ] Entry in `skills/_registry.yml` under a domain, and `total_skills` bumped by one
+- [ ] Symlink `.claude/skills/<skill-name>` → `../../skills/<skill-name>`, committed
+- [ ] Local checks run and clean (CONTRIBUTING.md § Local checks)
+- [ ] `description` is mine, not the template's; `allowed-tools` matches what the procedure invokes; every fence has been run, not only read
+- [ ] Vendor-neutral: works against any conforming target, one vendor location at most, no attribution parameters, sandbox first with the live path opt-in
+- [ ] I did **not** scaffold translations or regenerate READMEs — those are maintainer steps at merge, and CONTRIBUTING.md says why
+
+## How I checked
+
+<!-- Which of the local checks you ran and what they printed; anything you executed rather than read. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 <!-- Paired with CONTRIBUTING.md. The checklist below carries § Adding a skill — its four
      contributor steps and its four one-line checks — plus the acceptance rules from § What the
-     library accepts and the not-yours line from § Maintainer steps. Change both or neither. -->
+     library accepts and the two maintainer steps a contributor must leave out. Change both or
+     neither. -->
 
 ## Why
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,14 +263,16 @@ Agents that may run shell commands should also carry the `REPO_SAFETY` preamble 
 
 ## Adding a New Skill
 
-1. Create `skills/<skill-name>/SKILL.md` following the format of existing skills
-2. Add the entry to `skills/_registry.yml` under the appropriate domain
-3. Update `total_skills` count in `_registry.yml`
-4. Symlink into `.claude/skills/`: `ln -s ../../skills/<skill-name> .claude/skills/<skill-name>`
-5. Reference related skills in the new skill's "Related Skills" section
-6. Run `npm run update-readmes` (or let CI auto-commit on push to main)
-7. **Scaffold translations** (required — do not skip): `for locale in de zh-CN ja es; do npm run translate:scaffold -- skills <skill-name> "$locale"; done && npm run translation:status`
-8. The meta-skill at `skills/create-skill/SKILL.md` documents this process in detail
+The contributor's half — `SKILL.md` from the template with its six sections, the registry entry
+with its `total_skills` bump, the `.claude/skills/` symlink, and the local checks — lives in
+[CONTRIBUTING.md](CONTRIBUTING.md) § Adding a skill and is deliberately not repeated here (#765).
+Follow it first, whether the author is an external contributor or this session. What follows is
+the maintainer's half, run at merge and never asked of a contributor:
+
+1. Run `npm run update-readmes` (or let CI auto-commit on push to main)
+2. **Scaffold translations** (required — do not skip, and do not run early): `for locale in de zh-CN ja es; do npm run translate:scaffold -- skills <skill-name> "$locale"; done && npm run translation:status`. A scaffold copies the English bytes at the moment it runs, so it is made once, after the English is committed and final — on an external PR that means after merge, never while the PR is still being revised (#765 finding 2)
+3. For a new domain, the viz wiring — palette, glyph, icon, `skills.json` — becomes its own issue (#781 is the shape)
+4. The meta-skill at `skills/create-skill/SKILL.md` documents the full authoring procedure in detail
 
 ## Adding a New Agent
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,7 +170,7 @@ them on your PR, say so in the thread; it is not yours to fix.
   palette entry, glyph and icon. These become their own issue when a merge creates the need.
 - **The global discovery hub** on the maintainer's machine.
 
-### Local checks — the same commands CI runs
+### Local checks — what CI runs, plus the setup a fork needs
 
 Commit your work first: the style check diffs `<base>...HEAD`, so uncommitted changes — staged
 or not — are invisible to it, and it reports a clean run over nothing. `<base>` is this
@@ -180,13 +180,14 @@ run it again before each later round). The line-endings check is the one excepti
 the index, so `git add` is enough there.
 
 ```bash
-# On a fork only. Safe to paste every round: the first line adds the remote once, the second refreshes it.
-git remote get-url upstream >/dev/null 2>&1 || git remote add upstream https://github.com/pjt222/agent-almanac.git
+# On a fork only; safe to paste every round. The first line adds the remote once — and errors,
+# rather than silently using it, if you already have an `upstream` that points somewhere else.
+git remote get-url upstream 2>/dev/null | grep -q "github.com/pjt222/agent-almanac" || git remote add upstream https://github.com/pjt222/agent-almanac.git
 git fetch upstream main
 
 npm ci
 node scripts/audit-skill-sections.js --missing         # the six sections and a non-empty Common Pitfalls; "0 skill(s) reported" when clean
-lines=$(wc -l < skills/<skill-name>/SKILL.md); [ "$lines" -le 500 ] || { echo "FAIL: $lines lines > 500"; false; }   # the 500-line ceiling, counted the way CI counts it; silent when clean
+lines=$(wc -l < skills/<skill-name>/SKILL.md); [ "${lines:?no such file - check the path}" -le 500 ] || { echo "FAIL: $lines lines > 500"; false; }   # the 500-line ceiling, counted the way CI counts it; silent when clean
 node scripts/check-content-style.js --added <base>     # bare fences and table rules, on committed added lines
 npm run validate:line-endings                          # any CRLF in the index fails
 npm run validate:integrity                             # registry entry, symlink, cross-references

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,228 @@
+# Contributing
+
+Agent Almanac is a library of procedures for AI agents, written to the
+[Agent Skills](https://agentskills.io) open standard. This file is for anyone opening a pull
+request or an issue from outside the project. It states what the library accepts, what a skill
+PR must contain, which of the steps are yours and which are the maintainer's, and what to expect
+once you have opened it.
+
+The rules below are the ones that decided the first two external pull requests,
+[#589](https://github.com/pjt222/agent-almanac/pull/589) and
+[#763](https://github.com/pjt222/agent-almanac/pull/763). Both met them blind, because until
+then the rules lived only in `CLAUDE.md`, a file written for Claude Code sessions rather than for
+a person reading the repository on GitHub. Where a rule is enforced by a CI check, the check is
+named; where it is applied in review, that is said too.
+
+## What the library accepts
+
+**Skills are vendor-neutral procedures.** A skill describes how to do something so that any
+agent, on any tool, can follow it. It is not a product listing, and it is not a place to promote a
+service to the agents that read it. The working principle is *serve AI systems, don't promote to
+them*.
+
+A procedure may mention a product. What decides is the shape:
+
+- A skill whose procedure works against any conforming target, with one product as a worked
+  example, is a procedure. It fits.
+- A skill whose procedure only works against one product, however well built, is a listing. It
+  does not fit — but its generalisation usually does, and the reply will say what that
+  generalisation looks like rather than close the door. #763 arrived as the second shape and was
+  merged as the first, reworked by its author.
+
+Three rules follow from the principle. They are applied in review:
+
+- **One vendor location, not two.** A product may appear as a worked example, in one place — the
+  Examples section, or one named step. It must not also be the thing a required section defers
+  to: a Validation section describes the mechanism, not a vendor's checker.
+- **No attribution tracking.** No `?src=` or `?ref=` parameters on URLs, no tracking pixels, no
+  "powered by" lines. A skill is read by agents on behalf of people who did not choose it.
+- **Sandbox first; real money and real damage are opt-in.** A procedure that can move funds,
+  delete data, or change a live system makes the testnet, sandbox, or dry run its primary path
+  and gates the live path behind an explicit input the reader has to set. "Be careful" in prose is
+  not a gate. The merged form of #763 refuses a mainnet network unless `MAINNET_OPTIN=true` is
+  set, and that is the pattern.
+
+### Why the third rule is policy text and not a gate
+
+`scripts/scan-skill-content.js` runs on every pull request as the `content-security` check. It
+scans every file under a skill for credential shapes, and every committed executable under a
+skill's `scripts/` directory for dangerous invocations. It does not read the procedure's prose,
+and that scoping is deliberate: install skills legitimately document `curl … | sh`, so a prose
+scan false-fires on real content. Whether a procedure's *primary path* is a sandbox is not a
+syntactic property either — the same sentence is fine as a pitfall and wrong as Step 1. So this
+rule is stated here and applied in review. That is the recorded decision on #765 finding 4:
+policy text, not a gate. A mechanical form that does not false-fire would be welcome as an
+addition, not as a replacement for this paragraph.
+
+## What to expect from us
+
+Agent Almanac has one maintainer. There is no service-level agreement, but there is a track
+record, and the thresholds below are commitments in both directions.
+
+| You opened | What happens first | Nudge us after | We close after |
+|---|---|---|---|
+| A skill, agent, team, or guide PR | A substantive first reply — both external PRs so far got one within a day | 14 days of silence | 60 days of your silence following a change request |
+| A translation PR | A reply once the fence and frontmatter gates have run; the prose is read by a person | 14 days | 60 days, as above |
+| A bug report or a security finding | Triage written into the thread with the reasoning — #589 is the shape | 7 days | Never on age alone; on a decision, with the reason stated |
+| A question or a proposal | An answer, or a pointer to the issue that already owns it | 14 days | When answered |
+
+A pull request that is not merged is closed with the reason written into the thread. Your branch
+stays on your fork, the closing comment says so, and a reopen is welcome if the reason changes.
+Silence, age, and merge conflicts are not by themselves reasons to close — a conflict is a request
+to rebase, and the thread will say so.
+
+Three mechanics worth knowing before you open a PR:
+
+- **Leave "Allow edits by maintainers" on.** It is the default for a fork PR. On #763 it let the
+  review fixes land as commits on top of the author's own, with the author's commits untouched and
+  every edit listed in the thread for a veto before merge. Without it, each small fix is another
+  round trip.
+- **Merges are merge commits, never squashes.** Your commits keep their authorship and their
+  messages.
+- **Your PR reports checks.** Measured on #763: the checks on the contributor's first commit
+  started three seconds after the PR was opened and seven hours before the maintainer's first
+  comment. Two of them were red, and the red lines named exactly the items this file's checklist
+  now covers. If you ever see an *empty* check list on your PR, say so in the thread rather than
+  read it as a pass — that is what the first external PR, #589, got, before the fork-PR policy was
+  changed.
+
+## Adding a skill
+
+The steps are split in two, and the split is not cosmetic. The contributor's steps are the ones
+the CI checks read. The maintainer's steps run **once, at merge, after the English text is
+final** — and one of them is actively harmful if run earlier.
+
+### Your steps — what the PR must contain
+
+1. **`skills/<skill-name>/SKILL.md`, copied from `skills/_template/SKILL.md`.** The name is
+   lowercase kebab-case, starts with a verb, and is the directory name. The file carries the
+   template's frontmatter and all six required sections as `##` headings:
+
+   - When to Use
+   - Inputs
+   - Procedure — numbered steps, each with a fenced command, an **Expected:** line and an
+     **On failure:** line
+   - Validation
+   - Common Pitfalls
+   - Related Skills
+
+   The `skills` check enforces the six headings and a 500-line ceiling; the step shape is read in
+   review. Extended examples go in `references/EXAMPLES.md` rather than the main file. Every code
+   fence carries a language tag (` ```bash `, ` ```yaml `, ` ```text `), never a bare
+   ` ``` ` — the `content-style` check fails a bare fence on any added line.
+
+2. **A registry entry in `skills/_registry.yml`**, under a domain — add one if none fits; several
+   domains hold a single skill — plus the `total_skills` count at the top of that file bumped by
+   one. Copy the shape of a neighbouring entry: `path` is relative to `skills/`, so it reads
+   `<skill-name>/SKILL.md`. The `skills` check compares the count against the directories on
+   disk, and the `integrity` check refuses a skill on disk that has no entry.
+
+3. **A discovery symlink**, so Claude Code finds the skill as a slash command in this repository:
+
+   ```bash
+   ln -s ../../skills/<skill-name> .claude/skills/<skill-name>
+   git add .claude/skills/<skill-name>
+   ```
+
+   It is a git symlink and is committed. The `integrity` check fails on its absence — that was one
+   of the two red lines on #763's first push. On Windows, git needs `core.symlinks=true` to create
+   and check out symlinks; WSL is the easier path. The maintainer's own tool for this,
+   `scripts/sync-discovery-symlinks.sh --fix`, also writes to the global `~/.claude/skills/` hub
+   on whatever machine runs it, so the one-line form above is the right one for a contributor.
+
+4. **Run the local checks** in the section below and fix what they report.
+
+Optional, welcome, and never required for a merge: a test scenario under `tests/scenarios/skills/`
+made from `tests/_template.md`, and a `references/EXAMPLES.md`.
+
+Four things measured on the first two external PRs, each one line to check:
+
+- `description` in the frontmatter is your text, not the template's — the template's own
+  "Max 1024 characters." note has shipped in a PR before.
+- `allowed-tools` names the tools the procedure actually invokes. A procedure that makes HTTP
+  calls cannot run under `allowed-tools: Read`.
+- The commands are runnable as written. Reviewers execute fences rather than only read them, and
+  the defects found on #763 after it merged were all in fences that had been read but never run.
+- No directory inside the skill is named `bin`, `cache`, `logs`, `memories`, `sessions`,
+  `workspace`, `backups`, or `node_modules`, none starts with `_` or `.`, and nothing inside it is
+  a symlink. A downstream distribution filters those names at any depth, and the `skills` check
+  refuses them here so they cannot vanish silently there. The full list is `USER_OWNED_EXCLUDE`
+  in `scripts/build-hermes-distribution.js`.
+
+### Maintainer steps — run at merge, not in your PR
+
+These are listed so you know they exist and can leave them out. If a check goes red for one of
+them on your PR, say so in the thread; it is not yours to fix.
+
+- **Translation scaffolds** for every locale under `i18n/`. A scaffold copies the English bytes
+  at the moment it runs, so one made while a PR is still being revised leaves every mirror stale
+  after the next push. That is why it runs once, after merge, and why a contributor is asked
+  *not* to run `npm run translate:scaffold`.
+- **README regeneration** (`npm run update-readmes`). The generated index sections are rebuilt by
+  CI on push to `main`, and a PR that touches only content does not trigger the `readmes` check
+  at all. Running it locally is harmless if you want to; it is not on your list.
+- **The visualization's data and icons** — `viz/public/data/skills.json`, and for a new domain a
+  palette entry, glyph and icon. These become their own issue when a merge creates the need.
+- **The global discovery hub** on the maintainer's machine.
+
+### Local checks — the same commands CI runs
+
+Stage your files first (`git add`): the style check diffs tracked state, so an untracked file
+contributes nothing to it. `<base>` is the ref you branched from — `origin/main` on a clone of
+this repository, `upstream/main` on a fork that keeps this repository as `upstream`.
+
+```bash
+npm ci
+node scripts/audit-skill-sections.js --missing         # the six sections; "0 skill(s) reported" when clean
+node scripts/check-content-style.js --added <base>     # bare fences and table rules, on added lines only
+npm run validate:line-endings                          # any CRLF in the index fails
+npm run validate:integrity                             # registry entry, symlink, cross-references
+npm run validate:security                              # credential shapes, dangerous executables
+npm run check:hermes-distribution                      # the excluded-name and symlink rules above
+```
+
+Two more that CI runs and you may not be able to: `skills-ref validate skills/<skill-name>`, the
+reference validator from [agentskills/agentskills](https://github.com/agentskills/agentskills),
+installed with pip (CI pins a commit); and `claude plugin validate .`, which needs the Claude
+Code CLI and, on a clean tree, passes with two warnings — one about `CLAUDE.md`, one about
+`agents/README.md` — that are expected and not yours.
+
+`npm test` is the maintainer's release gate, not a contributor check: it includes a
+generated-README comparison that goes red on any registry change until the maintainer
+regenerates.
+
+### Which checks report, and which can refuse the merge
+
+A skill PR reports these contexts, measured on #763's first commit: `banned-invocations`,
+`cli-test`, `content-security`, `content-style`, `integrity`, `line-endings`, `scripts-test`,
+`skills`, `tests`, `yaml-fences`. Five of them are required by branch protection and refuse the
+merge while red: `line-endings`, `integrity`, `skills`, `scripts-test`, `cli-test`. The others
+go red visibly and are still findings to fix — the distinction only decides whether the merge
+button works, not whether a red is merged past. It is stated here so a red check does not read as
+a judgement call in the thread.
+
+## Other contributions
+
+- **Agents, teams and guides** follow the same split: the file and its registry entry are yours;
+  README regeneration and translation scaffolds are the maintainer's. The templates are
+  `agents/_template.md`, `teams/_template.md` and `guides/_template.md`, and each type's README
+  states its required sections. An agent lists at most five core skills in frontmatter —
+  [`guides/agent-best-practices.md`](guides/agent-best-practices.md) says why.
+- **Translations** have their own contributor guide at [`i18n/README.md`](i18n/README.md). The one
+  rule that surprises people: a code fence stays byte-identical to the English unless it is tagged
+  `text`, `markdown` or `md`, and a gate checks each fence against every revision of the English
+  file.
+- **Bug reports** are GitHub issues. The most useful report names the command, the measured
+  output, and the expected output. The reasoning written into the close of #589 is the shape of
+  triage you will get back.
+- **Security findings** follow [`SECURITY.md`](SECURITY.md): a public issue, no private channel,
+  no guaranteed timeline. Read its scope section first — `scripts/` does not ship in the npm
+  package, so a finding against it has a different threat model from one against `cli/`.
+
+## Commits, licence, and the PR text
+
+Commit subjects here follow the conventional-commits shape — `feat(<skill-name>): …`, `fix(…)`,
+`docs(…)`, `chore(…)`. It is a convention, not a gate; a clear message in another shape will not
+be bounced. The pull-request template in `.github/` carries the checklist above: fill in the why,
+tick what applies, delete what does not. Everything you contribute is licensed under the
+repository's [MIT licence](LICENSE), with you as its author in git history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,8 +183,8 @@ ceiling line's path guard ends the script at a mistyped path instead of ending t
 ```bash
 # On a fork only; safe to paste every round. The first line adds the remote once — and errors,
 # rather than silently using it, if you already have an `upstream` that points somewhere else
-# (https and ssh forms of this repository both pass; a longer repository name does not).
-git remote get-url upstream 2>/dev/null | grep -qE "github\.com[:/]pjt222/agent-almanac(\.git)?$" || git remote add upstream https://github.com/pjt222/agent-almanac.git
+# (https and ssh forms of this repository pass, with or without a port; a longer repository name does not).
+git remote get-url upstream 2>/dev/null | grep -qE "github\.com(:[0-9]+)?[:/]pjt222/agent-almanac(\.git)?$" || git remote add upstream https://github.com/pjt222/agent-almanac.git
 git fetch upstream main
 
 npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,13 @@ request or an issue from outside the project. It states what the library accepts
 PR must contain, which of the steps are yours and which are the maintainer's, and what to expect
 once you have opened it.
 
-The rules below are the ones that decided the first two external pull requests,
-[#589](https://github.com/pjt222/agent-almanac/pull/589) and
-[#763](https://github.com/pjt222/agent-almanac/pull/763). Both authors ran into them blind,
-because until then the rules lived only in `CLAUDE.md`, a file written for Claude Code sessions
-rather than for a person reading the repository on GitHub. Where a rule is enforced by a CI
-check, the check is named; where it is applied in review, that is said too.
+The rules below are the ones that decided [#763](https://github.com/pjt222/agent-almanac/pull/763),
+the first external skill PR; the triage that closed
+[#589](https://github.com/pjt222/agent-almanac/pull/589), the first external contribution of any
+kind, is the shape described under "What to expect from us". Both authors arrived at an
+undocumented repository, because until then the rules lived only in `CLAUDE.md`, a file written
+for Claude Code sessions rather than for a person reading the repository on GitHub. Where a rule
+is enforced by a CI check, the check is named; where it is applied in review, that is said too.
 
 ## What the library accepts
 
@@ -179,8 +180,8 @@ run it again before each later round). The line-endings check is the one excepti
 the index, so `git add` is enough there.
 
 ```bash
-# On a fork only — once to add the remote, and again before each round to refresh it:
-git remote add upstream https://github.com/pjt222/agent-almanac.git
+# On a fork only. Safe to paste every round: the first line adds the remote once, the second refreshes it.
+git remote get-url upstream >/dev/null 2>&1 || git remote add upstream https://github.com/pjt222/agent-almanac.git
 git fetch upstream main
 
 npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ git fetch upstream main
 
 npm ci
 node scripts/audit-skill-sections.js --missing         # the six sections and a non-empty Common Pitfalls; "0 skill(s) reported" when clean
-awk 'END { if (NR > 500) { print "FAIL: " NR " lines > 500"; exit 1 } }' skills/<skill-name>/SKILL.md   # the 500-line ceiling; silent when clean
+lines=$(wc -l < skills/<skill-name>/SKILL.md); [ "$lines" -le 500 ] || { echo "FAIL: $lines lines > 500"; false; }   # the 500-line ceiling, counted the way CI counts it; silent when clean
 node scripts/check-content-style.js --added <base>     # bare fences and table rules, on committed added lines
 npm run validate:line-endings                          # any CRLF in the index fails
 npm run validate:integrity                             # registry entry, symlink, cross-references

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ The rules below are the ones that decided the first two external pull requests,
 [#589](https://github.com/pjt222/agent-almanac/pull/589) and
 [#763](https://github.com/pjt222/agent-almanac/pull/763). Both authors ran into them blind,
 because until then the rules lived only in `CLAUDE.md`, a file written for Claude Code sessions
-rather than for a person reading the repository on GitHub. Where a rule is enforced by a CI check, the check is
-named; where it is applied in review, that is said too.
+rather than for a person reading the repository on GitHub. Where a rule is enforced by a CI
+check, the check is named; where it is applied in review, that is said too.
 
 ## What the library accepts
 
@@ -61,9 +61,9 @@ the track record; the other three are defaults, set in this file and changed by 
 
 | You opened | What happens first | Nudge us after | We close after |
 |---|---|---|---|
-| A skill, agent, team, or guide PR | A substantive first reply — the first two external PRs, #589 and #763, each got one within a day | 14 days of silence | 60 days of your silence following a change request |
+| A skill, agent, team, or guide PR | A substantive first reply — #763, the first skill PR from outside, got one within a day | 14 days of silence | 60 days of your silence following a change request |
 | A translation PR | A reply once the fence and frontmatter gates have run; the prose is read by a person | 14 days | 60 days, as above |
-| A bug report or a security finding | Triage written into the thread with the reasoning — the close of #589, a security patch that arrived as a PR, is the shape | 7 days | Never on age alone; on a decision, with the reason stated |
+| A bug report or a security finding | Triage written into the thread with the reasoning — the close of #589 is the shape, and it came within a day | 7 days | Never on age alone; on a decision, with the reason stated |
 | A question or a proposal | An answer, or a pointer to the issue that already owns it | 14 days | When answered |
 
 A pull request that is not merged is closed with the reason written into the thread. Your branch
@@ -144,7 +144,8 @@ Four things a first push has tripped on, or a gate refuses, each one line to che
 - `allowed-tools` names the tools the procedure actually invokes. #763's first push declared
   `allowed-tools: Read` for a procedure built on HTTP calls; this is read in review, not by a gate.
 - The commands are runnable as written. Reviewers execute fences rather than only read them, and
-  the defects found on #763 after it merged were in fences that had been read but never run.
+  the defects found on #763 after it merged were in fences that everyone, the maintainer
+  included, had read and nobody had run.
 - No file or directory inside the skill is named `bin`, `cache`, `logs`, `memories`, `sessions`,
   `workspace`, `backups`, `node_modules`, `venv` or `site-packages` — the full lists are
   `USER_OWNED_EXCLUDE` and `EXCLUDED_SKILL_DIRS` in `scripts/build-hermes-distribution.js` — no
@@ -158,10 +159,9 @@ These are listed so you know they exist and can leave them out. If a check goes 
 them on your PR, say so in the thread; it is not yours to fix.
 
 - **Translation scaffolds** for the four translated locales (`de`, `zh-CN`, `ja`, `es`). A
-  scaffold copies the English bytes
-  at the moment it runs, so one made while a PR is still being revised leaves every mirror stale
-  after the next push. That is why it runs once, after merge, and why a contributor is asked
-  *not* to run `npm run translate:scaffold`.
+  scaffold copies the English bytes at the moment it runs, so one made while a PR is still being
+  revised leaves every mirror stale after the next push. That is why it runs once, after merge,
+  and why a contributor is asked *not* to run `npm run translate:scaffold`.
 - **README regeneration** (`npm run update-readmes`). The generated index sections are rebuilt by
   CI on push to `main`, and a PR that touches only content does not trigger the `readmes` check
   at all. Running it locally is harmless if you want to; it is not on your list.
@@ -173,12 +173,16 @@ them on your PR, say so in the thread; it is not yours to fix.
 
 Commit your work first: the style check diffs `<base>...HEAD`, so uncommitted changes — staged
 or not — are invisible to it, and it reports a clean run over nothing. `<base>` is this
-repository's `main` as your clone knows it: `origin/main` on a clone of this repository; on a
-fork, add this repository as a remote and fetch it first (`git remote add upstream
-https://github.com/pjt222/agent-almanac.git && git fetch upstream main`), then `upstream/main`.
-The line-endings check is the one exception: it reads the index, so `git add` is enough there.
+repository's `main` as your clone knows it — `origin/main` on a clone of this repository,
+`upstream/main` on a fork once the two setup lines below have run (the fetch is one-shot, so
+run it again before each later round). The line-endings check is the one exception: it reads
+the index, so `git add` is enough there.
 
 ```bash
+# On a fork only — once to add the remote, and again before each round to refresh it:
+git remote add upstream https://github.com/pjt222/agent-almanac.git
+git fetch upstream main
+
 npm ci
 node scripts/audit-skill-sections.js --missing         # the six sections and a non-empty Common Pitfalls; "0 skill(s) reported" when clean
 awk 'END { if (NR > 500) { print "FAIL: " NR " lines > 500"; exit 1 } }' skills/<skill-name>/SKILL.md   # the 500-line ceiling; silent when clean

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,12 +177,14 @@ or not — are invisible to it, and it reports a clean run over nothing. `<base>
 repository's `main` as your clone knows it — `origin/main` on a clone of this repository,
 `upstream/main` on a fork once the two setup lines below have run (the fetch is one-shot, so
 run it again before each later round). The line-endings check is the one exception: it reads
-the index, so `git add` is enough there.
+the index, so `git add` is enough there. Paste the block interactively: saved as a script, the
+ceiling line's path guard ends the script at a mistyped path instead of ending the one check.
 
 ```bash
 # On a fork only; safe to paste every round. The first line adds the remote once — and errors,
-# rather than silently using it, if you already have an `upstream` that points somewhere else.
-git remote get-url upstream 2>/dev/null | grep -q "github.com/pjt222/agent-almanac" || git remote add upstream https://github.com/pjt222/agent-almanac.git
+# rather than silently using it, if you already have an `upstream` that points somewhere else
+# (https and ssh forms of this repository both pass; a longer repository name does not).
+git remote get-url upstream 2>/dev/null | grep -qE "github\.com[:/]pjt222/agent-almanac(\.git)?$" || git remote add upstream https://github.com/pjt222/agent-almanac.git
 git fetch upstream main
 
 npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,8 @@ The line-endings check is the one exception: it reads the index, so `git add` is
 
 ```bash
 npm ci
-node scripts/audit-skill-sections.js --missing         # the six sections; "0 skill(s) reported" when clean
+node scripts/audit-skill-sections.js --missing         # the six sections and a non-empty Common Pitfalls; "0 skill(s) reported" when clean
+awk 'END { if (NR > 500) { print "FAIL: " NR " lines > 500"; exit 1 } }' skills/<skill-name>/SKILL.md   # the 500-line ceiling; silent when clean
 node scripts/check-content-style.js --added <base>     # bare fences and table rules, on committed added lines
 npm run validate:line-endings                          # any CRLF in the index fails
 npm run validate:integrity                             # registry entry, symlink, cross-references

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ once you have opened it.
 
 The rules below are the ones that decided the first two external pull requests,
 [#589](https://github.com/pjt222/agent-almanac/pull/589) and
-[#763](https://github.com/pjt222/agent-almanac/pull/763). Both met them blind, because until
-then the rules lived only in `CLAUDE.md`, a file written for Claude Code sessions rather than for
-a person reading the repository on GitHub. Where a rule is enforced by a CI check, the check is
+[#763](https://github.com/pjt222/agent-almanac/pull/763). Both authors ran into them blind,
+because until then the rules lived only in `CLAUDE.md`, a file written for Claude Code sessions
+rather than for a person reading the repository on GitHub. Where a rule is enforced by a CI check, the check is
 named; where it is applied in review, that is said too.
 
 ## What the library accepts
@@ -56,14 +56,14 @@ addition, not as a replacement for this paragraph.
 
 ## What to expect from us
 
-Agent Almanac has one maintainer. There is no service-level agreement, but there is a track
-record, and the thresholds below are commitments in both directions.
+Agent Almanac has one maintainer. There is no service-level agreement. The first column below is
+the track record; the other three are defaults, set in this file and changed by editing it.
 
 | You opened | What happens first | Nudge us after | We close after |
 |---|---|---|---|
-| A skill, agent, team, or guide PR | A substantive first reply — both external PRs so far got one within a day | 14 days of silence | 60 days of your silence following a change request |
+| A skill, agent, team, or guide PR | A substantive first reply — the first two external PRs, #589 and #763, each got one within a day | 14 days of silence | 60 days of your silence following a change request |
 | A translation PR | A reply once the fence and frontmatter gates have run; the prose is read by a person | 14 days | 60 days, as above |
-| A bug report or a security finding | Triage written into the thread with the reasoning — #589 is the shape | 7 days | Never on age alone; on a decision, with the reason stated |
+| A bug report or a security finding | Triage written into the thread with the reasoning — the close of #589, a security patch that arrived as a PR, is the shape | 7 days | Never on age alone; on a decision, with the reason stated |
 | A question or a proposal | An answer, or a pointer to the issue that already owns it | 14 days | When answered |
 
 A pull request that is not merged is closed with the reason written into the thread. Your branch
@@ -73,10 +73,10 @@ to rebase, and the thread will say so.
 
 Three mechanics worth knowing before you open a PR:
 
-- **Leave "Allow edits by maintainers" on.** It is the default for a fork PR. On #763 it let the
-  review fixes land as commits on top of the author's own, with the author's commits untouched and
-  every edit listed in the thread for a veto before merge. Without it, each small fix is another
-  round trip.
+- **Leave "Allow edits by maintainers" ticked** — GitHub ticks it by default when a PR comes from
+  a fork. On #763 it is what let the review fixes land on the author's own branch: the PR's commit
+  list shows the author's two commits untouched and the fixes on top, each listed in the thread for
+  a veto before merge. Without it, each small fix is another round trip.
 - **Merges are merge commits, never squashes.** Your commits keep their authorship and their
   messages.
 - **Your PR reports checks.** Measured on #763: the checks on the contributor's first commit
@@ -106,10 +106,12 @@ final** — and one of them is actively harmful if run earlier.
    - Common Pitfalls
    - Related Skills
 
-   The `skills` check enforces the six headings and a 500-line ceiling; the step shape is read in
-   review. Extended examples go in `references/EXAMPLES.md` rather than the main file. Every code
-   fence carries a language tag (` ```bash `, ` ```yaml `, ` ```text `), never a bare
-   ` ``` ` — the `content-style` check fails a bare fence on any added line.
+   The `skills` check enforces the six headings, at least one entry under Common Pitfalls, and a
+   500-line ceiling; the step shape is read in review. Extended examples go in
+   `references/EXAMPLES.md` rather than the main file. Every code fence carries a language tag
+   (` ```bash `, ` ```yaml `, ` ```text `), never a bare ` ``` ` — the required `skills` check
+   fails on any untagged fence in the English content trees, and `content-style` fails one on any
+   added line as well.
 
 2. **A registry entry in `skills/_registry.yml`**, under a domain — add one if none fits; several
    domains hold a single skill — plus the `total_skills` count at the top of that file bumped by
@@ -135,26 +137,28 @@ final** — and one of them is actively harmful if run earlier.
 Optional, welcome, and never required for a merge: a test scenario under `tests/scenarios/skills/`
 made from `tests/_template.md`, and a `references/EXAMPLES.md`.
 
-Four things measured on the first two external PRs, each one line to check:
+Four things a first push has tripped on, or a gate refuses, each one line to check:
 
-- `description` in the frontmatter is your text, not the template's — the template's own
-  "Max 1024 characters." note has shipped in a PR before.
-- `allowed-tools` names the tools the procedure actually invokes. A procedure that makes HTTP
-  calls cannot run under `allowed-tools: Read`.
+- `description` in the frontmatter is your text, not the template's — #763's first push still
+  carried the template's own "Max 1024 characters." note.
+- `allowed-tools` names the tools the procedure actually invokes. #763's first push declared
+  `allowed-tools: Read` for a procedure built on HTTP calls; this is read in review, not by a gate.
 - The commands are runnable as written. Reviewers execute fences rather than only read them, and
-  the defects found on #763 after it merged were all in fences that had been read but never run.
-- No directory inside the skill is named `bin`, `cache`, `logs`, `memories`, `sessions`,
-  `workspace`, `backups`, or `node_modules`, none starts with `_` or `.`, and nothing inside it is
-  a symlink. A downstream distribution filters those names at any depth, and the `skills` check
-  refuses them here so they cannot vanish silently there. The full list is `USER_OWNED_EXCLUDE`
-  in `scripts/build-hermes-distribution.js`.
+  the defects found on #763 after it merged were in fences that had been read but never run.
+- No file or directory inside the skill is named `bin`, `cache`, `logs`, `memories`, `sessions`,
+  `workspace`, `backups`, `node_modules`, `venv` or `site-packages` — the full lists are
+  `USER_OWNED_EXCLUDE` and `EXCLUDED_SKILL_DIRS` in `scripts/build-hermes-distribution.js` — no
+  directory starts with `_` or `.`, and nothing inside it is a symlink. A downstream distribution
+  drops those names, and the `skills` check refuses them here, at any depth, so they cannot vanish
+  silently there.
 
 ### Maintainer steps — run at merge, not in your PR
 
 These are listed so you know they exist and can leave them out. If a check goes red for one of
 them on your PR, say so in the thread; it is not yours to fix.
 
-- **Translation scaffolds** for every locale under `i18n/`. A scaffold copies the English bytes
+- **Translation scaffolds** for the four translated locales (`de`, `zh-CN`, `ja`, `es`). A
+  scaffold copies the English bytes
   at the moment it runs, so one made while a PR is still being revised leaves every mirror stale
   after the next push. That is why it runs once, after merge, and why a contributor is asked
   *not* to run `npm run translate:scaffold`.
@@ -167,14 +171,17 @@ them on your PR, say so in the thread; it is not yours to fix.
 
 ### Local checks — the same commands CI runs
 
-Stage your files first (`git add`): the style check diffs tracked state, so an untracked file
-contributes nothing to it. `<base>` is the ref you branched from — `origin/main` on a clone of
-this repository, `upstream/main` on a fork that keeps this repository as `upstream`.
+Commit your work first: the style check diffs `<base>...HEAD`, so uncommitted changes — staged
+or not — are invisible to it, and it reports a clean run over nothing. `<base>` is this
+repository's `main` as your clone knows it: `origin/main` on a clone of this repository; on a
+fork, add this repository as a remote and fetch it first (`git remote add upstream
+https://github.com/pjt222/agent-almanac.git && git fetch upstream main`), then `upstream/main`.
+The line-endings check is the one exception: it reads the index, so `git add` is enough there.
 
 ```bash
 npm ci
 node scripts/audit-skill-sections.js --missing         # the six sections; "0 skill(s) reported" when clean
-node scripts/check-content-style.js --added <base>     # bare fences and table rules, on added lines only
+node scripts/check-content-style.js --added <base>     # bare fences and table rules, on committed added lines
 npm run validate:line-endings                          # any CRLF in the index fails
 npm run validate:integrity                             # registry entry, symlink, cross-references
 npm run validate:security                              # credential shapes, dangerous executables
@@ -213,11 +220,12 @@ a judgement call in the thread.
   `text`, `markdown` or `md`, and a gate checks each fence against every revision of the English
   file.
 - **Bug reports** are GitHub issues. The most useful report names the command, the measured
-  output, and the expected output. The reasoning written into the close of #589 is the shape of
-  triage you will get back.
+  output, and the expected output. The reasoning written into the close of #589 — a security
+  patch that arrived as a PR — is the shape of triage you will get back.
 - **Security findings** follow [`SECURITY.md`](SECURITY.md): a public issue, no private channel,
-  no guaranteed timeline. Read its scope section first — `scripts/` does not ship in the npm
-  package, so a finding against it has a different threat model from one against `cli/`.
+  no guaranteed timeline. Read its "What This Repository Contains" section first — `scripts/` does
+  not ship in the npm package, so a finding against it has a different threat model from one
+  against `cli/`.
 
 ## Commits, licence, and the PR text
 

--- a/README.md
+++ b/README.md
@@ -230,14 +230,17 @@ For step-by-step plugin install (POSIX + Windows + macOS variants, prereqs, veri
 
 ## Contributing
 
-Contributions welcome! Each content type has its own guide:
+Contributions welcome! Start with [CONTRIBUTING.md](CONTRIBUTING.md) — what the library accepts,
+the skill checklist, which steps are yours and which are the maintainer's at merge, and what to
+expect once a PR is open. Each content type also has its own guide:
 
 - **Skills** — [skills/README.md](skills/README.md) for format and consumption
 - **Agents** — [agents/README.md](agents/README.md) for template and best practices
 - **Teams** — [teams/README.md](teams/README.md) for coordination patterns
 - **Guides** — [guides/README.md](guides/README.md) for categories and template
 
-Update the relevant `_registry.yml` when adding content, then run `npm run update-readmes`.
+Update the relevant `_registry.yml` when adding content; the generated README sections are rebuilt
+by CI on `main` (`npm run update-readmes` locally, if you want to see them first).
 
 ## Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,10 +39,10 @@ If you find a security issue, open a [GitHub issue](https://github.com/pjt222/ag
   `first_time_contributors_new_to_github` (#689). **Measured on 2026-09-02 on #763**, the
   second fork PR and the first since the change: on the contributor's first commit each
   workflow run's `created_at` equals its `run_started_at`, three seconds after the PR was
-  opened and seven hours before the maintainer's first comment. An approval-gated run waits at
-  `action_required` between those two timestamps, so none was needed, and every check context
-  the changed paths trigger reported — two of them red on content rules, which is the gate
-  working. What the measurement cannot say is which side of the policy's own gate that
+  opened and seven hours before the maintainer's first comment, which is the maintainer's first
+  recorded action on the PR — so no approval preceded them. Every check context the changed
+  paths trigger reported, one run each — two of them red on content rules, which is the gate
+  working — where #589 above had reported none at all. What the measurement cannot say is which side of the policy's own gate that
   contributor fell on: the account was a month old, and GitHub does not publish the age at which
   an account stops being "new". So "will my PR report checks?" reads *yes* on the one case
   measured, and a contributor who sees an empty check list should say so in the thread rather

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,14 +39,14 @@ If you find a security issue, open a [GitHub issue](https://github.com/pjt222/ag
   `first_time_contributors_new_to_github` (#689). **Measured on 2026-09-02 on #763**, the
   second fork PR and the first since the change: on the contributor's first commit each
   workflow run's `created_at` equals its `run_started_at`, three seconds after the PR was
-  opened and seven hours before the maintainer's first comment, which is the maintainer's first
-  recorded action on the PR — so no approval preceded them. Every check context the changed
-  paths trigger reported, one run each — two of them red on content rules, which is the gate
-  working — where #589 above had reported none at all. What the measurement cannot say is which side of the policy's own gate that
-  contributor fell on: the account was a month old, and GitHub does not publish the age at which
-  an account stops being "new". So "will my PR report checks?" reads *yes* on the one case
-  measured, and a contributor who sees an empty check list should say so in the thread rather
-  than read it as a pass (`CONTRIBUTING.md`). The live setting is at
+  opened — an interval no human approval fits inside — and seven hours before the maintainer's
+  first comment. Every check context the changed paths trigger reported, one run each — two of
+  them red on content rules, which is the gate working — where #589 above had reported none at
+  all. What the measurement cannot say is which side of the policy's own gate that contributor
+  fell on: the account was a month old, and GitHub does not publish the age at which an account
+  stops being "new". So "will my PR report checks?" reads *yes* on the one case measured, and a
+  contributor who sees an empty check list should say so in the thread rather than read it as a
+  pass (`CONTRIBUTING.md`). The live setting is at
   `gh api repos/pjt222/agent-almanac/actions/permissions/fork-pr-contributor-approval`, though
   that endpoint needs admin rights — an external reader gets `401`/`403`, so ask us rather than
   assuming this paragraph has gone stale.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,9 +38,9 @@ If you find a security issue, open a [GitHub issue](https://github.com/pjt222/ag
   On 2026-08-20 that policy was changed to its loosest value,
   `first_time_contributors_new_to_github` (#689). **Measured on 2026-09-02 on #763**, the
   second fork PR and the first since the change: on the contributor's first commit each
-  workflow run's `created_at` equals its `run_started_at`, three seconds after the PR was
-  opened — an interval no human approval fits inside — and seven hours before the maintainer's
-  first comment. Every check context the changed paths trigger reported, one run each — two of
+  workflow run's `created_at` equals its `run_started_at` — nothing waited between the run
+  being created and being started — three seconds after the PR was opened, an interval no
+  human approval fits inside either, and seven hours before the maintainer's first comment. Every check context the changed paths trigger reported, one run each — two of
   them red on content rules, which is the gate working — where #589 above had reported none at
   all. What the measurement cannot say is which side of the policy's own gate that contributor
   fell on: the account was a month old, and GitHub does not publish the age at which an account

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,11 +36,17 @@ If you find a security issue, open a [GitHub issue](https://github.com/pjt222/ag
   policy will not have fixed the silence, which is the other reason the measurement below
   matters.
   On 2026-08-20 that policy was changed to its loosest value,
-  `first_time_contributors_new_to_github` (#689), so a returning contributor's PR should now
-  report checks without waiting for approval. **That has not yet been measured** — #589 is
-  closed and remains the only fork PR in this repository's history, so the next external
-  contribution is the measurement. Until then, treat "will my PR report checks?" as *unknown*
-  rather than as either yes or no. The live setting is at
+  `first_time_contributors_new_to_github` (#689). **Measured on 2026-09-02 on #763**, the
+  second fork PR and the first since the change: on the contributor's first commit each
+  workflow run's `created_at` equals its `run_started_at`, three seconds after the PR was
+  opened and seven hours before the maintainer's first comment. An approval-gated run waits at
+  `action_required` between those two timestamps, so none was needed, and every check context
+  the changed paths trigger reported — two of them red on content rules, which is the gate
+  working. What the measurement cannot say is which side of the policy's own gate that
+  contributor fell on: the account was a month old, and GitHub does not publish the age at which
+  an account stops being "new". So "will my PR report checks?" reads *yes* on the one case
+  measured, and a contributor who sees an empty check list should say so in the thread rather
+  than read it as a pass (`CONTRIBUTING.md`). The live setting is at
   `gh api repos/pjt222/agent-almanac/actions/permissions/fork-pr-contributor-approval`, though
   that endpoint needs admin rights — an external reader gets `401`/`403`, so ask us rather than
   assuming this paragraph has gone stale.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,10 +39,11 @@ If you find a security issue, open a [GitHub issue](https://github.com/pjt222/ag
   `first_time_contributors_new_to_github` (#689). **Measured on 2026-09-02 on #763**, the
   second fork PR and the first since the change: on the contributor's first commit each
   workflow run's `created_at` equals its `run_started_at` — nothing waited between the run
-  being created and being started — three seconds after the PR was opened, an interval no
-  human approval fits inside either, and seven hours before the maintainer's first comment. Every check context the changed paths trigger reported, one run each — two of
-  them red on content rules, which is the gate working — where #589 above had reported none at
-  all. What the measurement cannot say is which side of the policy's own gate that contributor
+  being created and being started. The runs began three seconds after the PR was opened, an
+  interval no human approval fits inside, and seven hours before the maintainer's first
+  comment. Every check context the changed paths trigger reported, one run each — two of them
+  red on content rules, which is the gate working — where #589 above had reported none at all.
+  What the measurement cannot say is which side of the policy's own gate that contributor
   fell on: the account was a month old, and GitHub does not publish the age at which an account
   stops being "new". So "will my PR report checks?" reads *yes* on the one case measured, and a
   contributor who sees an empty check list should say so in the thread rather than read it as a

--- a/guides/creating-skills.md
+++ b/guides/creating-skills.md
@@ -148,13 +148,13 @@ Edit `skills/_registry.yml` and add the new skill under the appropriate domain:
 
 ```yaml
 - id: skill-name-here
-  path: domain/skill-name-here/SKILL.md
+  path: skill-name-here/SKILL.md
   complexity: intermediate
   language: multi
   description: One-line description matching the frontmatter
 ```
 
-Increment the `total_skills` count at the top of the registry file.
+`path` is relative to `skills/` — the tree is flat, so it is the skill's own directory and nothing above it; the domain is the registry section the entry sits under. Increment the `total_skills` count at the top of the registry file. The `integrity` CI check refuses a skill on disk that has no entry, and the `skills` check compares `total_skills` against the directories on disk.
 
 ### 5. Regenerate READMEs
 
@@ -162,29 +162,34 @@ Increment the `total_skills` count at the top of the registry file.
 npm run update-readmes
 ```
 
-This updates the auto-generated sections in README files from the registries. CI will also auto-commit README updates when registry files change on `main`, but running locally ensures you catch errors early.
+This updates the auto-generated sections in README files from the registries. CI regenerates and auto-commits them when registry files change on `main`, so an external contributor is not expected to run it — a PR that touches only content does not trigger the `readmes` check. Running it locally is harmless and shows you the rendered index early.
 
 ### 6. Validate Before Committing
 
-```bash
-# Check line count (must be 500 or fewer)
-lines=$(wc -l < skills/<skill-name>/SKILL.md)
-[ "$lines" -le 500 ] && echo "OK ($lines lines)" || echo "FAIL: $lines lines > 500"
+Run the same commands CI runs — the full list, with what each one refuses, is in
+[CONTRIBUTING.md](../CONTRIBUTING.md) § Local checks. The three that catch most first pushes:
 
-# Check required frontmatter fields
-head -20 skills/<skill-name>/SKILL.md | grep -q '^name:' && echo "name: OK"
-head -20 skills/<skill-name>/SKILL.md | grep -q '^description:' && echo "description: OK"
+```bash
+node scripts/audit-skill-sections.js --missing        # the six required sections and the 500-line ceiling
+node scripts/check-content-style.js --added origin/main   # bare code fences on added lines (stage the file first)
+npm run validate:integrity                            # registry entry, symlink, cross-references
 ```
 
-### 7. Create Slash Command Symlinks (Optional)
+A line count and two frontmatter fields were the whole of this step once; the `skills` CI check
+requires all six sections and the check above is what it runs, so a pass here means a pass there.
 
-To make the skill discoverable as a `/slash-command` in Claude Code:
+### 7. Create the Discovery Symlink
+
+The project-level link is what makes the skill discoverable as a `/slash-command` in Claude Code,
+and the `integrity` CI check fails on its absence — it is a committed git symlink, not an
+optional convenience:
 
 ```bash
-# Project-level (available in this project)
+# Project-level (required; commit it)
 ln -s ../../skills/<skill-name> .claude/skills/<skill-name>
+git add .claude/skills/<skill-name>
 
-# Global (available in all projects)
+# Global (optional, your machine only — available in all projects)
 ln -s /mnt/d/dev/p/agent-almanac/skills/<skill-name> ~/.claude/skills/<skill-name>
 ```
 
@@ -344,5 +349,6 @@ domains:
 - [update-skill-content](../skills/update-skill-content/SKILL.md) -- content improvement procedure
 - [refactor-skill-structure](../skills/refactor-skill-structure/SKILL.md) -- structural refactoring for over-long skills
 - [Content Styleguide](content-styleguide.md) -- canonical markdown formatting for SKILL.md (tables, fences, headings)
-- [CLAUDE.md "Adding a New Skill"](../CLAUDE.md) -- the abbreviated checklist in the project root
+- [CONTRIBUTING.md "Adding a skill"](../CONTRIBUTING.md) -- the contributor checklist, the local checks, and which steps are the maintainer's at merge
+- [CLAUDE.md "Adding a New Skill"](../CLAUDE.md) -- the maintainer's half of that list, run once after merge
 - [agentskills.io specification](https://agentskills.io/specification) -- the open standard this system follows

--- a/guides/creating-skills.md
+++ b/guides/creating-skills.md
@@ -170,13 +170,16 @@ Run the same commands CI runs — the full list, with what each one refuses, is 
 [CONTRIBUTING.md](../CONTRIBUTING.md) § Local checks. The three that catch most first pushes:
 
 ```bash
-node scripts/audit-skill-sections.js --missing        # the six required sections and the 500-line ceiling
-node scripts/check-content-style.js --added origin/main   # bare code fences on added lines (stage the file first)
-npm run validate:integrity                            # registry entry, symlink, cross-references
+node scripts/audit-skill-sections.js --missing      # six sections, a non-empty Common Pitfalls, the 500-line ceiling
+node scripts/check-content-style.js --added <base>  # bare fences on committed added lines; <base> = origin/main here, upstream/main on a fork
+npm run validate:integrity                          # registry entry, symlink, cross-references
 ```
 
 A line count and two frontmatter fields were the whole of this step once; the `skills` CI check
-requires all six sections and the check above is what it runs, so a pass here means a pass there.
+requires all six sections, and the first command above is the one it runs for that. Commit
+before running the style check — it diffs `<base>...HEAD`, so uncommitted work is invisible to it.
+The `skills` job runs more than these three (the reference validator, the Hermes distribution
+gates, the i18n parity checks); CONTRIBUTING.md § Local checks lists what a contributor can run.
 
 ### 7. Create the Discovery Symlink
 

--- a/guides/creating-skills.md
+++ b/guides/creating-skills.md
@@ -164,28 +164,12 @@ npm run update-readmes
 
 This updates the auto-generated sections in README files from the registries. CI regenerates and auto-commits them when registry files change on `main`, so an external contributor is not expected to run it — a PR that touches only content does not trigger the `readmes` check. Running it locally is harmless and shows you the rendered index early.
 
-### 6. Validate Before Committing
-
-Run the same commands CI runs — the full list, with what each one refuses, is in
-[CONTRIBUTING.md](../CONTRIBUTING.md) § Local checks. The three that catch most first pushes:
-
-```bash
-node scripts/audit-skill-sections.js --missing      # six sections, a non-empty Common Pitfalls, the 500-line ceiling
-node scripts/check-content-style.js --added <base>  # bare fences on committed added lines; <base> = origin/main here, upstream/main on a fork
-npm run validate:integrity                          # registry entry, symlink, cross-references
-```
-
-A line count and two frontmatter fields were the whole of this step once; the `skills` CI check
-requires all six sections, and the first command above is the one it runs for that. Commit
-before running the style check — it diffs `<base>...HEAD`, so uncommitted work is invisible to it.
-The `skills` job runs more than these three (the reference validator, the Hermes distribution
-gates, the i18n parity checks); CONTRIBUTING.md § Local checks lists what a contributor can run.
-
-### 7. Create the Discovery Symlink
+### 6. Create the Discovery Symlink
 
 The project-level link is what makes the skill discoverable as a `/slash-command` in Claude Code,
 and the `integrity` CI check fails on its absence — it is a committed git symlink, not an
-optional convenience:
+optional convenience. It comes before validation because the validator refuses a registered skill
+that has no link:
 
 ```bash
 # Project-level (required; commit it)
@@ -193,12 +177,31 @@ ln -s ../../skills/<skill-name> .claude/skills/<skill-name>
 git add .claude/skills/<skill-name>
 
 # Global (optional, your machine only — available in all projects)
-ln -s /mnt/d/dev/p/agent-almanac/skills/<skill-name> ~/.claude/skills/<skill-name>
+ln -s "$(git rev-parse --show-toplevel)/skills/<skill-name>" ~/.claude/skills/<skill-name>
 ```
+
+### 7. Validate Before Committing
+
+Run the same commands CI runs — the full list, with what each one refuses, is in
+[CONTRIBUTING.md](../CONTRIBUTING.md) § Local checks. The four that catch most first pushes:
+
+```bash
+node scripts/audit-skill-sections.js --missing      # the six required sections and a non-empty Common Pitfalls
+awk 'END { if (NR > 500) { print "FAIL: " NR " lines > 500"; exit 1 } }' skills/<skill-name>/SKILL.md   # the 500-line ceiling
+node scripts/check-content-style.js --added <base>  # bare fences on committed added lines; <base> = origin/main here, upstream/main on a fork
+npm run validate:integrity                          # registry entry, symlink, cross-references
+```
+
+A line count and two frontmatter fields were the whole of this step once; the `skills` CI check
+requires all six sections and the 500-line ceiling, and the first two commands above are what it
+runs for those — as two separate checks, which is why there are two lines. Commit before running
+the style check: it diffs `<base>...HEAD`, so uncommitted work is invisible to it. The `skills`
+job runs more than these four (the reference validator, the Hermes distribution gates, the i18n
+parity checks); CONTRIBUTING.md § Local checks lists what a contributor can run.
 
 ## The Progressive Disclosure Pattern
 
-SKILL.md files must stay under 500 lines. CI enforces this limit on all PRs touching `skills/`. When a skill grows beyond this limit, extract extended content to a `references/` subdirectory.
+SKILL.md files must stay under 500 lines. CI enforces this limit on every PR — the `skills` job carries no path filter, so a required check can never sit on "Expected" (#641). When a skill grows beyond this limit, extract extended content to a `references/` subdirectory.
 
 ### Directory Structure
 

--- a/guides/creating-skills.md
+++ b/guides/creating-skills.md
@@ -187,7 +187,7 @@ Run the same commands CI runs — the full list, with what each one refuses, is 
 
 ```bash
 node scripts/audit-skill-sections.js --missing      # the six required sections and a non-empty Common Pitfalls
-lines=$(wc -l < skills/<skill-name>/SKILL.md); [ "$lines" -le 500 ] || { echo "FAIL: $lines lines > 500"; false; }   # the 500-line ceiling, CI's counter
+lines=$(wc -l < skills/<skill-name>/SKILL.md); [ "${lines:?no such file - check the path}" -le 500 ] || { echo "FAIL: $lines lines > 500"; false; }   # the 500-line ceiling, CI's counter
 node scripts/check-content-style.js --added <base>  # bare fences on committed added lines; <base> = origin/main here, upstream/main on a fork
 npm run validate:integrity                          # registry entry, symlink, cross-references
 ```

--- a/guides/creating-skills.md
+++ b/guides/creating-skills.md
@@ -187,7 +187,7 @@ Run the same commands CI runs — the full list, with what each one refuses, is 
 
 ```bash
 node scripts/audit-skill-sections.js --missing      # the six required sections and a non-empty Common Pitfalls
-awk 'END { if (NR > 500) { print "FAIL: " NR " lines > 500"; exit 1 } }' skills/<skill-name>/SKILL.md   # the 500-line ceiling
+lines=$(wc -l < skills/<skill-name>/SKILL.md); [ "$lines" -le 500 ] || { echo "FAIL: $lines lines > 500"; false; }   # the 500-line ceiling, CI's counter
 node scripts/check-content-style.js --added <base>  # bare fences on committed added lines; <base> = origin/main here, upstream/main on a fork
 npm run validate:integrity                          # registry entry, symlink, cross-references
 ```

--- a/guides/creating-skills.md
+++ b/guides/creating-skills.md
@@ -195,8 +195,9 @@ npm run validate:integrity                          # registry entry, symlink, c
 A line count and two frontmatter fields were the whole of this step once; the `skills` CI check
 requires all six sections and the 500-line ceiling, and the first two commands above are what it
 runs for those — as two separate checks, which is why there are two lines. Commit before running
-the style check: it diffs `<base>...HEAD`, so uncommitted work is invisible to it. The `skills`
-job runs more than these four (the reference validator, the Hermes distribution gates, the i18n
+the style check: it diffs `<base>...HEAD`, so uncommitted work is invisible to it. Paste the block
+interactively — saved as a script, the ceiling line's path guard ends the script at a mistyped
+path rather than the one check. The `skills` job runs more than these four (the reference validator, the Hermes distribution gates, the i18n
 parity checks); CONTRIBUTING.md § Local checks lists what a contributor can run.
 
 ## The Progressive Disclosure Pattern

--- a/guides/creating-skills.md
+++ b/guides/creating-skills.md
@@ -197,8 +197,9 @@ requires all six sections and the 500-line ceiling, and the first two commands a
 runs for those — as two separate checks, which is why there are two lines. Commit before running
 the style check: it diffs `<base>...HEAD`, so uncommitted work is invisible to it. Paste the block
 interactively — saved as a script, the ceiling line's path guard ends the script at a mistyped
-path rather than the one check. The `skills` job runs more than these four (the reference validator, the Hermes distribution gates, the i18n
-parity checks); CONTRIBUTING.md § Local checks lists what a contributor can run.
+path rather than the one check. The `skills` job runs more than these four (the reference
+validator, the Hermes distribution gates, the i18n parity checks); CONTRIBUTING.md § Local checks
+lists what a contributor can run.
 
 ## The Progressive Disclosure Pattern
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -183,11 +183,12 @@ When performing package development tasks, follow procedures from:
 
 ## Contributing a New Skill
 
-1. Create a directory: `skills/<skill-name>/`
-2. Write `SKILL.md` following the template (see any existing skill)
-3. Add the skill to `_registry.yml`
-4. Ensure frontmatter includes required fields: `name`, `description`, `allowed-tools`
-5. Include at minimum: When to Use, Procedure, and Validation sections
+The contributor steps are in [CONTRIBUTING.md](../CONTRIBUTING.md) § Adding a skill, together
+with the acceptance rules, the local checks, and which steps are the maintainer's at merge. In
+one line: `SKILL.md` from [`_template/SKILL.md`](_template/SKILL.md) with all six required
+sections — When to Use, Inputs, Procedure, Validation, Common Pitfalls, Related Skills — the
+`_registry.yml` entry with its `total_skills` bump, and the `.claude/skills/` symlink. The
+`skills` CI check enforces the six sections; three of them is not a minimum.
 
 ## See Also
 

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 allowed-tools: Read Write Edit Bash Grep Glob
 metadata:
   author: Philipp Thoss
-  version: "1.6"
+  version: "1.7"
   domain: general
   complexity: intermediate
   language: multi
@@ -338,6 +338,8 @@ bash scripts/sync-discovery-symlinks.sh --fix      # create/repair links
 ### Step 14: Scaffold Translations
 
 > **Required for all skills.** This step applies to both human authors and AI agents following this procedure. Do not skip — missing translations accumulate into stale backlog.
+
+> **Scope: the maintainer's repository, after the English is committed and final.** On an external pull request this step is the maintainer's, run once at merge — a scaffold copies the English bytes at the moment it runs, so one made while the PR is still being revised strands every mirror after the next push (#765 finding 2). A contributor leaves this step out; `CONTRIBUTING.md` § Adding a skill says which steps are theirs.
 
 Scaffold translation files for all 4 supported locales immediately after committing the new skill:
 

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -324,9 +324,9 @@ Move extended code examples, full configuration files, and multi-variant example
 
 ### Step 13: Sync Discovery Symlinks
 
-Run the idempotent sync script so Claude Code discovers the skill as a `/slash-command` at both discovery layers. It reads the registry and ensures every registered skill has its repo-internal relative link and its global absolute link, skipping any that already exist — do not hand-roll `ln -s` per skill:
-
 > **Scope: the maintainer's machine.** `--fix` also writes the global `~/.claude/skills/` hub and removes stale almanac-owned links there. An external contributor commits the one project-level link by hand instead (`ln -s ../../skills/<skill-name> .claude/skills/<skill-name>`), as `CONTRIBUTING.md` § Adding a skill says; the script's global half runs on the maintainer's side at merge.
+
+Run the idempotent sync script so Claude Code discovers the skill as a `/slash-command` at both discovery layers. It reads the registry and ensures every registered skill has its repo-internal relative link and its global absolute link, skipping any that already exist — on this machine, do not hand-roll `ln -s` per skill:
 
 ```bash
 bash scripts/sync-discovery-symlinks.sh --report   # preview drift
@@ -343,7 +343,7 @@ bash scripts/sync-discovery-symlinks.sh --fix      # create/repair links
 
 > **Scope: the maintainer's repository, after the English is committed and final.** On an external pull request this step is the maintainer's, run once at merge — a scaffold copies the English bytes at the moment it runs, so one made while the PR is still being revised strands every mirror after the next push (#765 finding 2). A contributor leaves this step out; `CONTRIBUTING.md` § Adding a skill says which steps are theirs.
 
-Scaffold translation files for all 4 supported locales immediately after committing the new skill:
+Scaffold translation files for the four translated locales (`de`, `zh-CN`, `ja`, `es`) as soon as the English commit is final:
 
 ```bash
 for locale in de zh-CN ja es; do

--- a/skills/create-skill/SKILL.md
+++ b/skills/create-skill/SKILL.md
@@ -326,6 +326,8 @@ Move extended code examples, full configuration files, and multi-variant example
 
 Run the idempotent sync script so Claude Code discovers the skill as a `/slash-command` at both discovery layers. It reads the registry and ensures every registered skill has its repo-internal relative link and its global absolute link, skipping any that already exist — do not hand-roll `ln -s` per skill:
 
+> **Scope: the maintainer's machine.** `--fix` also writes the global `~/.claude/skills/` hub and removes stale almanac-owned links there. An external contributor commits the one project-level link by hand instead (`ln -s ../../skills/<skill-name> .claude/skills/<skill-name>`), as `CONTRIBUTING.md` § Adding a skill says; the script's global half runs on the maintainer's side at merge.
+
 ```bash
 bash scripts/sync-discovery-symlinks.sh --report   # preview drift
 bash scripts/sync-discovery-symlinks.sh --fix      # create/repair links


### PR DESCRIPTION
Closes #765.

## Why

Two fork PRs (#589, #763) met the required checks blind: the rules that decided them lived only in `CLAUDE.md`, a file written for Claude Code sessions. The author of #763 asked up front how to fit the taxonomy and had nothing to read.

## What

1. **`CONTRIBUTING.md`** (new) — what the library accepts, in the words that decided #763 (*serve AI systems, don't promote to them*) with its three review-applied corollaries; what to expect from us (a rhythm table by contribution class, close with grace, maintainer edits, merge commits, checks on fork PRs); the skill checklist split into contributor steps and maintainer-at-merge steps with the reason stated inline; the local checks with the exact commands; and which contexts can refuse a merge.
2. **`.github/PULL_REQUEST_TEMPLATE.md`** (new) — the same checklist item for item; each file names the other as its paired copy.
3. **`CLAUDE.md` § Adding a New Skill** — the contributor half is gone and cross-referenced (AC3, the "cross-references rather than duplicates" branch); the maintainer half stays, with the reason a scaffold must not run early.
4. **`skills/README.md`** — said three sections were the minimum; the `skills` gate requires six.
5. **`README.md`** — links `CONTRIBUTING.md`, and no longer tells contributors to regenerate READMEs (`validate-readmes.yml` documents that they are not expected to).
6. **`SECURITY.md`** (own commit) — its fork-PR paragraph said "not yet measured"; #763 is the measurement, and `CONTRIBUTING.md` cannot tell a contributor their PR reports checks while a sibling document says that is unknown. It is also the measurement AC on #689.
7. **`skills/create-skill/SKILL.md`** (own commit) — Step 14 said the scaffold "applies to both human authors and AI agents … Do not skip", which becomes a live contradiction in the file `CLAUDE.md` step 8 sends a reader to. One scoping paragraph, prose only, `version` 1.6 → 1.7. No fence touched, so nothing to propagate to the ten mirrors.

## The design decision (finding 2)

**Contributor:** `SKILL.md` from the template with its six sections, the registry entry with the `total_skills` bump, the `.claude/skills/` symlink, the local checks. **Maintainer at merge:** translation scaffolds, README regeneration, viz wiring, the global hub. The reason the scaffold cannot be a contributor step is stated where a contributor reads it: a scaffold copies the English bytes at the moment it runs, so one made while a PR is still being revised strands every mirror after the next push.

## The finding 4 decision

Policy text, applied in review, not a gate — recorded in `CONTRIBUTING.md` under "Why the third rule is policy text and not a gate", with the reason: `scan-skill-content.js` deliberately does not read prose, and whether a procedure's *primary path* is a sandbox is not a syntactic property.

## Acceptance criteria

- [x] `CONTRIBUTING.md` states the six sections, the contributor steps, the maintainer-at-merge steps labelled as such, the vendor-neutrality rule with its reason, and the local pre-checks (`npm run validate:integrity`, `claude plugin validate .` and the rest)
- [x] `.github/PULL_REQUEST_TEMPLATE.md` carries the checklist, mirroring the contributor steps
- [x] `CLAUDE.md` "Adding a New Skill" cross-references `CONTRIBUTING.md` rather than duplicating it
- [x] The companion's `contribution-policy.md` shaped the tone and structure: a table by contribution class with thresholds in both directions, close with grace, "silence, age, and merge conflicts are not by themselves reasons to close"
- [x] The finding 4 decision is recorded in the file
- [ ] The #763 thread gets a link — after merge, once the file has a URL on `main`

## Measured, not asserted

- Checks on #763's first commit: each run's `created_at` equals its `run_started_at`, three seconds after the PR opened and seven hours before the maintainer's first comment; ten contexts reported, `integrity` and `skills` red with the exact lines the checklist now covers (no registry entry, no `.claude/skills` symlink, five of six sections missing).
- #589's head commit: no check-runs at all.
- Both external PRs got a substantive first reply within a day (#589 in about thirteen hours, #763 in about seven).
- The #763 contributor's account was one month old, and GitHub publishes no age at which an account stops being "new to GitHub", so `SECURITY.md` says *yes on the one case measured* rather than *yes*.

## Proposed defaults for the maintainer to adjust

The rhythm table's "nudge us after" (14 days for content PRs, 7 for bug and security reports) and "we close after" (60 days of contributor silence following a change request) are proposals. The first column is the two data points above. The file itself now says so — "the other three are defaults, set in this file and changed by editing it" — after review round 1 flagged that the PR body was the only place the provenance was written. Change the numbers in the table; nothing else reads them.

## Review

Round 1 (advocatus-diaboli, three lenses plus a thirteen-item attack list), revised once the guide commit was in the bundle: 2 blocking, 17 should-fix, 8 nits. Both blockers were real and mine:

- the local-check instruction said to **stage** before running the style check, and `check-content-style.js --added` diffs `<base>...HEAD`, so that instruction produced a vacuous pass — my own first run in this PR was one;
- the guide's rewritten §6 dropped its `wc -l` ceiling check and labelled `audit-skill-sections.js --missing` as enforcing "the 500-line ceiling", which that script never tests (the ceiling is a separate loop in `validate-skills.yml`). A working check was removed and its replacement mislabelled. My first fix commit carried the mislabel forward; the second restores an explicit ceiling command in both documents and was proved on a 501-line file (`FAIL: 501 lines > 500`, exit 1).

Also from the revised round: the guide validated in §6 before creating the symlink in §7, so a reader in order hit `FAIL: missing symlink` by construction — the two are swapped; the global-hub example carried the maintainer's absolute path, now `git rev-parse --show-toplevel`; and "CI enforces this limit on all PRs touching `skills/`" had been wrong since #641.

Every should-fix and nit is applied except one, with its reason in the fix commit: `create-skill`'s ten mirrors are not restamped, because they were already stale before this PR (they pin `496be0a2`/`82c77053`; the English last moved at `cbd37e717`, 2026-07-24) and `source_commit` records what a translator worked from.

Round 2, over the two applied-fix commits, graded against the live tree: 0 blocking, 4 should-fix, 5 nits, coverage complete, the one deliberate non-application accepted ("stronger than stated"). All four should-fixes were defects inside corrections — a replacement inference in `SECURITY.md` that an approval event would not have been visible to, a fork-setup command split across a line in an inline code span, an unsourced characterisation of #589 (now sourced: "harden: sanitize child_process call", semgrep, severity HIGH), and a PR-template header pointing at a line no checkbox carried. All applied in the round-2 fix commit, with the nits. AC4 was judged met with high fidelity once the reviewer had the companion file.

A re-issue of round 2 against the sha-cut bundle added two items on the restored ceiling command: it counted with awk's `NR` under a heading promising "the same commands CI runs", where CI counts with `wc -l` — measured to disagree on a 501-text-line file with no trailing newline (`wc` 500, `NR` 501: CI passes it, the awk form failed it) — and its proof lived only in a handoff message. Both documents now use CI's counter, proved on three fixtures and recorded in the review packet.

Round 3, over the round-2 fix commits: 0 blocking, 1 new should-fix, 2 nits. The should-fix is the third instance in this PR of a correction falsifying a sentence one screen away: once #589 was sourced as a security patch, the opening paragraph's "the rules below are the ones that decided the first two external pull requests" became checkable and false — #589 added no skill, reported no checks, and was decided in triage. The paragraph now says the rules decided #763 and points at the triage shape for #589. The nits (a `git remote add` that errors on a second paste, now guarded and proved idempotent; the SECURITY.md aside moved onto the measurement that carries it) are applied in the same commit.

Round 4, over that commit: 0 blocking, 1 should-fix, 2 nits — and the should-fix is the fourth instance of a correction introducing a defect: the idempotent guard I had just added skipped `git remote add` whenever an `upstream` existed, so a contributor whose `upstream` pointed at another repository would have run the style check against the wrong base, silently, where the unguarded form had at least errored. The guard now checks the URL, measured in all three cases (absent, correct, wrong) plus the fetch twice in a fresh repository. The same commit closes two nits the re-issued round 3 had raised (a phantom `FAIL` on a mistyped path, now `${lines:?…}`-guarded and measured in bash and zsh; the local-checks heading widened to cover the fork setup) and the two round-4 nits (rewrap, "either"). Round 5, over that commit: 0 blocking, 1 should-fix, 2 nits. The should-fix was the fifth correction-introduced defect and the sharpest: the URL check was unanchored, so `github.com/pjt222/agent-almanac-hermes-profile` — a real sibling repository a contributor may carry as a remote — passed it silently (measured: exit 0, remote used), while the slash-only form rejected a correct scp-style ssh remote with a message saying it pointed elsewhere. The pattern is now anchored (`github\.com[:/]pjt222/agent-almanac(\.git)?$`) and measured on seven remote forms. Both documents also now say to paste the check block interactively, since `${lines:?…}` ends a non-interactive shell. Round 6, over that commit: **0 blocking, 0 should-fix, 3 nits** — the first round with nothing above nit level. All three are applied in the final commit and measured: the remote match now admits a port (GitHub's `ssh.github.com:443` fallback included; nine remote forms measured), "the path guard ends the script" was proved by running the block as a file in bash and zsh, and the one recurring defect class of the whole review — an inserted sentence left unwrapped — is rewrapped. The last commit's closing pass, limited to blocking and should-fix findings: `GATE: blocking=0 should-fix=0 coverage=complete`, with one line not blocking merge — the remote match is unanchored on the left, so a lookalike host whose name ends in `github.com` would pass it; the remote is already in the contributor's own clone and `<base>` only selects which of their own added lines get style-checked, so it is noted here rather than fixed.

8. **`guides/creating-skills.md`** (own commit, added after the first push) — §7 called the `.claude/skills/` symlink "(Optional)" where `validate-integrity.sh` fails on its absence, §4 showed a `domain/…` registry path the flat registry does not use, §6 validated a line count and two frontmatter fields where the gate requires six sections, and §5 told every author to regenerate READMEs. The guide is what `skills/README.md` sends an author to, and it has no i18n mirror, so the fix is four prose edits and one yaml example with nothing to propagate.

## Not in this PR

- The other three "Adding a New …" lists in `CLAUDE.md` keep their scaffold step unchanged — they are read by maintainer sessions, and `CONTRIBUTING.md` § Other contributions states that the same split applies.
- The generated skills-by-domain table in `skills/README.md` links every domain to a directory that does not exist (the tree is flat). Found by the link-resolution pass; it is a generator defect (`generate-readmes.js:197`) and is filed as its own issue.

## Verification

All local gates green on the final tree: `check-content-style.js --added origin/main` (0 blocking errors), `validate:line-endings`, `validate:banned-invocations`, `validate:untagged-fences`, `check:generated-artifacts`, `validate:security`, `check:hermes-distribution`, `audit-skill-sections.js --missing`, `check-i18n-frontmatter-parity` (version direction only), `check-readmes` ("All files are up to date"), `npm test` (138 pass, 0 fail, 2 skipped). Every relative link and section reference in the edited files resolved by script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L37mLbqZESygyDvjJYUCjZ
