### PR TITLE
test(cli): cover the universal adapter's broken-symlink audit (#447)

### DIFF
--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -826,12 +826,14 @@ describe('audit exit codes end to end (#439)', () => {
 // left out — and NOT because it is covered. Its direct audit test above (#373)
 // exercises only the healthy path: it audits the real repository root, builds no
 // dangling link, and asserts `errors` is EMPTY, which is exactly what a
-// regression would also produce. Deleting claude-code's broken-symlink push
-// fails nothing — measured with a deletion mutant. That member is #823.
+// regression would also produce. Deleting its broken-skill-symlink push
+// (claude-code.js:199) fails nothing — measured with a deletion mutant. It has a
+// second broken branch at :203 that was not mutated; #823 carries both.
 //
-// Both numbers in the sentence above are prose that no tool reads; a tenth
-// symlink-installing adapter would join uncovered and make them silently wrong,
-// which is how #447 arose in the first place. Gating them is #824.
+// Both numbers in this paragraph's first sentence — nine, and EIGHT — are prose
+// that no tool reads. A tenth symlink-installing adapter would join uncovered,
+// the shape #447 had, except that there the gap was at least written down.
+// Gating them is #824.
 //
 // universal is the odd one here: alone among the nine it ENUMERATES the broken
 // ids in the error rather than only counting them (`N broken symlinks: <ids>`,
@@ -839,9 +841,10 @@ describe('audit exit codes end to end (#439)', () => {
 // dropping `.map(b => b.id).join(', ')` would keep the count right and still go
 // red (#447).
 //
-// `1 broken symlinks` disagrees with itself on number. That wording is pinned
-// DELIBERATELY — the string is behaviour, so a pluralisation fix should go red
-// here and be made on purpose rather than slipping through unnoticed.
+// `1 broken skill symlinks` (five rows) and `1 broken links` (opencode) each
+// disagree with themselves on number. That wording is pinned DELIBERATELY — the
+// string is behaviour, so a pluralisation fix should go red here and be made on
+// purpose rather than slipping through unnoticed.
 //
 // Each case builds one valid and one dangling symlink and asserts BOTH the
 // exact error and the exact ok string, so neither a regression to `errors: []`
@@ -906,7 +909,7 @@ describe('adapter audits detect broken symlinks', () => {
       extraGhosts: ['ghost-skill-2'],
       ok: '1 skills installed',
       errAssert: (errors) => {
-        assert.equal(errors.length, 1);
+        assert.equal(errors.length, 1, `expected one error, got: ${JSON.stringify(errors)}`);
         const enumerated = /^2 broken symlinks: (.+)$/.exec(errors[0]);
         assert.ok(enumerated, `unexpected error shape: ${errors[0]}`);
         assert.deepEqual(enumerated[1].split(', ').sort(), ['ghost-skill', 'ghost-skill-2']);

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -21,6 +21,7 @@ import { HermesAdapter } from '../adapters/hermes.js';
 import { resolveHermesHome } from '../lib/hermes-home.js';
 import { OpenClawAdapter } from '../adapters/openclaw.js';
 import { OpenCodeAdapter } from '../adapters/opencode.js';
+import { UniversalAdapter } from '../adapters/universal.js';
 import { VibeAdapter } from '../adapters/vibe.js';
 import { renderSprite, composite, canRenderPixelArt } from '../lib/pixel-renderer.js';
 import {
@@ -821,10 +822,14 @@ describe('audit exit codes end to end (#439)', () => {
 // opencode did report the error but still counted the dangling item in `ok`;
 // #445 aligned it, so all nine now split valid from broken the same way.
 //
-// Nine adapters split, but this block holds SEVEN cases. claude-code is
-// covered by its own direct audit test above; universal is not covered by any
-// broken-symlink test yet (#447) — its `N broken symlinks: <ids>` wording at
-// universal.js:123 is unexercised.
+// Nine adapters split, and this block holds EIGHT cases. claude-code is the
+// one left out, covered by its own direct audit test above.
+//
+// universal is the odd one here: alone among the nine it ENUMERATES the broken
+// ids in the error rather than only counting them (`N broken symlinks: <ids>`,
+// universal.js:123). Its case therefore pins the id list, not just the number —
+// dropping `.map(b => b.id).join(', ')` would keep the count right and still go
+// red (#447).
 //
 // Each case builds one valid and one dangling symlink and asserts BOTH the
 // exact error and the exact ok string, so neither a regression to `errors: []`
@@ -871,6 +876,10 @@ describe('adapter audits detect broken symlinks', () => {
     // line to valid-only like the rest. One dir is enough here: unlike hermes,
     // its skills and agents flow through the same expression (opencode.js:82).
     { name: 'opencode', base: 'project', dir: '.opencode/skills', ok: '1 items installed', err: '1 broken links', audit: (d) => new OpenCodeAdapter().audit(d, 'project') },
+    // universal enumerates the broken ids; every other adapter only counts them.
+    // `ghost-skill` in the expected string is the fixture's dangling link name,
+    // so this asserts the id-enumeration format and not merely the count.
+    { name: 'universal', base: 'project', dir: '.agents/skills', ok: '1 skills installed', err: '1 broken symlinks: ghost-skill', audit: (d) => new UniversalAdapter().audit(d, 'project') },
   ];
 
   // Which root a home-based case hangs off: hermes gets its own, so that the

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -836,19 +836,25 @@ describe('audit exit codes end to end (#439)', () => {
 // Gating them is #824.
 //
 // universal is the odd one here: alone among the nine it ENUMERATES the broken
-// ids in the error rather than only counting them (`N broken symlinks: <ids>`,
-// universal.js:123). Its case therefore pins the id list, not just the number —
+// ids in the error rather than only counting them (the `broken.map(b => b.id)`
+// in universal.js's errors.push — cited by expression, because a line number
+// here was already wrong once: #607 moved the push and the citation did not
+// follow). Its case therefore pins the id list, not just the number —
 // dropping `.map(b => b.id).join(', ')` would keep the count right and still go
 // red (#447).
 //
 // `1 broken skill symlinks` (five rows) and `1 broken links` (opencode) each
-// disagree with themselves on number. That wording is pinned DELIBERATELY — the
-// string is behaviour, so a pluralisation fix should go red here and be made on
-// purpose rather than slipping through unnoticed.
+// disagree with themselves on number, as do the ok strings `1 skills installed`,
+// `1 items installed` and `1 skills in workspace`. All of it is pinned
+// DELIBERATELY — the string is behaviour, so a pluralisation fix should go red
+// here and be made on purpose rather than slipping through unnoticed.
 //
-// Each case builds one valid and one dangling symlink and asserts BOTH the
-// exact error and the exact ok string, so neither a regression to `errors: []`
-// nor a drift back to counting totals passes. The wording differs per adapter
+// Each case builds one valid link and at least one dangling one, and asserts the
+// error and the exact ok string, so neither a regression to `errors: []` nor a
+// drift back to counting totals passes. Seven rows assert the error as an exact
+// string; universal supplies `errAssert` instead — it needs two dangling links
+// for the join to be observable, and their order is not promised (see the row).
+// hermes builds two of each, one pair per content type. The wording differs
 // by design and follows what each installs: "broken skill symlinks" where only
 // skills are linked, "broken links" for hermes and opencode, which link agents
 // too.

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -822,14 +822,26 @@ describe('audit exit codes end to end (#439)', () => {
 // opencode did report the error but still counted the dangling item in `ok`;
 // #445 aligned it, so all nine now split valid from broken the same way.
 //
-// Nine adapters split, and this block holds EIGHT cases. claude-code is the
-// one left out, covered by its own direct audit test above.
+// Nine adapters split, and this block holds EIGHT cases. claude-code is the one
+// left out — and NOT because it is covered. Its direct audit test above (#373)
+// exercises only the healthy path: it audits the real repository root, builds no
+// dangling link, and asserts `errors` is EMPTY, which is exactly what a
+// regression would also produce. Deleting claude-code's broken-symlink push
+// fails nothing — measured with a deletion mutant. That member is #823.
+//
+// Both numbers in the sentence above are prose that no tool reads; a tenth
+// symlink-installing adapter would join uncovered and make them silently wrong,
+// which is how #447 arose in the first place. Gating them is #824.
 //
 // universal is the odd one here: alone among the nine it ENUMERATES the broken
 // ids in the error rather than only counting them (`N broken symlinks: <ids>`,
 // universal.js:123). Its case therefore pins the id list, not just the number —
 // dropping `.map(b => b.id).join(', ')` would keep the count right and still go
 // red (#447).
+//
+// `1 broken symlinks` disagrees with itself on number. That wording is pinned
+// DELIBERATELY — the string is behaviour, so a pluralisation fix should go red
+// here and be made on purpose rather than slipping through unnoticed.
 //
 // Each case builds one valid and one dangling symlink and asserts BOTH the
 // exact error and the exact ok string, so neither a regression to `errors: []`
@@ -899,6 +911,10 @@ describe('adapter audits detect broken symlinks', () => {
         assert.ok(enumerated, `unexpected error shape: ${errors[0]}`);
         assert.deepEqual(enumerated[1].split(', ').sort(), ['ghost-skill', 'ghost-skill-2']);
       },
+      // 'project' is explicit, not load-bearing: _targetBase() returns the project
+      // path for any scope that is not 'global', so audit(d) behaves identically
+      // here — that mutant survives, measured. Passed anyway so the row states its
+      // scope instead of leaning on a default that could change.
       audit: (d) => new UniversalAdapter().audit(d, 'project'),
     },
   ];

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -877,9 +877,30 @@ describe('adapter audits detect broken symlinks', () => {
     // its skills and agents flow through the same expression (opencode.js:82).
     { name: 'opencode', base: 'project', dir: '.opencode/skills', ok: '1 items installed', err: '1 broken links', audit: (d) => new OpenCodeAdapter().audit(d, 'project') },
     // universal enumerates the broken ids; every other adapter only counts them.
-    // `ghost-skill` in the expected string is the fixture's dangling link name,
-    // so this asserts the id-enumeration format and not merely the count.
-    { name: 'universal', base: 'project', dir: '.agents/skills', ok: '1 skills installed', err: '1 broken symlinks: ghost-skill', audit: (d) => new UniversalAdapter().audit(d, 'project') },
+    //
+    // TWO dangling links, not one. With a single id there is nothing to join, so
+    // `join(', ')` and `join('; ')` produce identical output and a separator
+    // mutant SURVIVES — measured, before this was widened. One id pins an id;
+    // it does not pin an enumeration.
+    //
+    // The assertion splits on ', ' and compares as a set. Splitting is what pins
+    // the separator: under `join('; ')` the split yields one element and the
+    // deepEqual fails. Comparing as a set is what keeps it honest about order —
+    // the adapter enumerates in readdirSync order, which is not specified, so an
+    // exact two-id string would be asserting something universal.js does not
+    // promise.
+    {
+      name: 'universal', base: 'project', dir: '.agents/skills',
+      extraGhosts: ['ghost-skill-2'],
+      ok: '1 skills installed',
+      errAssert: (errors) => {
+        assert.equal(errors.length, 1);
+        const enumerated = /^2 broken symlinks: (.+)$/.exec(errors[0]);
+        assert.ok(enumerated, `unexpected error shape: ${errors[0]}`);
+        assert.deepEqual(enumerated[1].split(', ').sort(), ['ghost-skill', 'ghost-skill-2']);
+      },
+      audit: (d) => new UniversalAdapter().audit(d, 'project'),
+    },
   ];
 
   // Which root a home-based case hangs off: hermes gets its own, so that the
@@ -899,6 +920,10 @@ describe('adapter audits detect broken symlinks', () => {
       mkdirSync(skillsDir, { recursive: true });
       symlinkSync(realSkill, resolve(skillsDir, 'good-skill'));
       symlinkSync(resolve(tmpRoot, 'no-such-target'), resolve(skillsDir, 'ghost-skill'));
+      // Extra dangling links for a case that asserts the enumeration, not the count.
+      for (const extra of c.extraGhosts ?? []) {
+        symlinkSync(resolve(tmpRoot, 'no-such-target'), resolve(skillsDir, extra));
+      }
       if (c.agentDir) {
         const agentsDir = resolve(homeRootFor(c), c.agentDir);
         mkdirSync(agentsDir, { recursive: true });
@@ -940,7 +965,8 @@ describe('adapter audits detect broken symlinks', () => {
   for (const c of cases) {
     it(`${c.name}: reports a dangling symlink as an error`, async () => {
       const result = await c.audit(resolve(tmpRoot, c.name));
-      assert.deepEqual(result.errors, [c.err]);
+      if (c.errAssert) c.errAssert(result.errors);
+      else assert.deepEqual(result.errors, [c.err]);
       assert.deepEqual(result.ok, [c.ok]);
     });
   }


### PR DESCRIPTION
Closes #447.

Head: `e947b654a`. Every number below re-read at that commit, except console blocks measuring a superseded fixture or revision — each is introduced by a sentence naming which, and one of them (the claude-code mutant) is called out below as still true at HEAD.

## What was missing

The `adapter audits detect broken symlinks` block covered seven of the nine adapters that split valid from broken. `universal` was not one of them — the block's own comment said so and cited the issue.

Ruler for "nine", by the property rather than by a word: `rg -lF 'filter(i => i.broken)' cli/adapters/*.js` → exactly 9 (`-F`, literal: without it the parentheses are regex groups and the pattern matches nothing — the third wrong ruler in three rounds, caught in review) (claude-code, copilot, cursor, gemini, hermes, openclaw, opencode, universal, vibe). The six non-matches under `cli/adapters/` are ai-edge, aider, codex and windsurf, plus `base.js` and `index.js`, which are not adapters.

## Why a one-item list could not do the job

Alone among the nine, `universal` **enumerates** the broken ids rather than only counting them:

```js
result.errors.push(`${broken.length} broken symlinks: ${broken.map(b => b.id).join(', ')}`);
```

AC2 asks this case to pin that enumeration. The first version of this PR used the block's single dangling link and asserted `'1 broken symlinks: ghost-skill'`. **That cannot pin an enumeration.** `Array.prototype.join` never applies its separator to a one-element array, so against one broken id the shipped expression is byte-identical to `broken[0].id`, to `join('|')`, and to any ordering rule. Measured:

```console
$ npm run mutation-check -- --file cli/adapters/universal.js --replace "join(', ')::join('; ')" ...
MUTANT SURVIVED — this line is not covered.
```

So the case installs **two** dangling links and asserts:

```js
assert.equal(errors.length, 1, `expected one error, got: ${JSON.stringify(errors)}`);
const enumerated = /^2 broken symlinks: (.+)$/.exec(errors[0]);
assert.ok(enumerated, `unexpected error shape: ${errors[0]}`);
assert.deepEqual(enumerated[1].split(', ').sort(), ['ghost-skill', 'ghost-skill-2']);
```

**A deliberate deviation from #447's AC1 as written.** That AC asks for "the exact `errors` … strings". This case does not assert an exact error string, and should not: `universal.js` enumerates in `readdirSync` order, which is not specified, so an exact two-id string would pin behaviour the adapter does not promise and would flake on another filesystem. Splitting on `', '` is what pins the separator — under `join('; ')` the split yields one element and the comparison fails — and comparing as a set is what keeps it honest about order. The exact-string form was tried first, could not see the join, and was replaced for that reason.

`errors.length === 1` is exact, not a guess: the adapter has a single `if (broken.length > 0)` push, so two broken links produce one entry.

Two optional harness fields carry it, both following the existing `agentDir` pattern: `extraGhosts` (defaults to `[]`) and `errAssert` (falls back to the original `deepEqual`). The other seven rows are unchanged in behaviour.

## The gate was shown to fail — five ways

All against `cli/adapters/universal.js`, at the current head:

| mutation | result |
|---|---|
| `join(', ')` → `join('; ')` | KILLED by 1 |
| `join(', ')` → `join('\|')` | KILLED by 1 |
| `broken.map(b => b.id).join(', ')` → `broken[0].id` | KILLED by 1 |
| drop `: ${…}` — keep the count, lose the list | KILLED by 1 |
| `broken.map(…)` → `installed.map(…)` | KILLED by 1 |

Each parses (`node --check`) and runs to completion; each dies to **exactly one** test — not a crash counted as a kill, not a broad kill.

AC3 asks that "the new case fails **and only that case**", which is a claim about identity:

```console
$ node --test cli/test/cli.test.js   # deletion mutant applied, at this head
✖ failing tests:
✖ universal: reports a dangling symlink as an error (120.423695ms)
  AssertionError [ERR_ASSERTION]: unexpected error shape: 2 broken symlinks
```

One failure, this case by name. The `test at <file>:<line>` line the reporter also prints is deliberately omitted: it moved 982 → 985 → 991 across the three review rounds, so the two `✖` lines carry the identity claim without a number that is stale by the next commit. (`node --test` uses the spec reporter here, so grepping for `not ok` reports nothing either way.)

## What two adversarial rounds corrected

**Round 1 — the comment claimed a coverage that does not exist.** The rewrite said claude-code was "covered by its own direct audit test above". That test audits the real, healthy repository root, builds no dangling link, and asserts `errors` is empty — what a regression would produce too:

```console
$ npm run mutation-check -- --file cli/adapters/claude-code.js \
    --delete-matching 'broken skill symlinks' --test 'npm run test:cli'
MUTANT SURVIVED — this line is not covered.
```

That measurement is **still true at HEAD** — it is the basis of #823, not a claim this PR corrected. Closing #447 had quietly relabelled the remaining member of the same class as handled. Filed **#823** (the uncovered claude-code branch — both of them, `:199` and `:203`) and **#824** (the block's prose adapter counts, which nothing reads: `rg -n 'length' cli/test/*.test.js` finds no other pin).

**Round 2 — the fix for that repeated the same class.** The pluralisation note added in round 1 quoted `1 broken symlinks` as pinned. The two-ghost widening had already deleted that expectation, so the string existed nowhere but in the comment asserting it:

```console
$ rg -n '1 broken symlinks' cli/test/cli.test.js
842:// `1 broken symlinks` disagrees with itself on number. ...
```

The note now quotes the strings actually pinned — `1 broken skill symlinks` (five rows) and `1 broken links` (opencode).

## Acceptance criteria

- [x] `universal` added to the block, asserting the `errors` content including the id list, and the exact `ok` string
- [x] The assertion pins the id-enumeration format, not only the count — proven by the separator and first-only mutants, which survive a one-item fixture and die against this one. **Deviation noted above**: the enumeration is asserted as a set, not an exact string, because the adapter promises no order
- [x] Verified by mutation, confirming the new case fails and only that case, by name
- [x] The block comment's coverage note updated — and corrected twice, since both rewrites overclaimed
- [x] `npm run test:cli` passes

Re-read at `e947b654a`: `npm test` green — **862 script tests** (862 pass, 0 fail), **141 CLI tests** (139 pass, 0 fail, 2 skipped).

## Fixture isolation

`dirFor` sends a `base: 'project'` case to `resolve(tmpRoot, c.name, c.dir)` = `<ROOT>/.tmp-test-audit/universal/.agents/skills`, each case in its own namespace, swept in `before()` and removed in `after()`. The repository's own `.agents/` is touched only by `describe('install')`, which resolves it from `ROOT` directly.

Confirmed and **not** fixed here: `.tmp-test-audit` is not gitignored (`git check-ignore -v .tmp-test-audit` exits 1 — the pathspec matters: bare, it exits 128 with `fatal: no path specified`), so a crashed run leaves a stray tree in the repository. Pre-existing and inside #453's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011j7daSD1vfaAXBZsMebKb2


